### PR TITLE
Pin captures on screen with P

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,17 @@ target_link_libraries(omasnap PRIVATE
   PkgConfig::WaylandClient
 )
 
+qt_add_executable(omasnap-pin
+  pin.cpp
+)
+target_compile_features(omasnap-pin PRIVATE cxx_std_23)
+target_compile_options(omasnap-pin PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(omasnap-pin PRIVATE
+  Qt6::Core
+  Qt6::Gui
+  Qt6::Widgets
+)
+
 qt_add_executable(omasnap-smoke
   editor-smoke.cpp
   capture.cpp
@@ -84,7 +95,7 @@ target_link_libraries(omasnap-smoke PRIVATE
   PkgConfig::WaylandClient
 )
 
-install(TARGETS omasnap
+install(TARGETS omasnap omasnap-pin
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 )
 install(FILES assets/OFL.txt

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   editable Neucha text.
 - Per-layer preset or custom colors, undo/redo history, OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
+- Pin a finished capture on screen as a floating always-on-top window (`omasnap-pin`),
+  independent of the capture process so new captures keep working.
 - Crash-resistant working snapshots under `/tmp/omasnap/snapshot-<pid>.png`, written
   immediately after selection and overwritten after every completed edit. Saving moves
   that file into `~/Pictures/Screenshots`; clipboard output streams the same PNG.
@@ -199,7 +201,50 @@ Install the corresponding Tesseract language data before adding a language to
 | `Ctrl+C` | Copy PNG only |
 | `Ctrl+S` | Save PNG only |
 | `Enter` | Copy and save |
+| `P` | Pin the capture on screen and close the editor |
 | `Esc` | Return to Select; press again to close |
+
+### Pinned captures
+
+`P` renders the current capture, writes it to `/tmp/omasnap/pin-<pid>-<n>.png`, and hands
+it to `omasnap-pin` — a separate binary that deliberately runs without
+`QT_WAYLAND_SHELL_INTEGRATION`, so the pin is a plain toplevel the compositor can float,
+stack, and move like any other window. Pinning neither touches the clipboard nor writes to
+the screenshot directory; it is a fourth output alongside copy, save, and copy-and-save.
+
+`P` closes the editor, which releases the single-instance lock so the next capture starts
+immediately. Pins from separate captures accumulate; each one is an independent process.
+
+| Input on a pin | Action |
+|---|---|
+| Drag body | Move (compositor-driven `startSystemMove`) |
+| Wheel, bottom-right grip | Resize, aspect preserved |
+| `Ctrl+C` | Copy the pinned PNG to the clipboard |
+| `Esc`, middle-click, hover close button | Close |
+
+`Ctrl+C` copies through `wl-copy` rather than `QClipboard`, so the image stays on the
+clipboard after the pin is closed, and it copies the capture at full resolution regardless
+of how small the pin has been scaled.
+
+Recommended window rules, in the Lua config syntax these were tested with:
+
+```lua
+hl.window_rule({
+  match = { class = "^omasnap-pin$" },
+  float = true,
+  pin = true,
+  no_initial_focus = true,
+  no_dim = true,
+  keep_aspect_ratio = true,
+  opacity = "1 1 override",
+})
+```
+
+The `override` on the opacity rule matters: without it a configured
+`decoration:inactive_opacity` still multiplies through, and an unfocused pin then shows
+colors that no longer match the capture. In a legacy `hyprland.conf` the equivalents are
+`float`, `pin`, `noinitialfocus`, `nodim`, `keepaspectratio` and
+`opacity 1.0 1.0 override` on `class:^omasnap-pin$`.
 
 Creation tools return to Select after one placement without selecting the new layer. In
 Select mode, arrows and lines show only their two endpoint handles; other layers show a

--- a/capture.cpp
+++ b/capture.cpp
@@ -97,6 +97,8 @@ QString runtimePath(const QString &name) {
   return QDir(runtime).filePath(name);
 }
 
+QDir snapshotRoot() { return QDir(QStringLiteral("/tmp/omasnap")); }
+
 QString screenshotTargetPath(QString &error) {
   QString root = qEnvironmentVariable("OMASNAP_SCREENSHOT_DIR");
   if (root.isEmpty())
@@ -537,9 +539,24 @@ QString moveSnapshotToScreenshots(const QString &sourcePath, QString &error) {
 }
 
 QString temporarySnapshotPath() {
-  return QDir(QStringLiteral("/tmp/omasnap"))
-      .filePath(QStringLiteral("snapshot-%1.png")
-                    .arg(QCoreApplication::applicationPid()));
+  return snapshotRoot().filePath(QStringLiteral("snapshot-%1.png")
+                                     .arg(QCoreApplication::applicationPid()));
+}
+
+QString pinnedSnapshotPath(int index) {
+  return snapshotRoot().filePath(QStringLiteral("pin-%1-%2.png")
+                                     .arg(QCoreApplication::applicationPid())
+                                     .arg(index));
+}
+
+void prunePinnedSnapshots() {
+  const QDateTime cutoff = QDateTime::currentDateTime().addDays(-1);
+  const QFileInfoList stale =
+      snapshotRoot().entryInfoList({QStringLiteral("pin-*.png")}, QDir::Files);
+  for (const QFileInfo &entry : stale) {
+    if (entry.lastModified() < cutoff)
+      QFile::remove(entry.absoluteFilePath());
+  }
 }
 
 bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {

--- a/capture.hpp
+++ b/capture.hpp
@@ -63,6 +63,8 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
 [[nodiscard]] QString moveSnapshotToScreenshots(const QString &sourcePath,
                                                 QString &error);
 [[nodiscard]] QString temporarySnapshotPath();
+[[nodiscard]] QString pinnedSnapshotPath(int index);
+void prunePinnedSnapshots();
 [[nodiscard]] bool saveTemporarySnapshot(const QImage &image, QString path,
                                          QString &error);
 [[nodiscard]] QString recognizeText(const QImage &image, QString &error);

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -281,13 +281,13 @@ int main(int argc, char **argv) {
   application.processEvents();
   if (QImage(snapshotPath) == beforeBackdropSnapshot)
     return 55;
-  QTest::mouseMove(&editor, QPoint(378, 92), 20);
+  QTest::mouseMove(&editor, QPoint(358, 92), 20);
   application.processEvents();
   if (!editor.grab().save(outputRoot + QStringLiteral("-palette.png"), "PNG"))
     return 14;
-  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(460, 134));
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(440, 134));
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(320, 200));
-  QTest::mouseMove(&editor, QPoint(178, 92), 20);
+  QTest::mouseMove(&editor, QPoint(158, 92), 20);
   application.processEvents();
   if (editor.cursor().shape() != Qt::PointingHandCursor)
     return 12;

--- a/editor.cpp
+++ b/editor.cpp
@@ -6,7 +6,9 @@
 #include <QClipboard>
 #include <QCursor>
 #include <QDebug>
+#include <QDir>
 #include <QEvent>
+#include <QFile>
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QFontMetrics>
@@ -15,6 +17,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
+#include <QProcess>
 #include <QScreen>
 #include <QTimer>
 #include <QWheelEvent>
@@ -29,7 +32,17 @@ constexpr std::array<const char *, 6> kColorNames{
     "#ff375f", "#ff9f0a", "#ffd60a", "#30d158", "#0a84ff", "#bf5af2"};
 constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
-constexpr qreal kToolbarWidth = 640;
+constexpr qreal kToolbarWidth = 680;
+
+// Prefer the sibling binary so an uninstalled build tree pins with its own pin
+// viewer instead of an older installed one.
+QString pinProgram() {
+  const QString sibling = QDir(QCoreApplication::applicationDirPath())
+                              .filePath(QStringLiteral("omasnap-pin"));
+  if (QFileInfo::exists(sibling))
+    return sibling;
+  return QStringLiteral("omasnap-pin");
+}
 
 bool hasEndpointHandles(Annotation::Kind kind) {
   return kind == Annotation::Kind::Arrow || kind == Annotation::Kind::Line ||
@@ -223,6 +236,10 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     tray.lineTo(19, 20);
     tray.lineTo(19, 18);
     painter.drawPath(tray);
+  } else if (action == QStringLiteral("pin")) {
+    painter.drawRoundedRect(QRectF(8, 4, 8, 6), 2, 2);
+    painter.drawLine(QPointF(5, 10), QPointF(19, 10));
+    painter.drawLine(QPointF(12, 10), QPointF(12, 20));
   } else if (action == QStringLiteral("close")) {
     painter.drawLine(QPointF(6, 6), QPointF(18, 18));
     painter.drawLine(QPointF(18, 6), QPointF(6, 18));
@@ -734,6 +751,8 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(36, QStringLiteral("undo"), {}, QStringLiteral("Undo · Ctrl+Z"));
   add(36, QStringLiteral("redo"), {},
       QStringLiteral("Redo · Ctrl+Shift+Z / Ctrl+Y"));
+  add(36, QStringLiteral("pin"), {},
+      QStringLiteral("Pin on screen · P · Ctrl+C on the pin copies it"));
   add(36, QStringLiteral("copy"), {}, QStringLiteral("Copy only · Ctrl+C"));
   add(40, QStringLiteral("both"), {}, QStringLiteral("Copy and save · Enter"));
   add(36, QStringLiteral("save"), {}, QStringLiteral("Save only · Ctrl+S"));
@@ -840,6 +859,39 @@ void CaptureEditor::persistSnapshot() {
   QString error;
   if (!saveTemporarySnapshot(image, snapshotPath_, error))
     qWarning().noquote() << error;
+}
+
+void CaptureEditor::pinSnapshot() {
+  if (busy_ || selection_.isEmpty())
+    return;
+
+  prunePinnedSnapshots();
+  const QString path = pinnedSnapshotPath(++pinCount_);
+  const QImage image =
+      renderCapture(capture_, selection_, annotations_, backgroundStyle_);
+  QString error;
+  if (!saveTemporarySnapshot(image, path, error)) {
+    setStatus(error);
+    return;
+  }
+
+  // The capture process exports QT_WAYLAND_SHELL_INTEGRATION for its own
+  // layer-shell overlay; the pin needs a plain toplevel the compositor can
+  // float, move and stack like any other window.
+  QProcess pin;
+  QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+  environment.remove(QStringLiteral("QT_WAYLAND_SHELL_INTEGRATION"));
+  pin.setProcessEnvironment(environment);
+  pin.setProgram(pinProgram());
+  pin.setArguments({path});
+  if (!pin.startDetached()) {
+    QFile::remove(path);
+    --pinCount_;
+    setStatus(QStringLiteral("Could not start omasnap-pin"));
+    return;
+  }
+
+  close();
 }
 
 void CaptureEditor::enterEdit(QString status) {
@@ -1112,7 +1164,9 @@ void CaptureEditor::handleToolbar(const QString &action) {
     undoEdit();
   } else if (action == QStringLiteral("redo")) {
     redoEdit();
-  } else if (action == QStringLiteral("copy"))
+  } else if (action == QStringLiteral("pin"))
+    pinSnapshot();
+  else if (action == QStringLiteral("copy"))
     finish(OutputMode::Copy);
   else if (action == QStringLiteral("both"))
     finish(OutputMode::Both);
@@ -1212,6 +1266,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Text;
   } else if (event->key() == Qt::Key_O) {
     tool_ = Tool::Ocr;
+  } else if (event->key() == Qt::Key_P) {
+    pinSnapshot();
+    return;
   } else if (event->key() == Qt::Key_B) {
     recordEdit();
     backgroundStyle_ = static_cast<BackgroundStyle>(

--- a/editor.hpp
+++ b/editor.hpp
@@ -109,6 +109,7 @@ private:
   [[nodiscard]] EditState editState() const;
   void enterEdit(QString status);
   void persistSnapshot();
+  void pinSnapshot();
   void pushUndoState(const EditState &state);
   void recordEdit();
   void redoEdit();
@@ -158,6 +159,7 @@ private:
   bool dragStartStateValid_ = false;
   bool dragChanged_ = false;
   QString snapshotPath_;
+  int pinCount_ = 0;
   QString status_ =
       QStringLiteral("Drag to select an area · Space selects a window");
   QLineEdit *textEditor_ = nullptr;

--- a/pin.cpp
+++ b/pin.cpp
@@ -1,0 +1,247 @@
+#include <QApplication>
+#include <QBuffer>
+#include <QEnterEvent>
+#include <QFontMetrics>
+#include <QGuiApplication>
+#include <QImage>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QProcess>
+#include <QScreen>
+#include <QTimer>
+#include <QWheelEvent>
+#include <QWidget>
+#include <QWindow>
+
+#include <algorithm>
+#include <utility>
+
+namespace {
+
+constexpr int kMinimumEdge = 80;
+constexpr qreal kCloseButtonSize = 22;
+constexpr qreal kCloseButtonInset = 8;
+constexpr qreal kResizeGripSize = 18;
+constexpr qreal kInitialScreenShare = 0.4;
+constexpr qreal kWheelStep = 0.1;
+constexpr int kToastMs = 1200;
+
+// wl-copy backgrounds itself and keeps serving the selection after this process
+// exits, which QClipboard cannot do on Wayland.
+bool copyPngToClipboard(const QImage &image, QString &error) {
+  QByteArray png;
+  QBuffer buffer(&png);
+  buffer.open(QIODevice::WriteOnly);
+  if (!image.save(&buffer, "PNG")) {
+    error = QStringLiteral("Could not encode PNG");
+    return false;
+  }
+
+  QProcess copy;
+  copy.start(QStringLiteral("wl-copy"),
+             {QStringLiteral("--type"), QStringLiteral("image/png")});
+  if (!copy.waitForStarted(2000)) {
+    error = copy.errorString();
+    return false;
+  }
+  copy.write(png);
+  copy.closeWriteChannel();
+  if (!copy.waitForFinished(5000) || copy.exitCode() != 0) {
+    error = QString::fromUtf8(copy.readAllStandardError()).trimmed();
+    if (error.isEmpty())
+      error = QStringLiteral("wl-copy failed");
+    return false;
+  }
+  return true;
+}
+
+class PinWindow final : public QWidget {
+public:
+  explicit PinWindow(QImage image) : image_(std::move(image)) {
+    setWindowTitle(QStringLiteral("omasnap-pin"));
+    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+    setMouseTracking(true);
+    resize(initialSize());
+  }
+
+protected:
+  void paintEvent(QPaintEvent *) override {
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+    painter.drawImage(rect(), image_);
+    if (!toast_.isEmpty())
+      paintToast(painter);
+    if (!hovered_)
+      return;
+
+    const QRectF close = closeButtonRect();
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor(12, 12, 16, 190));
+    painter.drawRoundedRect(close, 6, 6);
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(QPen(QColor(255, 255, 255, 225), 1.6));
+    const QPointF center = close.center();
+    const qreal arm = 4.5;
+    painter.drawLine(center + QPointF(-arm, -arm), center + QPointF(arm, arm));
+    painter.drawLine(center + QPointF(arm, -arm), center + QPointF(-arm, arm));
+  }
+
+  void paintToast(QPainter &painter) const {
+    const QFontMetrics metrics(painter.font());
+    const QRectF pill((width() - metrics.horizontalAdvance(toast_) - 28) / 2.0,
+                      height() - 42, metrics.horizontalAdvance(toast_) + 28,
+                      26);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor(12, 12, 16, 205));
+    painter.drawRoundedRect(pill, 13, 13);
+    painter.setPen(QColor(240, 240, 245));
+    painter.drawText(pill, Qt::AlignCenter, toast_);
+  }
+
+  void mousePressEvent(QMouseEvent *event) override {
+    if (event->button() == Qt::MiddleButton ||
+        closeButtonRect().contains(event->position())) {
+      close();
+      return;
+    }
+    if (event->button() != Qt::LeftButton)
+      return;
+
+    QWindow *handle = windowHandle();
+    if (!handle)
+      return;
+    if (resizeGripRect().contains(event->position()))
+      handle->startSystemResize(Qt::BottomEdge | Qt::RightEdge);
+    else
+      handle->startSystemMove();
+  }
+
+  void mouseMoveEvent(QMouseEvent *event) override {
+    setCursor(resizeGripRect().contains(event->position()) ? Qt::SizeFDiagCursor
+                                                           : Qt::ArrowCursor);
+  }
+
+  void wheelEvent(QWheelEvent *event) override {
+    const int steps = event->angleDelta().y();
+    if (steps == 0)
+      return;
+    const qreal factor = steps > 0 ? 1 + kWheelStep : 1 - kWheelStep;
+    resize(scaledSize(qRound(width() * factor)));
+    event->accept();
+  }
+
+  void keyPressEvent(QKeyEvent *event) override {
+    if (event->key() == Qt::Key_Escape) {
+      close();
+      return;
+    }
+    if (event->matches(QKeySequence::Copy)) {
+      QString error;
+      showToast(copyPngToClipboard(image_, error)
+                    ? QStringLiteral("Copied to clipboard")
+                    : error);
+      return;
+    }
+    QWidget::keyPressEvent(event);
+  }
+
+  void enterEvent(QEnterEvent *) override {
+    hovered_ = true;
+    update();
+  }
+
+  void leaveEvent(QEvent *) override {
+    hovered_ = false;
+    setCursor(Qt::ArrowCursor);
+    update();
+  }
+
+private:
+  [[nodiscard]] QSize availableSize() const {
+    const QScreen *target =
+        screen() ? screen() : QGuiApplication::primaryScreen();
+    return target ? target->availableGeometry().size() : QSize(1920, 1080);
+  }
+
+  // The rendered capture is in device pixels, so a scaled output would
+  // otherwise open at twice its apparent size.
+  [[nodiscard]] QSize initialSize() const {
+    const QScreen *target =
+        screen() ? screen() : QGuiApplication::primaryScreen();
+    const qreal ratio =
+        target ? std::max<qreal>(1.0, target->devicePixelRatio()) : 1.0;
+    const QSizeF logical = QSizeF(image_.size()) / ratio;
+    const QSizeF limit = QSizeF(availableSize()) * kInitialScreenShare;
+    const qreal fit = std::min({1.0, limit.width() / logical.width(),
+                                limit.height() / logical.height()});
+    return scaledSize(qRound(logical.width() * fit));
+  }
+
+  [[nodiscard]] QSize scaledSize(int targetWidth) const {
+    const QSize available = availableSize();
+    const int maximumWidth = std::max(
+        kMinimumEdge,
+        qRound(image_.height() >= image_.width()
+                   ? available.height() * static_cast<qreal>(image_.width()) /
+                         image_.height()
+                   : available.width()));
+    const int clamped = std::clamp(targetWidth, kMinimumEdge, maximumWidth);
+    const int height = std::max(
+        kMinimumEdge,
+        qRound(clamped * static_cast<qreal>(image_.height()) / image_.width()));
+    return QSize(clamped, height);
+  }
+
+  void showToast(QString message) {
+    toast_ = std::move(message);
+    update();
+    QTimer::singleShot(kToastMs, this, [this] {
+      toast_.clear();
+      update();
+    });
+  }
+
+  [[nodiscard]] QRectF closeButtonRect() const {
+    return QRectF(width() - kCloseButtonSize - kCloseButtonInset,
+                  kCloseButtonInset, kCloseButtonSize, kCloseButtonSize);
+  }
+
+  [[nodiscard]] QRectF resizeGripRect() const {
+    return QRectF(width() - kResizeGripSize, height() - kResizeGripSize,
+                  kResizeGripSize, kResizeGripSize);
+  }
+
+  QImage image_;
+  QString toast_;
+  bool hovered_ = false;
+};
+
+} // namespace
+
+int main(int argc, char **argv) {
+  // The capture process exports this for its own layer-shell overlay;
+  // inheriting it here would turn the pin into a layer surface with no window
+  // rules.
+  qunsetenv("QT_WAYLAND_SHELL_INTEGRATION");
+  QCoreApplication::setApplicationName(QStringLiteral("omasnap-pin"));
+  QGuiApplication::setDesktopFileName(QStringLiteral("omasnap-pin"));
+  QApplication application(argc, argv);
+
+  const QStringList arguments = QCoreApplication::arguments();
+  if (arguments.size() < 2) {
+    qWarning("usage: omasnap-pin <image>");
+    return 2;
+  }
+  QImage image(arguments.at(1));
+  if (image.isNull()) {
+    qWarning("omasnap-pin: could not load %s", qUtf8Printable(arguments.at(1)));
+    return 1;
+  }
+
+  PinWindow window(std::move(image));
+  window.show();
+  return application.exec();
+}


### PR DESCRIPTION
## What

Adds a fourth output to the annotation editor: `P` pins the finished capture on screen as a floating window and closes the editor. Pinning does not write to the screenshot directory and does not touch the clipboard.

On a pin: drag the body to move, wheel or the bottom-right grip to resize, `Ctrl+C` to copy, `Esc` / middle-click / the hover close button to close.

## Why a separate binary

`main.cpp` exports `QT_WAYLAND_SHELL_INTEGRATION=layer-shell`, and layer-shell-qt's `createShellSurface` is unconditional, so every `QWindow` in the capture process becomes a layer surface. A pin created there could not be floated, stacked, moved by the compositor, or reached with alt-tab.

`omasnap-pin` is a small target (`Qt6::Core/Gui/Widgets` only) that clears the variable and shows the PNG in a frameless toplevel. Consequences that fall out of that choice:

- The capture process still exits right after pinning, so the `QLockFile` single-instance lock is released and the next capture starts immediately.
- Pins from different captures accumulate, each an independent process.
- Move, resize and stacking come from the compositor rather than hand-rolled margin math.

The pinned image is produced by the existing `renderCapture()` path rather than by reading `snapshotPath_` back, since `finish()` renames that file. `Ctrl+C` goes through `wl-copy` rather than `QClipboard`, matching what `capture.cpp` already does, so the image survives the pin's exit; it copies the full-resolution capture regardless of how small the pin is scaled.

## Verified on Hyprland 0.56.2 / Qt 6.11 / layer-shell-qt 6.7.4

- `P` closes the editor, pin appears, `hyprctl clients` reports `class: omasnap-pin` and no matching layer surface — including when the parent's environment still has `QT_WAYLAND_SHELL_INTEGRATION=layer-shell` exported.
- A new capture starts while pins are alive; pins survive the parent's exit and each other's close.
- Pinned pixels match the source PNG exactly (sampled solid patches) under the window rules documented in the README. The `opacity ... override` note exists because a configured `decoration:inactive_opacity` otherwise multiplies through and shifts the colors.
- `Ctrl+C` puts `image/png` on the clipboard at the source resolution, byte-for-byte colors, and it is still there after the pin closes.
- `Esc` closes a focused pin.
- `omasnap-smoke` passes offscreen (`QT_QPA_PLATFORM=offscreen`), matching the pre-change baseline built from `main` in a separate worktree. Under a live Wayland session the baseline and this branch both fail the same pre-existing hover check (`return 7`), so that is unrelated to this change.
- Build clean under `-Wall -Wextra -Wpedantic`; touched files are clang-formatted.

Not yet exercised, because the test environment can only synthesize keyboard input: dragging the pin body (`startSystemMove`), wheel resize, the bottom-right resize grip, middle-click close, and the hover close button. Those are straightforward Qt calls, but they are unverified — happy to follow up if a reviewer hits a problem.

## Note on the toolbar

The new toolbar button widens `kToolbarWidth` from 640 to 680, which moves the toolbar origin by 20px at the smoke test's 800px width. The three toolbar-relative coordinates in `editor-smoke.cpp` move with it; that is the only smoke change.