### PR TITLE
Add highlighter tool with color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Clean window-surface capture through Wayland image-copy protocols. A failed native
   capture stays in the window picker; Omasnap never substitutes a crop of the desktop.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
-- Arrows, straight lines, smoothed freehand strokes, rectangles, numbered markers, and
-  editable Neucha text.
-- Per-layer preset or custom colors, undo/redo history, OCR-region capture,
+- Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
+  rectangles, numbered markers, and editable Neucha text.
+- Per-layer preset or custom colors (including highlighter ink), undo/redo history,
+  OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
 - Crash-resistant working snapshots under `/tmp/omasnap/snapshot-<pid>.png`, written
   immediately after selection and overwritten after every completed edit. Saving moves

--- a/capture.cpp
+++ b/capture.cpp
@@ -216,7 +216,8 @@ void drawAnnotation(QPainter &painter, const Annotation &annotation) {
     return;
   }
 
-  if (annotation.kind == Annotation::Kind::Freehand) {
+  if (annotation.kind == Annotation::Kind::Freehand ||
+      annotation.kind == Annotation::Kind::Highlighter) {
     if (annotation.points.size() < 2)
       return;
     QPainterPath stroke(annotation.points.first());
@@ -227,6 +228,15 @@ void drawAnnotation(QPainter &painter, const Annotation &annotation) {
     }
     stroke.lineTo(annotation.points.last());
     painter.setBrush(Qt::NoBrush);
+    if (annotation.kind == Annotation::Kind::Highlighter) {
+      QColor ink = annotation.color;
+      if (ink.alpha() >= 255)
+        ink.setAlpha(120);
+      const qreal highlightWidth =
+          std::max<qreal>(6.0, annotation.size * 3.0);
+      painter.setPen(QPen(ink, highlightWidth, Qt::SolidLine, Qt::RoundCap,
+                          Qt::RoundJoin));
+    }
     painter.drawPath(stroke);
     return;
   }

--- a/capture.hpp
+++ b/capture.hpp
@@ -34,7 +34,15 @@ struct CaptureData {
 enum class BackgroundStyle { None, Aurora, Sunset, Lagoon, Violet };
 
 struct Annotation {
-  enum class Kind { Arrow, Line, Freehand, Marker, Rectangle, Text };
+  enum class Kind {
+    Arrow,
+    Line,
+    Freehand,
+    Highlighter,
+    Marker,
+    Rectangle,
+    Text
+  };
 
   Kind kind = Kind::Arrow;
   QPointF start;

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -208,7 +208,8 @@ int main(int argc, char **argv) {
     return 48;
   const QImage beforeTextSnapshot(snapshotPath);
   QTest::keyClick(&editor, Qt::Key_T);
-  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(320, 133));
+  // Text size panel under the Text toolbar button (shifted by Highlighter).
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(341, 133));
   QWheelEvent textSizeWheel(QPointF(360, 320), QPointF(360, 320), {}, {0, -120},
                             Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase,
                             false);
@@ -281,13 +282,16 @@ int main(int argc, char **argv) {
   application.processEvents();
   if (QImage(snapshotPath) == beforeBackdropSnapshot)
     return 55;
-  QTest::mouseMove(&editor, QPoint(378, 92), 20);
+  // Palette toolbar button (index 8 after Highlighter was inserted).
+  QTest::mouseMove(&editor, QPoint(398, 92), 20);
   application.processEvents();
   if (!editor.grab().save(outputRoot + QStringLiteral("-palette.png"), "PNG"))
     return 14;
-  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(460, 134));
+  // Custom color control in the open palette strip.
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(470, 134));
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(320, 200));
-  QTest::mouseMove(&editor, QPoint(178, 92), 20);
+  // Freehand toolbar button.
+  QTest::mouseMove(&editor, QPoint(198, 92), 20);
   application.processEvents();
   if (editor.cursor().shape() != Qt::PointingHandCursor)
     return 12;
@@ -432,6 +436,12 @@ int main(int argc, char **argv) {
   freehand.size = 4;
   freehand.points = {{40, 170}, {110, 145}, {165, 185}, {225, 150}};
   annotations.push_back(std::move(freehand));
+  Annotation highlighter;
+  highlighter.kind = Annotation::Kind::Highlighter;
+  highlighter.color = QColor(QStringLiteral("#ffd60a"));
+  highlighter.size = 5;
+  highlighter.points = {{50, 210}, {140, 205}, {220, 215}, {300, 200}};
+  annotations.push_back(std::move(highlighter));
   annotations.push_back({Annotation::Kind::Marker,
                          {260, 180},
                          {},

--- a/editor.cpp
+++ b/editor.cpp
@@ -29,7 +29,7 @@ constexpr std::array<const char *, 6> kColorNames{
     "#ff375f", "#ff9f0a", "#ffd60a", "#30d158", "#0a84ff", "#bf5af2"};
 constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
-constexpr qreal kToolbarWidth = 640;
+constexpr qreal kToolbarWidth = 680;
 
 bool hasEndpointHandles(Annotation::Kind kind) {
   return kind == Annotation::Kind::Arrow || kind == Annotation::Kind::Line ||
@@ -38,6 +38,17 @@ bool hasEndpointHandles(Annotation::Kind kind) {
 
 bool showsSelectionBounds(Annotation::Kind kind) {
   return kind != Annotation::Kind::Arrow && kind != Annotation::Kind::Line;
+}
+
+bool isStrokeKind(Annotation::Kind kind) {
+  return kind == Annotation::Kind::Freehand ||
+         kind == Annotation::Kind::Highlighter;
+}
+
+qreal strokeHitTolerance(const Annotation &annotation) {
+  if (annotation.kind == Annotation::Kind::Highlighter)
+    return std::max<qreal>(8.0, annotation.size * 3.0 + 4.0);
+  return std::max<qreal>(8.0, annotation.size + 4.0);
 }
 
 QString toolAction(CaptureEditor::Tool tool) {
@@ -50,6 +61,8 @@ QString toolAction(CaptureEditor::Tool tool) {
     return QStringLiteral("tool-line");
   case CaptureEditor::Tool::Freehand:
     return QStringLiteral("tool-freehand");
+  case CaptureEditor::Tool::Highlighter:
+    return QStringLiteral("tool-highlighter");
   case CaptureEditor::Tool::Marker:
     return QStringLiteral("tool-marker");
   case CaptureEditor::Tool::Rectangle:
@@ -114,6 +127,10 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     stroke.cubicTo(7, 5, 10, 20, 14, 11);
     stroke.cubicTo(17, 5, 18, 11, 21, 7);
     painter.drawPath(stroke);
+  } else if (action == QStringLiteral("tool-highlighter")) {
+    painter.setPen(
+        QPen(color, 5.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter.drawLine(QPointF(5, 16), QPointF(19, 8));
   } else if (action == QStringLiteral("tool-marker")) {
     painter.drawEllipse(QPointF(12, 12), 8, 8);
     QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
@@ -405,7 +422,7 @@ QRectF CaptureEditor::annotationBounds(const Annotation &annotation) const {
     return {annotation.start.x(), annotation.start.y() - metrics.ascent(),
             metrics.horizontalAdvance(annotation.text), metrics.height()};
   }
-  if (annotation.kind == Annotation::Kind::Freehand) {
+  if (isStrokeKind(annotation.kind)) {
     if (annotation.points.isEmpty())
       return {};
     qreal left = annotation.points.first().x();
@@ -441,7 +458,8 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
       if (QLineF(point, closest).length() <=
           std::max<qreal>(8.0, annotation.size + 4.0))
         return index;
-    } else if (annotation.kind == Annotation::Kind::Freehand) {
+    } else if (isStrokeKind(annotation.kind)) {
+      const qreal tolerance = strokeHitTolerance(annotation);
       for (int pointIndex = 1; pointIndex < annotation.points.size();
            ++pointIndex) {
         const QLineF segment(annotation.points.at(pointIndex - 1),
@@ -457,8 +475,7 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
                            lengthSquared,
                        0.0, 1.0);
         const QPointF closest = segment.p1() + delta * t;
-        if (QLineF(point, closest).length() <=
-            std::max<qreal>(8.0, annotation.size + 4.0))
+        if (QLineF(point, closest).length() <= tolerance)
           return index;
       }
     } else if (annotationBounds(annotation)
@@ -483,7 +500,7 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
     annotation.start = scaledPoint(annotation.start);
     annotation.end = scaledPoint(annotation.end);
     annotation.size = std::clamp(annotation.size * factor, 2.0, 30.0);
-  } else if (annotation.kind == Annotation::Kind::Freehand) {
+  } else if (isStrokeKind(annotation.kind)) {
     for (QPointF &point : annotation.points)
       point = scaledPoint(point);
     if (!annotation.points.isEmpty()) {
@@ -508,7 +525,7 @@ QRectF CaptureEditor::colorPaletteRect() const {
   const qreal toolbarX = (width() - toolbarWidth) / 2.0;
   const qreal toolbarY =
       std::max<qreal>(10, editImageRect().top() - buttonHeight - 10);
-  const QRectF anchor(toolbarX + 280, toolbarY, 36, buttonHeight);
+  const QRectF anchor(toolbarX + 320, toolbarY, 36, buttonHeight);
   const qreal paletteWidth = 204;
   const qreal x = std::clamp(anchor.center().x() - paletteWidth / 2.0, 8.0,
                              std::max(8.0, width() - paletteWidth - 8.0));
@@ -531,7 +548,7 @@ QRectF CaptureEditor::textSizePanelRect() const {
   const qreal toolbarX = (width() - toolbarWidth) / 2.0;
   const qreal toolbarY =
       std::max<qreal>(10, editImageRect().top() - buttonHeight - 10);
-  const QRectF anchor(toolbarX + 240, toolbarY, 36, buttonHeight);
+  const QRectF anchor(toolbarX + 280, toolbarY, 36, buttonHeight);
   return {anchor.center().x() - 51, anchor.bottom() + 6, 102, 34};
 }
 
@@ -715,6 +732,9 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
           .arg(qRound(annotationSize_)));
   add(36, QStringLiteral("tool-freehand"), {},
       QStringLiteral("Freehand · F · Size %1 · Wheel")
+          .arg(qRound(annotationSize_)));
+  add(36, QStringLiteral("tool-highlighter"), {},
+      QStringLiteral("Highlighter · H · Size %1 · Wheel")
           .arg(qRound(annotationSize_)));
   add(36, QStringLiteral("tool-marker"), {},
       QStringLiteral("Number marker · C · Size %1 · Wheel")
@@ -1077,6 +1097,8 @@ void CaptureEditor::handleToolbar(const QString &action) {
     tool_ = Tool::Line;
   else if (action == QStringLiteral("tool-freehand"))
     tool_ = Tool::Freehand;
+  else if (action == QStringLiteral("tool-highlighter"))
+    tool_ = Tool::Highlighter;
   else if (action == QStringLiteral("tool-marker"))
     tool_ = Tool::Marker;
   else if (action == QStringLiteral("tool-rectangle"))
@@ -1204,6 +1226,8 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Line;
   } else if (event->key() == Qt::Key_F) {
     tool_ = Tool::Freehand;
+  } else if (event->key() == Qt::Key_H) {
+    tool_ = Tool::Highlighter;
   } else if (event->key() == Qt::Key_C || event->key() == Qt::Key_M) {
     tool_ = Tool::Marker;
   } else if (event->key() == Qt::Key_R) {
@@ -1278,7 +1302,7 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
           annotation.start += annotationDelta;
           if (hasEndpointHandles(annotation.kind))
             annotation.end += annotationDelta;
-          if (annotation.kind == Annotation::Kind::Freehand) {
+          if (isStrokeKind(annotation.kind)) {
             for (QPointF &point : annotation.points)
               point += annotationDelta;
             if (!annotation.points.isEmpty()) {
@@ -1301,7 +1325,7 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
         annotation.start += delta;
         if (hasEndpointHandles(annotation.kind))
           annotation.end += delta;
-        if (annotation.kind == Annotation::Kind::Freehand) {
+        if (isStrokeKind(annotation.kind)) {
           for (QPointF &strokePoint : annotation.points)
             strokePoint += delta;
         }
@@ -1311,7 +1335,7 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
       } else if (interaction_ == Interaction::ResizeEnd) {
         if (hasEndpointHandles(annotation.kind)) {
           annotation.end = point;
-        } else if (annotation.kind == Annotation::Kind::Freehand) {
+        } else if (isStrokeKind(annotation.kind)) {
           const QRectF originalBounds = annotationBounds(originalAnnotation_);
           const qreal scaleX =
               originalBounds.width() > 0
@@ -1349,7 +1373,7 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
       }
       dragChanged_ = true;
     }
-    if (tool_ == Tool::Freehand && dragging_) {
+    if ((tool_ == Tool::Freehand || tool_ == Tool::Highlighter) && dragging_) {
       const QPointF point = toAnnotationPoint(cursor_);
       if (freehandPoints_.isEmpty() ||
           QLineF(freehandPoints_.last(), point).length() >= 1.5)
@@ -1515,7 +1539,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
   } else {
     dragStart_ = point;
     dragging_ = true;
-    if (tool_ == Tool::Freehand) {
+    if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
       freehandPoints_.clear();
       freehandPoints_.reserve(256);
       freehandPoints_.push_back(point);
@@ -1557,7 +1581,7 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
   }
 
   const QPointF end = toAnnotationPoint(event->position());
-  if (tool_ == Tool::Freehand) {
+  if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
     if (freehandPoints_.isEmpty() ||
         QLineF(freehandPoints_.last(), end).length() >= 1.0)
       freehandPoints_.push_back(end);
@@ -1567,8 +1591,10 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
                     .length();
     if (length > 4) {
       recordEdit();
+      const bool highlighter = tool_ == Tool::Highlighter;
       Annotation annotation;
-      annotation.kind = Annotation::Kind::Freehand;
+      annotation.kind = highlighter ? Annotation::Kind::Highlighter
+                                    : Annotation::Kind::Freehand;
       annotation.start = freehandPoints_.first();
       annotation.end = freehandPoints_.last();
       annotation.color = annotationColor();
@@ -1577,7 +1603,11 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       annotations_.push_back(std::move(annotation));
       selectedAnnotation_ = -1;
       tool_ = Tool::Select;
-      setStatus(QStringLiteral("Stroke added · Select tool chooses layers"));
+      setStatus(highlighter
+                    ? QStringLiteral(
+                          "Highlight added · Select tool chooses layers")
+                    : QStringLiteral(
+                          "Stroke added · Select tool chooses layers"));
       persistSnapshot();
     }
     freehandPoints_.clear();
@@ -1634,7 +1664,8 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
                   .arg(QString::fromLatin1(kTextSizeNames.at(
                       static_cast<std::size_t>(textSizeIndex_)))));
   } else if (tool_ == Tool::Arrow || tool_ == Tool::Line ||
-             tool_ == Tool::Freehand || tool_ == Tool::Marker) {
+             tool_ == Tool::Freehand || tool_ == Tool::Highlighter ||
+             tool_ == Tool::Marker) {
     annotationSize_ = std::clamp(annotationSize_ + step, 2.0, 12.0);
     setStatus(QStringLiteral("Size %1 · mouse wheel changes size")
                   .arg(qRound(annotationSize_)));
@@ -1784,8 +1815,9 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   }
   if (dragging_ && tool_ != Tool::Select) {
     Annotation preview;
-    if (tool_ == Tool::Freehand) {
-      preview.kind = Annotation::Kind::Freehand;
+    if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
+      preview.kind = tool_ == Tool::Highlighter ? Annotation::Kind::Highlighter
+                                                : Annotation::Kind::Freehand;
       preview.points = freehandPoints_;
     } else {
       preview.kind = (tool_ == Tool::Rectangle || tool_ == Tool::Ocr)
@@ -1956,7 +1988,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       {{QStringLiteral("V"), QStringLiteral("Select / move layer")},
        {QStringLiteral("A"), QStringLiteral("Arrow")},
        {QStringLiteral("L"), QStringLiteral("Line")},
-       {QStringLiteral("F"), QStringLiteral("Freehand")},
+       {QStringLiteral("F / H"), QStringLiteral("Freehand / Highlighter")},
        {QStringLiteral("C"), QStringLiteral("Marker")},
        {QStringLiteral("R"), QStringLiteral("Rectangle")},
        {QStringLiteral("T"), QStringLiteral("Text")},
@@ -1975,8 +2007,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     drawInstantTooltip(painter, rect(), hoveredButton->rect,
                        hoveredButton->tooltip);
   } else if (tool_ == Tool::Arrow || tool_ == Tool::Line ||
-             tool_ == Tool::Freehand || tool_ == Tool::Marker ||
-             tool_ == Tool::Text) {
+             tool_ == Tool::Freehand || tool_ == Tool::Highlighter ||
+             tool_ == Tool::Marker || tool_ == Tool::Text) {
     const QString selectedAction = toolAction(tool_);
     for (const ToolbarButton &button : buttons) {
       if (button.action == selectedAction) {

--- a/editor.hpp
+++ b/editor.hpp
@@ -37,6 +37,7 @@ public:
     Arrow,
     Line,
     Freehand,
+    Highlighter,
     Marker,
     Rectangle,
     Text,


### PR DESCRIPTION
Introduce a freehand highlighter annotation with translucent wide strokes, toolbar/hotkey access, and the existing palette/custom colors.