### PR TITLE
fix: redraw undo and redo toolbar icons

### DIFF
--- a/editor.cpp
+++ b/editor.cpp
@@ -174,24 +174,23 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     path.lineTo(14, 12);
     path.lineTo(21, 19);
     painter.drawPath(path);
-  } else if (action == QStringLiteral("undo")) {
-    QPainterPath path;
-    path.moveTo(9, 7);
-    path.lineTo(4, 12);
-    path.lineTo(9, 17);
-    path.moveTo(5, 12);
-    path.cubicTo(8, 8, 14, 7, 18, 10);
-    path.cubicTo(20, 12, 20, 15, 19, 17);
-    painter.drawPath(path);
-  } else if (action == QStringLiteral("redo")) {
-    QPainterPath path;
-    path.moveTo(15, 7);
-    path.lineTo(20, 12);
-    path.lineTo(15, 17);
-    path.moveTo(19, 12);
-    path.cubicTo(16, 8, 10, 7, 6, 10);
-    path.cubicTo(4, 12, 4, 15, 5, 17);
-    painter.drawPath(path);
+  } else if (action == QStringLiteral("undo") ||
+             action == QStringLiteral("redo")) {
+    const bool forward = action == QStringLiteral("redo");
+    // Shaft runs along y = 9 into a half-circle that hooks back underneath.
+    const qreal tip = forward ? 20 : 4;
+    const qreal elbow = forward ? 9.5 : 14.5;
+    QPainterPath head;
+    head.moveTo(tip + (forward ? -5 : 5), 4);
+    head.lineTo(tip, 9);
+    head.lineTo(tip + (forward ? -5 : 5), 14);
+    painter.drawPath(head);
+    QPainterPath shaft;
+    shaft.moveTo(tip, 9);
+    shaft.lineTo(elbow, 9);
+    shaft.arcTo(QRectF(elbow - 5.5, 9, 11, 11), 90, forward ? 180 : -180);
+    shaft.lineTo(elbow + (forward ? 3.5 : -3.5), 20);
+    painter.drawPath(shaft);
   } else if (action == QStringLiteral("copy") ||
              action == QStringLiteral("both")) {
     painter.drawRoundedRect(QRectF(8, 8, 12, 12), 2, 2);


### PR DESCRIPTION
Thanks for the tool! 

These undo/redo icons looked a bit weird, unless that was the goal.

Old:
<img width="140" height="85" alt="screenshot-2026-08-11_08-27-09" src="https://github.com/user-attachments/assets/a45bd2b2-3c9b-4e35-8f5d-96e7fb1ac8b2" />


New:
<img width="135" height="75" alt="image" src="https://github.com/user-attachments/assets/dbd64cae-edaa-44e3-be5b-6eb149596e71" />

## Summary
  - Redraw the undo and redo toolbar icons with cleaner curved arrows
  - Keep the undo and redo icons visually consistent by drawing them from the same shape.

## Testing
  - Release build
  - Offscreen interaction smoke test
  - Clang-format check