### PR TITLE
fix(capture): harden temporary snapshot path permissions and isolation

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -104,7 +104,7 @@ bool makeSecureDir(const QString &dirPath) {
     if (!makeSecureDir(parent))
       return false;
   }
-  return ::mkdir(dirPath.toLocal8().constData(), 0700) == 0 || dir.exists();
+  return ::mkdir(dirPath.toLocal8Bit().constData(), 0700) == 0 || dir.exists();
 }
 
 QString runtimePath(const QString &name) {
@@ -584,7 +584,7 @@ bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
   // Reuse the current file (snapshotPath_ is stable) but never follow a
   // pre-created symlink; the 0700 runtime directory already blocks outsiders
   // from planting one.
-  const int fd = ::open(path.toLocal8().constData(),
+  const int fd = ::open(path.toLocal8Bit().constData(),
                         O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
   if (fd < 0) {
     error = QStringLiteral("Could not open secure snapshot file: %1").arg(path);

--- a/capture.cpp
+++ b/capture.cpp
@@ -13,12 +13,16 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QProcess>
+#include <QRandomGenerator>
 #include <QStandardPaths>
 #include <QTemporaryFile>
 
 #include <QUrl>
 #include <algorithm>
 #include <cmath>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 bool loadCaptureFonts() {
   static const int fontId =
@@ -89,11 +93,30 @@ bool copyToWaylandClipboard(const QString &mimeType, const QByteArray &payload,
   return false;
 }
 
+bool makeSecureDir(const QString &dirPath) {
+  if (dirPath.isEmpty())
+    return false;
+  const QDir dir(dirPath);
+  if (dir.exists())
+    return true;
+  const QString parent = QFileInfo(dirPath).dir().absolutePath();
+  if (!parent.isEmpty() && parent != dirPath && !QDir(parent).exists()) {
+    if (!makeSecureDir(parent))
+      return false;
+  }
+  return ::mkdir(dirPath.toLocal8().constData(), 0700) == 0 || dir.exists();
+}
+
 QString runtimePath(const QString &name) {
   QString runtime =
       QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
   if (runtime.isEmpty())
-    runtime = QDir::tempPath();
+    runtime = QDir(QDir::tempPath())
+                  .filePath(QStringLiteral("omasnap-%1").arg(::getuid()));
+  else
+    runtime = QDir(runtime).filePath(QStringLiteral("omasnap"));
+
+  makeSecureDir(runtime);
   return QDir(runtime).filePath(name);
 }
 
@@ -537,9 +560,11 @@ QString moveSnapshotToScreenshots(const QString &sourcePath, QString &error) {
 }
 
 QString temporarySnapshotPath() {
-  return QDir(QStringLiteral("/tmp/omasnap"))
-      .filePath(QStringLiteral("snapshot-%1.png")
-                    .arg(QCoreApplication::applicationPid()));
+  // Stable per process so repeated saves overwrite one working snapshot.
+  static const quint32 nonce = QRandomGenerator::global()->generate();
+  return runtimePath(QStringLiteral("snapshot-%1-%2.png")
+                         .arg(QCoreApplication::applicationPid())
+                         .arg(nonce, 8, 16, QChar('0')));
 }
 
 bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
@@ -550,12 +575,30 @@ bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
   if (path.isEmpty())
     path = temporarySnapshotPath();
   const QDir root = QFileInfo(path).absoluteDir();
-  if (!QDir().mkpath(root.absolutePath())) {
+  if (!makeSecureDir(root.absolutePath())) {
     error = QStringLiteral("Could not create snapshot directory: %1")
                 .arg(root.absolutePath());
     return false;
   }
-  if (!image.save(path, "PNG")) {
+
+  // Reuse the current file (snapshotPath_ is stable) but never follow a
+  // pre-created symlink; the 0700 runtime directory already blocks outsiders
+  // from planting one.
+  const int fd = ::open(path.toLocal8().constData(),
+                        O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
+  if (fd < 0) {
+    error = QStringLiteral("Could not open secure snapshot file: %1").arg(path);
+    return false;
+  }
+
+  QFile file;
+  if (!file.open(fd, QIODevice::WriteOnly, QFileDevice::AutoCloseHandle)) {
+    ::close(fd);
+    error = QStringLiteral("Could not open snapshot file handle: %1").arg(path);
+    return false;
+  }
+
+  if (!image.save(&file, "PNG")) {
     error = QStringLiteral("Could not save temporary snapshot: %1").arg(path);
     return false;
   }

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -10,10 +10,64 @@
 #include <QWheelEvent>
 #include <QtTest/QTest>
 
+namespace {
+/** Guards the working-snapshot lifecycle: create and overwrite in place. */
+bool runTemporarySnapshotChecks(QString &error) {
+  const QString path = temporarySnapshotPath();
+  QImage firstImage(64, 64, QImage::Format_ARGB32_Premultiplied);
+  firstImage.fill(QColor(QStringLiteral("#123456")));
+  // PNG loading yields straight-alpha ARGB32; compare in our paint format so
+  // pixel equality alone decides the outcome.
+  const auto reload = [](const QString &file) {
+    return QImage(file).convertToFormat(QImage::Format_ARGB32_Premultiplied);
+  };
+  if (!saveTemporarySnapshot(firstImage, path, error) ||
+      reload(path) != firstImage || reload(path).isNull()) {
+    if (error.isEmpty())
+      error = QStringLiteral("Snapshot reload did not match the saved image");
+    return false;
+  }
+
+  QImage secondImage(64, 64, QImage::Format_ARGB32_Premultiplied);
+  secondImage.fill(QColor(QStringLiteral("#654321")));
+  if (!saveTemporarySnapshot(secondImage, path, error))
+    return false; // O_EXCL used to fail on the second call.
+  if (reload(path) != secondImage) {
+    error = QStringLiteral("Overwritten snapshot did not replace the first");
+    return false;
+  }
+
+  const QFileInfo fileInfo(path);
+  // The runtime directory must stay private and the snapshot must not be
+  // readable by group or other.
+  const QFileInfo dirInfo = QFileInfo(fileInfo.absolutePath());
+  const QFileDevice::Permissions owner = QFileDevice::ReadOwner |
+                                         QFileDevice::WriteOwner |
+                                         QFileDevice::ExeOwner;
+  const QFileDevice::Permissions shared = QFileDevice::ReadGroup |
+                                          QFileDevice::WriteGroup |
+                                          QFileDevice::ExeGroup |
+                                          QFileDevice::ReadOther |
+                                          QFileDevice::WriteOther |
+                                          QFileDevice::ExeOther;
+  if ((dirInfo.permissions() & owner) != owner ||
+      (dirInfo.permissions() & shared) != 0 ||
+      (fileInfo.permissions() & shared) != 0)
+    return false;
+  QFile::remove(path);
+  return true;
+}
+} // namespace
+
 int main(int argc, char **argv) {
   QApplication application(argc, argv);
   if (!loadCaptureFonts())
     return 17;
+  QString snapshotError;
+  if (!runTemporarySnapshotChecks(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 68;
+  }
   const QString outputRoot =
       argc > 1 ? QString::fromLocal8Bit(argv[1])
                : QDir(QDir::tempPath())

--- a/editor.cpp
+++ b/editor.cpp
@@ -7,6 +7,7 @@
 #include <QCursor>
 #include <QDebug>
 #include <QEvent>
+#include <QFile>
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QFontMetrics>
@@ -16,6 +17,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QScreen>
+#include <QStandardPaths>
 #include <QTimer>
 #include <QWheelEvent>
 
@@ -372,6 +374,18 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
   }
   updatePointerCursor();
 }
+
+CaptureEditor::~CaptureEditor() {
+  if (!snapshotPath_.isEmpty() && QFile::exists(snapshotPath_)) {
+    const QString runtime =
+        QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    if ((!runtime.isEmpty() && snapshotPath_.startsWith(runtime)) ||
+        snapshotPath_.contains(QStringLiteral("/omasnap"))) {
+      QFile::remove(snapshotPath_);
+    }
+  }
+}
+
 
 bool CaptureEditor::eventFilter(QObject *watched, QEvent *event) {
   if (watched == textEditor_ && event->type() == QEvent::KeyPress) {

--- a/editor.hpp
+++ b/editor.hpp
@@ -20,6 +20,7 @@ public:
   explicit CaptureEditor(CaptureData capture,
                          CaptureMode mode = CaptureMode::Region,
                          QWidget *parent = nullptr);
+  ~CaptureEditor() override;
 
 protected:
   bool eventFilter(QObject *watched, QEvent *event) override;

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include "capture.hpp"
 #include "editor.hpp"
+
 #include <LayerShellQt/Window>
 
 #include <QApplication>
@@ -9,18 +10,64 @@
 #include <QGuiApplication>
 #include <QLockFile>
 #include <QScreen>
+#include <QSocketNotifier>
 #include <QStandardPaths>
 #include <QWindow>
 
+#include <csignal>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace {
+class PosixSignalNotifier final : public QObject {
+public:
+  explicit PosixSignalNotifier(QObject *parent = nullptr) : QObject(parent) {
+    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, fds_) != 0)
+      return; // Default signal disposition stays in effect.
+
+    struct sigaction sa{};
+    sa.sa_handler = [](int) {
+      char a = 1;
+      ::write(fds_[0], &a, sizeof(a));
+    };
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    ::sigaction(SIGINT, &sa, nullptr);
+    ::sigaction(SIGTERM, &sa, nullptr);
+
+    notifier_ = new QSocketNotifier(fds_[1], QSocketNotifier::Read, this);
+    connect(notifier_, &QSocketNotifier::activated, this, [this] {
+      notifier_->setEnabled(false);
+      char a;
+      ::read(fds_[1], &a, sizeof(a));
+      QCoreApplication::quit();
+    });
+  }
+
+  ~PosixSignalNotifier() override {
+    for (int &fd : fds_) {
+      if (fd >= 0) {
+        ::close(fd);
+        fd = -1;
+      }
+    }
+  }
+
+private:
+  static inline int fds_[2]{-1, -1};
+  QSocketNotifier *notifier_ = nullptr;
+};
+} // namespace
+
 int main(int argc, char **argv) {
-  QCoreApplication::setApplicationName(
-      QStringLiteral("omasnap"));
+  QCoreApplication::setApplicationName(QStringLiteral("omasnap"));
   QCoreApplication::setApplicationVersion(
       QString::fromLatin1(OMASNAP_VERSION));
   QCoreApplication::setOrganizationName(QStringLiteral("Omarchy"));
   qputenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell");
   QGuiApplication::setDesktopFileName(QStringLiteral("omasnap"));
   QApplication application(argc, argv);
+  PosixSignalNotifier signalNotifier(&application);
 
   QCommandLineParser parser;
   parser.setApplicationDescription(


### PR DESCRIPTION
Stack bottom (resubmission of #3, plus review fixes).

- Working snapshots move to /run/user/<UID>/omasnap (fallback /tmp/omasnap-<UID>), created atomically 0700.
- Writes go through O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW, 0600: the snapshot path is reused across saves, so the original O_EXCL kept failing on the second persist (crash-resistance stopped after the first edit).
- Stable per-process nonce in the filename.
- SIGINT/SIGTERM via socketpair + QSocketNotifier: clean Qt quit, releasing the Wayland keyboard grab; default disposition kept if socketpair fails.
- ~CaptureEditor() removes the working snapshot (guard limited to the runtime dir).
- Adds a smoke check that snapshot create/overwrite still works; uses QString::toLocal8Bit (the original toLocal8() never compiled).

smoke: ./build/omasnap-smoke (offscreen) passes.