### PR TITLE
fix: clip annotations to cropped capture

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -524,6 +524,7 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   painter.save();
   painter.translate(marginX, marginY);
   painter.scale(scaleX, scaleY);
+  painter.setClipRect(QRectF(QPointF(), selection.size()));
   for (const Annotation &annotation : annotations)
     drawAnnotation(painter, annotation);
   painter.restore();

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -61,7 +61,6 @@ bool runTemporarySnapshotChecks(QString &error) {
   return true;
 }
 } // namespace
-
 /** Runs the interaction and rendering smoke checks. */
 int main(int argc, char **argv) {
   QApplication application(argc, argv);
@@ -467,6 +466,34 @@ int main(int argc, char **argv) {
       QColor(QStringLiteral("#0a84ff")))
     return 58;
 
+  CaptureEditor previewClipEditor(capture);
+  previewClipEditor.resize(800, 600);
+  previewClipEditor.show();
+  application.processEvents();
+  QTest::mousePress(&previewClipEditor, Qt::LeftButton, Qt::NoModifier,
+                    QPoint(100, 100));
+  QTest::mouseMove(&previewClipEditor, QPoint(650, 470), 20);
+  QTest::mouseRelease(&previewClipEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(650, 470));
+  QTest::keyClick(&previewClipEditor, Qt::Key_C);
+  QTest::mouseClick(&previewClipEditor, Qt::LeftButton, Qt::NoModifier,
+                    QPoint(640, 300));
+  QTest::keyClick(&previewClipEditor, Qt::Key_B);
+  QTest::mousePress(&previewClipEditor, Qt::LeftButton, Qt::NoModifier,
+                    QPoint(682, 305));
+  QTest::mouseMove(&previewClipEditor, QPoint(500, 305), 20);
+  QTest::mouseRelease(&previewClipEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(500, 305));
+  application.processEvents();
+  const QImage clippedPreview = previewClipEditor.grab().toImage();
+  for (int y = 270; y <= 330; ++y) {
+    for (int x = 690; x <= 760; ++x) {
+      const QColor pixel = clippedPreview.pixelColor(x, y);
+      if (pixel.red() > 240 && pixel.green() < 96 && pixel.blue() < 128)
+        return 66;
+    }
+  }
+
   QVector<Annotation> annotations;
   annotations.push_back({Annotation::Kind::Arrow,
                          {50, 60},
@@ -519,6 +546,31 @@ int main(int argc, char **argv) {
   if (rendered.isNull() || rendered.size() != QSize(628, 428) ||
       !rendered.save(outputRoot + QStringLiteral("-render.png"), "PNG"))
     return 3;
+
+  CaptureData clippingCapture;
+  clippingCapture.monitor.scale = 1.0;
+  clippingCapture.source = QImage(100, 100, QImage::Format_RGB32);
+  clippingCapture.source.fill(Qt::white);
+  clippingCapture.preview = clippingCapture.source;
+  Annotation croppedOut;
+  croppedOut.kind = Annotation::Kind::Rectangle;
+  croppedOut.start = {120, 20};
+  croppedOut.end = {150, 60};
+  croppedOut.color = QColor(QStringLiteral("#ff00ff"));
+  croppedOut.size = 4;
+  const QImage clippedExport =
+      renderCapture(clippingCapture, QRectF(0, 0, 100, 100), {croppedOut},
+                    BackgroundStyle::Aurora);
+  const QRect exportedImageBounds(64, 64, 100, 100);
+  for (int y = 0; y < clippedExport.height(); ++y) {
+    for (int x = 0; x < clippedExport.width(); ++x) {
+      if (exportedImageBounds.contains(x, y))
+        continue;
+      const QColor pixel = clippedExport.pixelColor(x, y);
+      if (pixel.red() > 240 && pixel.green() < 32 && pixel.blue() > 240)
+        return 65;
+    }
+  }
 
   CaptureData highDpiCapture = capture;
   highDpiCapture.monitor.scale = 2.0;

--- a/editor.cpp
+++ b/editor.cpp
@@ -1,3 +1,5 @@
+/** @fileoverview Handles screenshot selection, annotation, and editor drawing.
+ */
 #include "editor.hpp"
 
 #include <QtConcurrent/QtConcurrentRun>
@@ -1792,6 +1794,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   painter.save();
   painter.translate(image.topLeft());
   painter.scale(editScale(), editScale());
+  painter.save();
+  painter.setClipRect(QRectF(QPointF(), selection_.size()));
   for (int index = 0; index < annotations_.size(); ++index) {
     if (index != editingAnnotation_)
       paintAnnotation(painter, annotations_.at(index));
@@ -1822,6 +1826,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     preview.size = annotationSize_;
     paintAnnotation(painter, preview);
   }
+  painter.restore();
   if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
       selectedAnnotation_ != editingAnnotation_) {
     const Annotation &selected = annotations_.at(selectedAnnotation_);


### PR DESCRIPTION
Resubmission of #5 on the stack.

- Clips annotation drawing to the selected crop in the editor preview (paintEdit) and in renderCapture exports.
- Selection controls stay outside the clipped area.
- Smoke checks cover both preview and exported image.

smoke: passes (incl. both clip checks).