### PR TITLE
OCR: fall back to OMARCHY_OCR_LANGS for non-English text

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Install the complete build/runtime dependency set:
 sudo pacman -S --needed \
   base-devel cmake ninja pkgconf qt6-base layer-shell-qt \
   wayland wayland-protocols hyprland grim wl-clipboard \
-  tesseract tesseract-data-eng
+  tesseract tesseract-data-eng tesseract-data-tha
 ```
 
 Build and install:
@@ -159,10 +159,14 @@ Environment overrides:
 ```bash
 OMASNAP_SCREENSHOT_DIR="$HOME/Pictures/Captures" omasnap
 OMASNAP_OCR_LANGS="eng+deu" omasnap
+# Thai plus English:
+OMASNAP_OCR_LANGS="tha+eng" omasnap
 ```
 
 Install the corresponding Tesseract language data before adding a language to
-`OMASNAP_OCR_LANGS`.
+`OMASNAP_OCR_LANGS`. When unset, omasnap falls back to Omarchy's
+`OMARCHY_OCR_LANGS` (which commonly includes the user's script, e.g.
+`tha+eng`), then to `eng`.
 
 ## Controls
 

--- a/capture.cpp
+++ b/capture.cpp
@@ -585,8 +585,10 @@ QString recognizeText(const QImage &image, QString &error) {
     return {};
   }
 
-  const QString languages =
-      qEnvironmentVariable("OMASNAP_OCR_LANGS", QStringLiteral("eng"));
+  QString languages = qEnvironmentVariable("OMASNAP_OCR_LANGS");
+  if (languages.isEmpty())
+    languages = qEnvironmentVariable("OMARCHY_OCR_LANGS", QStringLiteral("eng"));
+  languages = languages.trimmed();
   const ProcessResult result = runProcess(
       QStringLiteral("tesseract"),
       {path, QStringLiteral("stdout"), QStringLiteral("--oem"),
@@ -596,8 +598,8 @@ QString recognizeText(const QImage &image, QString &error) {
        QStringLiteral("preserve_interword_spaces=1")},
       {}, 30000);
   if (!result.finished || result.exitCode != 0) {
-    error = QStringLiteral("OCR failed: %1")
-                .arg(QString::fromUtf8(result.error).trimmed());
+    error = QStringLiteral("OCR failed for languages %1: %2")
+                .arg(languages, QString::fromUtf8(result.error).trimmed());
     return {};
   }
   const QString text = QString::fromUtf8(result.output).trimmed();

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -491,6 +491,21 @@ int main(int argc, char **argv) {
   if (!recognizeText(ocrImage, ocrError)
            .contains(QStringLiteral("OCR smoke test 42")))
     return 5;
+  const QByteArray savedOmasnapLangs = qgetenv("OMASNAP_OCR_LANGS");
+  const QByteArray savedOmarchyLangs = qgetenv("OMARCHY_OCR_LANGS");
+  qputenv("OMASNAP_OCR_LANGS", "");
+  qputenv("OMARCHY_OCR_LANGS", "eng");
+  const QString fallbackOcr = recognizeText(ocrImage, ocrError);
+  if (savedOmasnapLangs.isEmpty())
+    qunsetenv("OMASNAP_OCR_LANGS");
+  else
+    qputenv("OMASNAP_OCR_LANGS", savedOmasnapLangs);
+  if (savedOmarchyLangs.isEmpty())
+    qunsetenv("OMARCHY_OCR_LANGS");
+  else
+    qputenv("OMARCHY_OCR_LANGS", savedOmarchyLangs);
+  if (!fallbackOcr.contains(QStringLiteral("OCR smoke test 42")))
+    return 65;
   QTest::mouseMove(&editor, QPoint(400, 300), 20);
   QTest::keyClick(&editor, Qt::Key_T);
   QTest::keyClick(&editor, Qt::Key_Escape);

--- a/install-omarchy
+++ b/install-omarchy
@@ -13,7 +13,7 @@ fi
 omarchy-pkg-add \
   base-devel cmake ninja pkgconf qt6-base layer-shell-qt \
   wayland wayland-protocols grim wl-clipboard \
-  tesseract tesseract-data-eng
+  tesseract tesseract-data-eng tesseract-data-tha
 
 cmake -S "$repo_dir" -B "$build_dir" -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
## Summary
- Recognize text with `OMASNAP_OCR_LANGS` when set, otherwise fall back to
  `OMARCHY_OCR_LANGS` (which commonly includes the user's script, e.g. `tha+eng`),
  then to `eng`.
- Add `tesseract-data-tha` to the installer and manual build dependency lists.
- Document the override and fallback in the README.
- Extend the smoke test to cover the `OMARCHY_OCR_LANGS` fallback path.

This makes omasnap's OCR region tool (`O`) recognize Thai and other scripts out of
the box on Omarchy, matching `omarchy capture text`.

## Test plan
- [x] `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build --parallel`
- [x] `QT_QPA_PLATFORM=offscreen ./build/omasnap-smoke /tmp/omasnap-smoke`
- [x] Installed to `~/.local`, verified `OMARCHY_OCR_LANGS=tha+eng` is used when `OMASNAP_OCR_LANGS` is unset
- [x] OCR'd a Thai region via `PRINT` -> `O`; clipboard contains Thai text