### PR TITLE
fix: support rotated and flipped Wayland displays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ target_link_libraries(omasnap PRIVATE
 
 qt_add_executable(omasnap-smoke
   editor-smoke.cpp
+  transform-smoke.cpp
+  transform-smoke.hpp
   capture.cpp
   capture.hpp
   surface-capture.cpp

--- a/capture.cpp
+++ b/capture.cpp
@@ -1,3 +1,4 @@
+/** @fileoverview Captures, renders, saves, and shares screenshots. */
 #include "capture.hpp"
 
 #include <QCoreApplication>
@@ -165,7 +166,7 @@ bool parseMonitor(const QByteArray &json, MonitorInfo &monitor,
         static_cast<int>(std::floor(rawWidth / std::max<qreal>(scale, 0.01)));
     int logicalHeight =
         static_cast<int>(std::floor(rawHeight / std::max<qreal>(scale, 0.01)));
-    if (transform == 1 || transform == 3)
+    if (transform == 1 || transform == 3 || transform == 5 || transform == 7)
       std::swap(logicalWidth, logicalHeight);
 
     monitor.name = object.value(QStringLiteral("name")).toString();

--- a/capture.hpp
+++ b/capture.hpp
@@ -1,4 +1,7 @@
+/** @fileoverview Declares screenshot capture, rendering, and output types. */
 #pragma once
+
+#include <cstdint>
 
 #include <QColor>
 #include <QImage>
@@ -51,6 +54,9 @@ struct Annotation {
 [[nodiscard]] bool captureFocusedMonitor(CaptureData &capture, QString &error);
 [[nodiscard]] bool captureWindowSurface(const WindowTarget &window,
                                         QImage &image, QString &error);
+/** Returns an upright image for captured Wayland buffer contents. */
+[[nodiscard]] QImage normalizeWaylandCapture(const QImage &image,
+                                             std::uint32_t transform);
 [[nodiscard]] QImage renderCapture(const CaptureData &capture,
                                    const QRectF &selection,
                                    const QVector<Annotation> &annotations,

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -1,5 +1,8 @@
+/** @fileoverview Exercises capture editor behavior without a live compositor.
+ */
 #include "capture.hpp"
 #include "editor.hpp"
+#include "transform-smoke.hpp"
 
 #include <QApplication>
 #include <QDebug>
@@ -59,6 +62,7 @@ bool runTemporarySnapshotChecks(QString &error) {
 }
 } // namespace
 
+/** Runs the interaction and rendering smoke checks. */
 int main(int argc, char **argv) {
   QApplication application(argc, argv);
   if (!loadCaptureFonts())
@@ -590,6 +594,12 @@ int main(int argc, char **argv) {
       qWarning().noquote() << clipboardError;
       return 64;
     }
+  }
+
+  QString transformError;
+  if (!runTransformSmoke(transformError)) {
+    qWarning().noquote() << transformError;
+    return 67;
   }
   return 0;
 }

--- a/surface-capture.cpp
+++ b/surface-capture.cpp
@@ -1,3 +1,4 @@
+/** @fileoverview Captures native window surfaces through Wayland protocols. */
 #include "capture.hpp"
 
 #include "ext-foreign-toplevel-list-v1-client-protocol.h"
@@ -5,6 +6,7 @@
 #include "ext-image-copy-capture-v1-client-protocol.h"
 
 #include <QImage>
+#include <QTransform>
 
 #include <wayland-client.h>
 
@@ -309,6 +311,35 @@ QImage copyCapturedImage(const CaptureState &state) {
 }
 } // namespace
 
+QImage normalizeWaylandCapture(const QImage &image, std::uint32_t transform) {
+  const auto rotated = [&image](qreal degrees) {
+    return image.transformed(QTransform().rotate(degrees));
+  };
+  const auto flipped = [](const QImage &source) {
+    return source.transformed(QTransform().scale(-1, 1));
+  };
+  switch (transform) {
+  case WL_OUTPUT_TRANSFORM_NORMAL:
+    return image;
+  case WL_OUTPUT_TRANSFORM_90:
+    return rotated(90);
+  case WL_OUTPUT_TRANSFORM_180:
+    return rotated(180);
+  case WL_OUTPUT_TRANSFORM_270:
+    return rotated(-90);
+  case WL_OUTPUT_TRANSFORM_FLIPPED:
+    return flipped(image);
+  case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+    return flipped(rotated(90));
+  case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+    return flipped(rotated(180));
+  case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+    return flipped(rotated(-90));
+  default:
+    return {};
+  }
+}
+
 bool captureWindowSurface(const WindowTarget &window, QImage &image,
                           QString &error) {
   if (window.stableId.isEmpty()) {
@@ -377,14 +408,14 @@ bool captureWindowSurface(const WindowTarget &window, QImage &image,
           "Compositor could not capture the selected window surface");
     return false;
   }
-  if (state.transform != WL_OUTPUT_TRANSFORM_NORMAL) {
-    error = QStringLiteral("Unsupported transform in native window capture");
+  const QImage captured = copyCapturedImage(state);
+  if (captured.isNull()) {
+    error = QStringLiteral("Could not decode native window capture");
     return false;
   }
-
-  image = copyCapturedImage(state);
+  image = normalizeWaylandCapture(captured, state.transform);
   if (image.isNull()) {
-    error = QStringLiteral("Could not decode native window capture");
+    error = QStringLiteral("Unsupported transform in native window capture");
     return false;
   }
   return true;

--- a/transform-smoke.cpp
+++ b/transform-smoke.cpp
@@ -1,0 +1,116 @@
+/** @fileoverview Tests monitor geometry and Wayland buffer orientation. */
+#include "transform-smoke.hpp"
+
+#include "capture.hpp"
+
+#include <QDir>
+#include <QFile>
+#include <QImage>
+#include <QTemporaryDir>
+#include <QVector>
+
+#include <wayland-client-protocol.h>
+
+namespace {
+/** Writes an executable helper used to replace an external command. */
+bool writeExecutable(const QString &path, const QByteArray &contents) {
+  QFile file(path);
+  if (!file.open(QIODevice::WriteOnly) ||
+      file.write(contents) != contents.size())
+    return false;
+  file.close();
+  return QFile::setPermissions(path, QFileDevice::ReadOwner |
+                                         QFileDevice::WriteOwner |
+                                         QFileDevice::ExeOwner);
+}
+
+/** Creates a small image whose red channel stores easy-to-check values. */
+QImage indexedImage(const QVector<QVector<int>> &rows) {
+  QImage image(rows.constFirst().size(), rows.size(), QImage::Format_RGB32);
+  for (int y = 0; y < rows.size(); ++y) {
+    for (int x = 0; x < rows.at(y).size(); ++x)
+      image.setPixelColor(x, y, QColor(rows.at(y).at(x), 0, 0));
+  }
+  return image;
+}
+} // namespace
+
+bool runTransformSmoke(QString &error) {
+  QTemporaryDir fakeCommands;
+  if (!fakeCommands.isValid()) {
+    error = QStringLiteral("Could not create transform-test directory");
+    return false;
+  }
+  const QString fakeHyprctl =
+      QDir(fakeCommands.path()).filePath(QStringLiteral("hyprctl"));
+  const QString fakeGrim =
+      QDir(fakeCommands.path()).filePath(QStringLiteral("grim"));
+  const QByteArray hyprctlScript = QByteArrayLiteral(
+      "#!/usr/bin/env bash\n"
+      "set -euo pipefail\n"
+      "if [[ \"${1:-}\" == \"monitors\" ]]; then\n"
+      "  printf '[{\"focused\":true,\"scale\":1.0,\"width\":300,"
+      "\"height\":200,\"transform\":%s,\"name\":\"TEST-ROTATED\","
+      "\"x\":0,\"y\":0,\"activeWorkspace\":{\"id\":7}}]\\n' "
+      "\"$OMASNAP_TEST_TRANSFORM\"\n"
+      "else\n"
+      "  printf '[]\\n'\n"
+      "fi\n");
+  const QByteArray grimScript =
+      QByteArrayLiteral("#!/usr/bin/env bash\n"
+                        "set -euo pipefail\n"
+                        "cp -- \"$OMASNAP_TEST_PPM\" \"${@: -1}\"\n");
+  if (!writeExecutable(fakeHyprctl, hyprctlScript) ||
+      !writeExecutable(fakeGrim, grimScript)) {
+    error = QStringLiteral("Could not create transform-test commands");
+    return false;
+  }
+  QImage rotatedSource(300, 200, QImage::Format_RGB32);
+  rotatedSource.fill(QColor(QStringLiteral("#123456")));
+  const QString ppmPath =
+      QDir(fakeCommands.path()).filePath(QStringLiteral("source.ppm"));
+  if (!rotatedSource.save(ppmPath, "PPM")) {
+    error = QStringLiteral("Could not create transform-test capture");
+    return false;
+  }
+
+  const QByteArray originalPath = qgetenv("PATH");
+  qputenv("PATH", fakeCommands.path().toUtf8() + ':' + originalPath);
+  qputenv("OMASNAP_TEST_PPM", ppmPath.toUtf8());
+  for (const int transform : {1, 3, 5, 7}) {
+    qputenv("OMASNAP_TEST_TRANSFORM", QByteArray::number(transform));
+    CaptureData rotatedCapture;
+    if (!captureFocusedMonitor(rotatedCapture, error) ||
+        rotatedCapture.monitor.geometry.size() != QSize(200, 300) ||
+        rotatedCapture.preview.size() != QSize(200, 300)) {
+      if (error.isEmpty())
+        error = QStringLiteral("Quarter-turn monitor geometry was not swapped");
+      qputenv("PATH", originalPath);
+      qunsetenv("OMASNAP_TEST_PPM");
+      qunsetenv("OMASNAP_TEST_TRANSFORM");
+      return false;
+    }
+  }
+  qputenv("PATH", originalPath);
+  qunsetenv("OMASNAP_TEST_PPM");
+  qunsetenv("OMASNAP_TEST_TRANSFORM");
+
+  const QImage upright = indexedImage({{1, 2}, {3, 4}, {5, 6}});
+  const QVector<QPair<std::uint32_t, QImage>> transformedImages{
+      {WL_OUTPUT_TRANSFORM_NORMAL, upright},
+      {WL_OUTPUT_TRANSFORM_90, indexedImage({{2, 4, 6}, {1, 3, 5}})},
+      {WL_OUTPUT_TRANSFORM_180, indexedImage({{6, 5}, {4, 3}, {2, 1}})},
+      {WL_OUTPUT_TRANSFORM_270, indexedImage({{5, 3, 1}, {6, 4, 2}})},
+      {WL_OUTPUT_TRANSFORM_FLIPPED, indexedImage({{2, 1}, {4, 3}, {6, 5}})},
+      {WL_OUTPUT_TRANSFORM_FLIPPED_90, indexedImage({{1, 3, 5}, {2, 4, 6}})},
+      {WL_OUTPUT_TRANSFORM_FLIPPED_180, indexedImage({{5, 6}, {3, 4}, {1, 2}})},
+      {WL_OUTPUT_TRANSFORM_FLIPPED_270, indexedImage({{6, 4, 2}, {5, 3, 1}})},
+  };
+  for (const auto &[transform, transformed] : transformedImages) {
+    if (normalizeWaylandCapture(transformed, transform) != upright) {
+      error = QStringLiteral("Captured Wayland buffer was not upright");
+      return false;
+    }
+  }
+  return true;
+}

--- a/transform-smoke.hpp
+++ b/transform-smoke.hpp
@@ -1,0 +1,7 @@
+/** @fileoverview Declares display-transform smoke checks. */
+#pragma once
+
+#include <QString>
+
+/** Checks monitor geometry and captured-buffer orientation. */
+[[nodiscard]] bool runTransformSmoke(QString &error);


### PR DESCRIPTION
Resubmission of #6 on the stack.

- Swap logical geometry for quarter-turn transforms (1/3/5/7) in parseMonitor.
- normalizeWaylandCapture() rotates/flips captured buffers upright for all eight Wayland transforms.
- transform-smoke.cpp verifies every transform and the fake-monitor geometry.

smoke: passes (incl. transform checks).