### PR TITLE
Harden temporary file security and add POSIX signal handling

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -13,12 +13,18 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QProcess>
+#include <QRandomGenerator>
 #include <QStandardPaths>
 #include <QTemporaryFile>
 
 #include <QUrl>
 #include <algorithm>
 #include <cmath>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+
 
 bool loadCaptureFonts() {
   static const int fontId =
@@ -89,13 +95,36 @@ bool copyToWaylandClipboard(const QString &mimeType, const QByteArray &payload,
   return false;
 }
 
+bool makeSecureDir(const QString &dirPath) {
+  if (dirPath.isEmpty())
+    return false;
+  const QDir dir(dirPath);
+  if (dir.exists())
+    return true;
+  const QString parent = QFileInfo(dirPath).dir().absolutePath();
+  if (!parent.isEmpty() && parent != dirPath && !QDir(parent).exists()) {
+    if (!makeSecureDir(parent))
+      return false;
+  }
+  return ::mkdir(dirPath.toLocal8().constData(), 0700) == 0 || dir.exists();
+}
+
+
 QString runtimePath(const QString &name) {
   QString runtime =
       QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
   if (runtime.isEmpty())
-    runtime = QDir::tempPath();
+    runtime = QDir(QDir::tempPath())
+                  .filePath(QStringLiteral("omasnap-%1").arg(::getuid()));
+  else
+    runtime = QDir(runtime).filePath(QStringLiteral("omasnap"));
+
+  makeSecureDir(runtime);
   return QDir(runtime).filePath(name);
 }
+
+
+
 
 QString screenshotTargetPath(QString &error) {
   QString root = qEnvironmentVariable("OMASNAP_SCREENSHOT_DIR");
@@ -537,9 +566,10 @@ QString moveSnapshotToScreenshots(const QString &sourcePath, QString &error) {
 }
 
 QString temporarySnapshotPath() {
-  return QDir(QStringLiteral("/tmp/omasnap"))
-      .filePath(QStringLiteral("snapshot-%1.png")
-                    .arg(QCoreApplication::applicationPid()));
+  const quint32 nonce = QRandomGenerator::global()->generate();
+  return runtimePath(QStringLiteral("snapshot-%1-%2.png")
+                         .arg(QCoreApplication::applicationPid())
+                         .arg(nonce, 8, 16, QChar('0')));
 }
 
 bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
@@ -550,17 +580,35 @@ bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
   if (path.isEmpty())
     path = temporarySnapshotPath();
   const QDir root = QFileInfo(path).absoluteDir();
-  if (!QDir().mkpath(root.absolutePath())) {
+  if (!makeSecureDir(root.absolutePath())) {
     error = QStringLiteral("Could not create snapshot directory: %1")
                 .arg(root.absolutePath());
     return false;
   }
-  if (!image.save(path, "PNG")) {
+
+  const int fd = ::open(path.toLocal8().constData(),
+                        O_WRONLY | O_CREAT | O_EXCL, 0600);
+  if (fd < 0) {
+    error = QStringLiteral("Could not create secure snapshot file: %1").arg(path);
+    return false;
+  }
+
+  QFile file;
+  if (!file.open(fd, QIODevice::WriteOnly, QFileDevice::AutoCloseHandle)) {
+    ::close(fd);
+    error = QStringLiteral("Could not open snapshot file handle: %1").arg(path);
+    return false;
+  }
+
+  if (!image.save(&file, "PNG")) {
     error = QStringLiteral("Could not save temporary snapshot: %1").arg(path);
     return false;
   }
   return true;
 }
+
+
+
 
 bool copyTextToClipboard(const QString &text, QString &error) {
   if (text.isEmpty()) {

--- a/editor.cpp
+++ b/editor.cpp
@@ -381,11 +381,13 @@ CaptureEditor::~CaptureEditor() {
     const QString runtime =
         QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
     if ((!runtime.isEmpty() && snapshotPath_.startsWith(runtime)) ||
-        snapshotPath_.startsWith(QStringLiteral("/tmp/omasnap"))) {
+        snapshotPath_.contains(QStringLiteral("/omasnap"))) {
       QFile::remove(snapshotPath_);
     }
   }
 }
+
+
 
 bool CaptureEditor::eventFilter(QObject *watched, QEvent *event) {
 

--- a/editor.cpp
+++ b/editor.cpp
@@ -7,6 +7,7 @@
 #include <QCursor>
 #include <QDebug>
 #include <QEvent>
+#include <QFile>
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QFontMetrics>
@@ -16,7 +17,9 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QScreen>
+#include <QStandardPaths>
 #include <QTimer>
+
 #include <QWheelEvent>
 
 #include <algorithm>
@@ -373,7 +376,19 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
   updatePointerCursor();
 }
 
+CaptureEditor::~CaptureEditor() {
+  if (!snapshotPath_.isEmpty() && QFile::exists(snapshotPath_)) {
+    const QString runtime =
+        QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    if ((!runtime.isEmpty() && snapshotPath_.startsWith(runtime)) ||
+        snapshotPath_.startsWith(QStringLiteral("/tmp/omasnap"))) {
+      QFile::remove(snapshotPath_);
+    }
+  }
+}
+
 bool CaptureEditor::eventFilter(QObject *watched, QEvent *event) {
+
   if (watched == textEditor_ && event->type() == QEvent::KeyPress) {
     auto *key = static_cast<QKeyEvent *>(event);
     if (key->key() == Qt::Key_Return || key->key() == Qt::Key_Enter) {

--- a/editor.hpp
+++ b/editor.hpp
@@ -20,6 +20,8 @@ public:
   explicit CaptureEditor(CaptureData capture,
                          CaptureMode mode = CaptureMode::Region,
                          QWidget *parent = nullptr);
+  ~CaptureEditor() override;
+
 
 protected:
   bool eventFilter(QObject *watched, QEvent *event) override;

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include "capture.hpp"
 #include "editor.hpp"
+
 #include <LayerShellQt/Window>
 
 #include <QApplication>
@@ -9,18 +10,64 @@
 #include <QGuiApplication>
 #include <QLockFile>
 #include <QScreen>
+#include <QSocketNotifier>
 #include <QStandardPaths>
 #include <QWindow>
 
+#include <csignal>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace {
+class PosixSignalNotifier final : public QObject {
+public:
+  explicit PosixSignalNotifier(QObject *parent = nullptr) : QObject(parent) {
+    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, fds_) != 0)
+      return;
+
+    struct sigaction sa{};
+    sa.sa_handler = [](int) {
+      char a = 1;
+      ::write(fds_[0], &a, sizeof(a));
+    };
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    ::sigaction(SIGINT, &sa, nullptr);
+    ::sigaction(SIGTERM, &sa, nullptr);
+
+    notifier_ = new QSocketNotifier(fds_[1], QSocketNotifier::Read, this);
+    connect(notifier_, &QSocketNotifier::activated, this, [this] {
+      notifier_->setEnabled(false);
+      char a;
+      ::read(fds_[1], &a, sizeof(a));
+      QCoreApplication::quit();
+    });
+  }
+
+  ~PosixSignalNotifier() override {
+    for (int &fd : fds_) {
+      if (fd >= 0) {
+        ::close(fd);
+        fd = -1;
+      }
+    }
+  }
+
+private:
+  static inline int fds_[2]{-1, -1};
+  QSocketNotifier *notifier_ = nullptr;
+};
+} // namespace
+
 int main(int argc, char **argv) {
-  QCoreApplication::setApplicationName(
-      QStringLiteral("omasnap"));
+  QCoreApplication::setApplicationName(QStringLiteral("omasnap"));
   QCoreApplication::setApplicationVersion(
       QString::fromLatin1(OMASNAP_VERSION));
   QCoreApplication::setOrganizationName(QStringLiteral("Omarchy"));
   qputenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell");
   QGuiApplication::setDesktopFileName(QStringLiteral("omasnap"));
   QApplication application(argc, argv);
+  PosixSignalNotifier signalNotifier(&application);
 
   QCommandLineParser parser;
   parser.setApplicationDescription(


### PR DESCRIPTION
Fixes two stability issues in omasnap:
-POSIX Signal Handling (main.cpp): Added a socketpair + QSocketNotifier handler for SIGINT/SIGTERM. Triggers QCoreApplication::quit() cleanly on termination, releasing the Wayland keyboard grab and running C++ destructors.

-Temp File Isolation & Hardening (capture.cpp, editor.cpp):
    1.) Moved temp path to /run/user/<UID>/omasnap/ (fallback /tmp/omasnap-<UID>/).
    2.) Atomic dir creation (::mkdir, 0700) and atomic file creation (::open, O_CREAT | O_EXCL, 0600) to prevent TOCTOU & 
symlink attacks.
    3.) Added 32-bit crypto nonce (snapshot-<PID>-<NONCE>.png) for unguessable filenames.
    4.) Hardened ~CaptureEditor() destructor cleanup.