### PR TITLE
feat: pin captures on screen with P

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ endforeach()
 
 qt_add_executable(omasnap
   main.cpp
+  icons.cpp
+  icons.hpp
   capture.cpp
   capture.hpp
   surface-capture.cpp
@@ -60,6 +62,8 @@ target_link_libraries(omasnap PRIVATE
 
 qt_add_executable(omasnap-pin
   pin.cpp
+  icons.cpp
+  icons.hpp
 )
 target_compile_features(omasnap-pin PRIVATE cxx_std_23)
 target_compile_options(omasnap-pin PRIVATE -Wall -Wextra -Wpedantic)
@@ -67,10 +71,13 @@ target_link_libraries(omasnap-pin PRIVATE
   Qt6::Core
   Qt6::Gui
   Qt6::Widgets
+  LayerShellQt::Interface
 )
 
 qt_add_executable(omasnap-smoke
   editor-smoke.cpp
+  icons.cpp
+  icons.hpp
   transform-smoke.cpp
   transform-smoke.hpp
   capture.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,17 @@ target_link_libraries(omasnap PRIVATE
   PkgConfig::WaylandClient
 )
 
+qt_add_executable(omasnap-pin
+  pin.cpp
+)
+target_compile_features(omasnap-pin PRIVATE cxx_std_23)
+target_compile_options(omasnap-pin PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(omasnap-pin PRIVATE
+  Qt6::Core
+  Qt6::Gui
+  Qt6::Widgets
+)
+
 qt_add_executable(omasnap-smoke
   editor-smoke.cpp
   transform-smoke.cpp
@@ -86,7 +97,7 @@ target_link_libraries(omasnap-smoke PRIVATE
   PkgConfig::WaylandClient
 )
 
-install(TARGETS omasnap
+install(TARGETS omasnap omasnap-pin
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 )
 install(FILES assets/OFL.txt

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
-- Pin a finished capture on screen as a floating always-on-top window (`omasnap-pin`),
-  independent of the capture process so new captures keep working.
+- Pin a finished capture as a bottom-right always-on-top layer surface (`omasnap-pin`),
+  visible on every workspace and independent of the capture process.
 - Crash-resistant working snapshots under `/run/user/<UID>/omasnap/` (falling back to
   a private `/tmp/omasnap-<UID>/`), written immediately after selection and overwritten
   after every completed edit. Saving moves that file into `~/Pictures/Screenshots`;
@@ -209,45 +209,30 @@ Install the corresponding Tesseract language data before adding a language to
 ### Pinned captures
 
 `P` renders the current capture, writes it to a `pin-<pid>-<n>.png` under the runtime
-snapshot directory, and hands it to `omasnap-pin` — a separate binary that deliberately
-runs without
-`QT_WAYLAND_SHELL_INTEGRATION`, so the pin is a plain toplevel the compositor can float,
-stack, and move like any other window. Pinning neither touches the clipboard nor writes to
-the screenshot directory; it is a fourth output alongside copy, save, and copy-and-save.
+snapshot directory, and hands it to `omasnap-pin`. The separate layer-shell surface is
+anchored 14 logical pixels from the bottom-right corner and stays visible on every
+workspace without compositor window rules. It preserves the image aspect ratio, with a
+maximum width of one third of the screen and a maximum height of one half.
 
-`P` closes the editor, which releases the single-instance lock so the next capture starts
-immediately. Pins from separate captures accumulate; each one is an independent process.
+Pinning neither touches the clipboard nor writes to the screenshot directory; it is a
+fourth output alongside copy, save, and copy-and-save. `P` closes the editor and releases
+the single-instance lock immediately. Pins from separate captures accumulate as independent
+processes.
+
+Hover the pin to reveal its controls:
 
 | Input on a pin | Action |
 |---|---|
-| Drag body | Move (compositor-driven `startSystemMove`) |
-| Wheel, bottom-right grip | Resize, aspect preserved |
-| `Ctrl+C` | Copy the pinned PNG to the clipboard |
-| `Esc`, middle-click, hover close button | Close |
+| Edit button | Reopen the full-resolution PNG in Omasnap and replace the pin |
+| Link button | Copy the source file path |
+| Copy button, `Ctrl+C` | Copy the full-resolution PNG |
+| Double-wide top-left drag handle | Drag the PNG into a file-capable drop target |
+| Wheel | Resize within the screen caps, preserving aspect ratio |
+| Close button, `Esc`, middle-click | Close |
 
-`Ctrl+C` copies through `wl-copy` rather than `QClipboard`, so the image stays on the
-clipboard after the pin is closed, and it copies the capture at full resolution regardless
-of how small the pin has been scaled.
-
-Recommended window rules, in the Lua config syntax these were tested with:
-
-```lua
-hl.window_rule({
-  match = { class = "^omasnap-pin$" },
-  float = true,
-  pin = true,
-  no_initial_focus = true,
-  no_dim = true,
-  keep_aspect_ratio = true,
-  opacity = "1 1 override",
-})
-```
-
-The `override` on the opacity rule matters: without it a configured
-`decoration:inactive_opacity` still multiplies through, and an unfocused pin then shows
-colors that no longer match the capture. In a legacy `hyprland.conf` the equivalents are
-`float`, `pin`, `noinitialfocus`, `nodim`, `keepaspectratio` and
-`opacity 1.0 1.0 override` on `class:^omasnap-pin$`.
+Image and path copying use `wl-copy` rather than `QClipboard`, so clipboard data remains
+available after the pin is closed. No font-based symbol set or compositor-specific window
+rule is required; the controls use the same vector icon renderer as the annotation toolbar.
 
 Creation tools return to Select after one placement without selecting the new layer. In
 Select mode, arrows and lines show only their two endpoint handles; other layers show a

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
+- Pin a finished capture on screen as a floating always-on-top window (`omasnap-pin`),
+  independent of the capture process so new captures keep working.
 - Crash-resistant working snapshots under `/run/user/<UID>/omasnap/` (falling back to
   a private `/tmp/omasnap-<UID>/`), written immediately after selection and overwritten
   after every completed edit. Saving moves that file into `~/Pictures/Screenshots`;
@@ -201,7 +203,51 @@ Install the corresponding Tesseract language data before adding a language to
 | `Ctrl+C` | Copy PNG only |
 | `Ctrl+S` | Save PNG only |
 | `Enter` | Copy and save |
+| `P` | Pin the capture on screen and close the editor |
 | `Esc` | Return to Select; press again to close |
+
+### Pinned captures
+
+`P` renders the current capture, writes it to a `pin-<pid>-<n>.png` under the runtime
+snapshot directory, and hands it to `omasnap-pin` — a separate binary that deliberately
+runs without
+`QT_WAYLAND_SHELL_INTEGRATION`, so the pin is a plain toplevel the compositor can float,
+stack, and move like any other window. Pinning neither touches the clipboard nor writes to
+the screenshot directory; it is a fourth output alongside copy, save, and copy-and-save.
+
+`P` closes the editor, which releases the single-instance lock so the next capture starts
+immediately. Pins from separate captures accumulate; each one is an independent process.
+
+| Input on a pin | Action |
+|---|---|
+| Drag body | Move (compositor-driven `startSystemMove`) |
+| Wheel, bottom-right grip | Resize, aspect preserved |
+| `Ctrl+C` | Copy the pinned PNG to the clipboard |
+| `Esc`, middle-click, hover close button | Close |
+
+`Ctrl+C` copies through `wl-copy` rather than `QClipboard`, so the image stays on the
+clipboard after the pin is closed, and it copies the capture at full resolution regardless
+of how small the pin has been scaled.
+
+Recommended window rules, in the Lua config syntax these were tested with:
+
+```lua
+hl.window_rule({
+  match = { class = "^omasnap-pin$" },
+  float = true,
+  pin = true,
+  no_initial_focus = true,
+  no_dim = true,
+  keep_aspect_ratio = true,
+  opacity = "1 1 override",
+})
+```
+
+The `override` on the opacity rule matters: without it a configured
+`decoration:inactive_opacity` still multiplies through, and an unfocused pin then shows
+colors that no longer match the capture. In a legacy `hyprland.conf` the equivalents are
+`float`, `pin`, `noinitialfocus`, `nodim`, `keepaspectratio` and
+`opacity 1.0 1.0 override` on `class:^omasnap-pin$`.
 
 Creation tools return to Select after one placement without selecting the new layer. In
 Select mode, arrows and lines show only their two endpoint handles; other layers show a

--- a/capture.cpp
+++ b/capture.cpp
@@ -579,6 +579,23 @@ QString temporarySnapshotPath() {
                          .arg(nonce, 8, 16, QChar('0')));
 }
 
+QString pinnedSnapshotPath(int index) {
+  return runtimePath(QStringLiteral("pin-%1-%2.png")
+                         .arg(QCoreApplication::applicationPid())
+                         .arg(index));
+}
+
+void prunePinnedSnapshots() {
+  const QDateTime cutoff = QDateTime::currentDateTime().addDays(-1);
+  const QFileInfoList stale =
+      QDir(runtimePath(QString())).entryInfoList({QStringLiteral("pin-*.png")},
+                                                 QDir::Files);
+  for (const QFileInfo &entry : stale) {
+    if (entry.lastModified() < cutoff)
+      QFile::remove(entry.absoluteFilePath());
+  }
+}
+
 bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
   if (image.isNull()) {
     error = QStringLiteral("Temporary snapshot is empty");

--- a/capture.hpp
+++ b/capture.hpp
@@ -77,6 +77,8 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
 [[nodiscard]] QString moveSnapshotToScreenshots(const QString &sourcePath,
                                                 QString &error);
 [[nodiscard]] QString temporarySnapshotPath();
+[[nodiscard]] QString pinnedSnapshotPath(int index);
+void prunePinnedSnapshots();
 [[nodiscard]] bool saveTemporarySnapshot(const QImage &image, QString path,
                                          QString &error);
 [[nodiscard]] QString recognizeText(const QImage &image, QString &error);

--- a/editor.cpp
+++ b/editor.cpp
@@ -8,6 +8,7 @@
 #include <QClipboard>
 #include <QCursor>
 #include <QDebug>
+#include <QDir>
 #include <QEvent>
 #include <QFile>
 #include <QFileInfo>
@@ -18,6 +19,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
+#include <QProcess>
 #include <QScreen>
 #include <QStandardPaths>
 #include <QTimer>
@@ -34,6 +36,16 @@ constexpr std::array<const char *, 6> kColorNames{
 constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
 constexpr qreal kToolbarWidth = 680;
+
+// Prefer the sibling binary so an uninstalled build tree pins with its own pin
+// viewer instead of an older installed one.
+QString pinProgram() {
+  const QString sibling = QDir(QCoreApplication::applicationDirPath())
+                              .filePath(QStringLiteral("omasnap-pin"));
+  if (QFileInfo::exists(sibling))
+    return sibling;
+  return QStringLiteral("omasnap-pin");
+}
 
 bool hasEndpointHandles(Annotation::Kind kind) {
   return kind == Annotation::Kind::Arrow || kind == Annotation::Kind::Line ||
@@ -243,6 +255,10 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     tray.lineTo(19, 20);
     tray.lineTo(19, 18);
     painter.drawPath(tray);
+  } else if (action == QStringLiteral("pin")) {
+    painter.drawRoundedRect(QRectF(8, 4, 8, 6), 2, 2);
+    painter.drawLine(QPointF(5, 10), QPointF(19, 10));
+    painter.drawLine(QPointF(12, 10), QPointF(12, 20));
   } else if (action == QStringLiteral("close")) {
     painter.drawLine(QPointF(6, 6), QPointF(18, 18));
     painter.drawLine(QPointF(18, 6), QPointF(6, 18));
@@ -769,6 +785,8 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(36, QStringLiteral("undo"), {}, QStringLiteral("Undo · Ctrl+Z"));
   add(36, QStringLiteral("redo"), {},
       QStringLiteral("Redo · Ctrl+Shift+Z / Ctrl+Y"));
+  add(36, QStringLiteral("pin"), {},
+      QStringLiteral("Pin on screen · P · Ctrl+C on the pin copies it"));
   add(36, QStringLiteral("copy"), {}, QStringLiteral("Copy only · Ctrl+C"));
   add(40, QStringLiteral("both"), {}, QStringLiteral("Copy and save · Enter"));
   add(36, QStringLiteral("save"), {}, QStringLiteral("Save only · Ctrl+S"));
@@ -875,6 +893,39 @@ void CaptureEditor::persistSnapshot() {
   QString error;
   if (!saveTemporarySnapshot(image, snapshotPath_, error))
     qWarning().noquote() << error;
+}
+
+void CaptureEditor::pinSnapshot() {
+  if (busy_ || selection_.isEmpty())
+    return;
+
+  prunePinnedSnapshots();
+  const QString path = pinnedSnapshotPath(++pinCount_);
+  const QImage image =
+      renderCapture(capture_, selection_, annotations_, backgroundStyle_);
+  QString error;
+  if (!saveTemporarySnapshot(image, path, error)) {
+    setStatus(error);
+    return;
+  }
+
+  // The capture process exports QT_WAYLAND_SHELL_INTEGRATION for its own
+  // layer-shell overlay; the pin needs a plain toplevel the compositor can
+  // float, move and stack like any other window.
+  QProcess pin;
+  QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+  environment.remove(QStringLiteral("QT_WAYLAND_SHELL_INTEGRATION"));
+  pin.setProcessEnvironment(environment);
+  pin.setProgram(pinProgram());
+  pin.setArguments({path});
+  if (!pin.startDetached()) {
+    QFile::remove(path);
+    --pinCount_;
+    setStatus(QStringLiteral("Could not start omasnap-pin"));
+    return;
+  }
+
+  close();
 }
 
 void CaptureEditor::enterEdit(QString status) {
@@ -1149,7 +1200,9 @@ void CaptureEditor::handleToolbar(const QString &action) {
     undoEdit();
   } else if (action == QStringLiteral("redo")) {
     redoEdit();
-  } else if (action == QStringLiteral("copy"))
+  } else if (action == QStringLiteral("pin"))
+    pinSnapshot();
+  else if (action == QStringLiteral("copy"))
     finish(OutputMode::Copy);
   else if (action == QStringLiteral("both"))
     finish(OutputMode::Both);
@@ -1251,6 +1304,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Text;
   } else if (event->key() == Qt::Key_O) {
     tool_ = Tool::Ocr;
+  } else if (event->key() == Qt::Key_P) {
+    pinSnapshot();
+    return;
   } else if (event->key() == Qt::Key_B) {
     recordEdit();
     backgroundStyle_ = static_cast<BackgroundStyle>(

--- a/editor.cpp
+++ b/editor.cpp
@@ -1,6 +1,7 @@
 /** @fileoverview Handles screenshot selection, annotation, and editor drawing.
  */
 #include "editor.hpp"
+#include "icons.hpp"
 
 #include <QtConcurrent/QtConcurrentRun>
 
@@ -104,166 +105,6 @@ void drawStatusPill(QPainter &painter, const QRect &bounds,
   painter.drawRoundedRect(pill, 10, 10);
   painter.setPen(Qt::white);
   painter.drawText(pill, Qt::AlignCenter, text);
-}
-
-void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
-                     const QString &action, const QString &label,
-                     const QColor &color) {
-  if (action == QStringLiteral("size")) {
-    painter.setPen(color);
-    painter.drawText(bounds, Qt::AlignCenter, label);
-    return;
-  }
-
-  painter.save();
-  constexpr qreal iconSize = 19.0;
-  painter.translate(bounds.center().x() - iconSize / 2.0,
-                    bounds.center().y() - iconSize / 2.0);
-  painter.scale(iconSize / 24.0, iconSize / 24.0);
-  painter.setPen(QPen(color, 2.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-  painter.setBrush(Qt::NoBrush);
-
-  if (action == QStringLiteral("tool-select")) {
-    QPainterPath pointer;
-    pointer.moveTo(5, 4);
-    pointer.lineTo(17, 15);
-    pointer.lineTo(12, 16);
-    pointer.lineTo(9, 21);
-    pointer.closeSubpath();
-    painter.drawPath(pointer);
-  } else if (action == QStringLiteral("tool-arrow")) {
-    painter.drawLine(QPointF(7, 17), QPointF(17, 7));
-    painter.drawLine(QPointF(7, 7), QPointF(17, 7));
-    painter.drawLine(QPointF(17, 7), QPointF(17, 17));
-  } else if (action == QStringLiteral("tool-line")) {
-    painter.drawLine(QPointF(5, 19), QPointF(19, 5));
-  } else if (action == QStringLiteral("tool-freehand")) {
-    QPainterPath stroke;
-    stroke.moveTo(4, 16);
-    stroke.cubicTo(7, 5, 10, 20, 14, 11);
-    stroke.cubicTo(17, 5, 18, 11, 21, 7);
-    painter.drawPath(stroke);
-  } else if (action == QStringLiteral("tool-highlighter")) {
-    painter.setPen(
-        QPen(color, 5.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-    painter.drawLine(QPointF(5, 16), QPointF(19, 8));
-  } else if (action == QStringLiteral("tool-marker")) {
-    painter.drawEllipse(QPointF(12, 12), 8, 8);
-    QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
-    font.setPixelSize(11);
-    font.setBold(true);
-    painter.setFont(font);
-    painter.drawText(QRectF(4, 4, 16, 16), Qt::AlignCenter,
-                     QStringLiteral("1"));
-  } else if (action == QStringLiteral("tool-rectangle")) {
-    painter.drawRoundedRect(QRectF(4, 4, 16, 16), 2, 2);
-  } else if (action == QStringLiteral("tool-text")) {
-    painter.drawLine(QPointF(5, 5), QPointF(19, 5));
-    painter.drawLine(QPointF(12, 5), QPointF(12, 19));
-    painter.drawLine(QPointF(9, 19), QPointF(15, 19));
-  } else if (action == QStringLiteral("tool-ocr")) {
-    QPainterPath path;
-    path.moveTo(9, 4);
-    path.lineTo(5, 4);
-    path.lineTo(5, 8);
-    path.moveTo(15, 4);
-    path.lineTo(19, 4);
-    path.lineTo(19, 8);
-    path.moveTo(9, 20);
-    path.lineTo(5, 20);
-    path.lineTo(5, 16);
-    path.moveTo(15, 20);
-    path.lineTo(19, 20);
-    path.lineTo(19, 16);
-    path.moveTo(8, 9);
-    path.lineTo(16, 9);
-    path.moveTo(8, 13);
-    path.lineTo(16, 13);
-    path.moveTo(8, 17);
-    path.lineTo(13, 17);
-    painter.drawPath(path);
-  } else if (action == QStringLiteral("custom-color")) {
-    QConicalGradient gradient(QPointF(12, 12), 90);
-    gradient.setColorAt(0.0, QColor(QStringLiteral("#ff375f")));
-    gradient.setColorAt(0.17, QColor(QStringLiteral("#ff9f0a")));
-    gradient.setColorAt(0.34, QColor(QStringLiteral("#ffd60a")));
-    gradient.setColorAt(0.51, QColor(QStringLiteral("#30d158")));
-    gradient.setColorAt(0.68, QColor(QStringLiteral("#0a84ff")));
-    gradient.setColorAt(0.85, QColor(QStringLiteral("#bf5af2")));
-    gradient.setColorAt(1.0, QColor(QStringLiteral("#ff375f")));
-    painter.setPen(QPen(color, 1.5));
-    painter.setBrush(gradient);
-    painter.drawEllipse(QPointF(12, 12), 8, 8);
-    painter.setPen(QPen(Qt::white, 1.5, Qt::SolidLine, Qt::RoundCap));
-    painter.drawLine(QPointF(12, 8), QPointF(12, 16));
-    painter.drawLine(QPointF(8, 12), QPointF(16, 12));
-  } else if (action == QStringLiteral("background")) {
-    painter.drawRoundedRect(QRectF(3, 4, 18, 16), 2, 2);
-    painter.drawEllipse(QPointF(8, 9), 1.5, 1.5);
-    QPainterPath path;
-    path.moveTo(3, 17);
-    path.lineTo(8, 12);
-    path.lineTo(11, 15);
-    path.lineTo(14, 12);
-    path.lineTo(21, 19);
-    painter.drawPath(path);
-  } else if (action == QStringLiteral("undo") ||
-             action == QStringLiteral("redo")) {
-    const bool forward = action == QStringLiteral("redo");
-    // Shaft runs along y = 9 into a half-circle that hooks back underneath.
-    const qreal tip = forward ? 20 : 4;
-    const qreal elbow = forward ? 9.5 : 14.5;
-    QPainterPath head;
-    head.moveTo(tip + (forward ? -5 : 5), 4);
-    head.lineTo(tip, 9);
-    head.lineTo(tip + (forward ? -5 : 5), 14);
-    painter.drawPath(head);
-    QPainterPath shaft;
-    shaft.moveTo(tip, 9);
-    shaft.lineTo(elbow, 9);
-    shaft.arcTo(QRectF(elbow - 5.5, 9, 11, 11), 90, forward ? 180 : -180);
-    shaft.lineTo(elbow + (forward ? 3.5 : -3.5), 20);
-    painter.drawPath(shaft);
-  } else if (action == QStringLiteral("copy") ||
-             action == QStringLiteral("both")) {
-    painter.drawRoundedRect(QRectF(8, 8, 12, 12), 2, 2);
-    QPainterPath path;
-    path.moveTo(16, 8);
-    path.lineTo(16, 6);
-    path.quadTo(16, 4, 14, 4);
-    path.lineTo(6, 4);
-    path.quadTo(4, 4, 4, 6);
-    path.lineTo(4, 14);
-    path.quadTo(4, 16, 6, 16);
-    path.lineTo(8, 16);
-    painter.drawPath(path);
-    if (action == QStringLiteral("both")) {
-      painter.setBrush(QColor(QStringLiteral("#0a84ff")));
-      painter.setPen(
-          QPen(Qt::white, 1.8, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-      painter.drawEllipse(QPointF(18, 18), 4.5, 4.5);
-      painter.drawLine(QPointF(16, 18), QPointF(17.5, 19.5));
-      painter.drawLine(QPointF(17.5, 19.5), QPointF(20.5, 16.5));
-    }
-  } else if (action == QStringLiteral("save")) {
-    painter.drawLine(QPointF(12, 4), QPointF(12, 15));
-    painter.drawLine(QPointF(8, 11), QPointF(12, 15));
-    painter.drawLine(QPointF(12, 15), QPointF(16, 11));
-    QPainterPath tray;
-    tray.moveTo(5, 18);
-    tray.lineTo(5, 20);
-    tray.lineTo(19, 20);
-    tray.lineTo(19, 18);
-    painter.drawPath(tray);
-  } else if (action == QStringLiteral("pin")) {
-    painter.drawRoundedRect(QRectF(8, 4, 8, 6), 2, 2);
-    painter.drawLine(QPointF(5, 10), QPointF(19, 10));
-    painter.drawLine(QPointF(12, 10), QPointF(12, 20));
-  } else if (action == QStringLiteral("close")) {
-    painter.drawLine(QPointF(6, 6), QPointF(18, 18));
-    painter.drawLine(QPointF(18, 6), QPointF(6, 18));
-  }
-  painter.restore();
 }
 
 void drawInstantTooltip(QPainter &painter, const QRect &bounds,
@@ -419,7 +260,6 @@ CaptureEditor::~CaptureEditor() {
     }
   }
 }
-
 
 bool CaptureEditor::eventFilter(QObject *watched, QEvent *event) {
   if (watched == textEditor_ && event->type() == QEvent::KeyPress) {
@@ -1674,11 +1514,10 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       annotations_.push_back(std::move(annotation));
       selectedAnnotation_ = -1;
       tool_ = Tool::Select;
-      setStatus(highlighter
-                    ? QStringLiteral(
-                          "Highlight added · Select tool chooses layers")
-                    : QStringLiteral(
-                          "Stroke added · Select tool chooses layers"));
+      setStatus(
+          highlighter
+              ? QStringLiteral("Highlight added · Select tool chooses layers")
+              : QStringLiteral("Stroke added · Select tool chooses layers"));
       persistSnapshot();
     }
     freehandPoints_.clear();

--- a/editor.hpp
+++ b/editor.hpp
@@ -111,6 +111,7 @@ private:
   [[nodiscard]] EditState editState() const;
   void enterEdit(QString status);
   void persistSnapshot();
+  void pinSnapshot();
   void pushUndoState(const EditState &state);
   void recordEdit();
   void redoEdit();
@@ -160,6 +161,7 @@ private:
   bool dragStartStateValid_ = false;
   bool dragChanged_ = false;
   QString snapshotPath_;
+  int pinCount_ = 0;
   QString status_ =
       QStringLiteral("Drag to select an area · Space selects a window");
   QLineEdit *textEditor_ = nullptr;

--- a/icons.cpp
+++ b/icons.cpp
@@ -1,0 +1,195 @@
+#include "icons.hpp"
+
+#include <QConicalGradient>
+#include <QFontDatabase>
+#include <QPainter>
+#include <QPainterPath>
+
+void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
+                     const QString &action, const QString &label,
+                     const QColor &color) {
+  if (action == QStringLiteral("size")) {
+    painter.setPen(color);
+    painter.drawText(bounds, Qt::AlignCenter, label);
+    return;
+  }
+
+  painter.save();
+  constexpr qreal iconSize = 19.0;
+  painter.translate(bounds.center().x() - iconSize / 2.0,
+                    bounds.center().y() - iconSize / 2.0);
+  painter.scale(iconSize / 24.0, iconSize / 24.0);
+  painter.setPen(QPen(color, 2.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+  painter.setBrush(Qt::NoBrush);
+
+  if (action == QStringLiteral("tool-select")) {
+    QPainterPath pointer;
+    pointer.moveTo(5, 4);
+    pointer.lineTo(17, 15);
+    pointer.lineTo(12, 16);
+    pointer.lineTo(9, 21);
+    pointer.closeSubpath();
+    painter.drawPath(pointer);
+  } else if (action == QStringLiteral("tool-arrow")) {
+    painter.drawLine(QPointF(7, 17), QPointF(17, 7));
+    painter.drawLine(QPointF(7, 7), QPointF(17, 7));
+    painter.drawLine(QPointF(17, 7), QPointF(17, 17));
+  } else if (action == QStringLiteral("tool-line")) {
+    painter.drawLine(QPointF(5, 19), QPointF(19, 5));
+  } else if (action == QStringLiteral("tool-freehand")) {
+    QPainterPath stroke;
+    stroke.moveTo(4, 16);
+    stroke.cubicTo(7, 5, 10, 20, 14, 11);
+    stroke.cubicTo(17, 5, 18, 11, 21, 7);
+    painter.drawPath(stroke);
+  } else if (action == QStringLiteral("tool-highlighter")) {
+    painter.setPen(
+        QPen(color, 5.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter.drawLine(QPointF(5, 16), QPointF(19, 8));
+  } else if (action == QStringLiteral("tool-marker")) {
+    painter.drawEllipse(QPointF(12, 12), 8, 8);
+    QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
+    font.setPixelSize(11);
+    font.setBold(true);
+    painter.setFont(font);
+    painter.drawText(QRectF(4, 4, 16, 16), Qt::AlignCenter,
+                     QStringLiteral("1"));
+  } else if (action == QStringLiteral("tool-rectangle")) {
+    painter.drawRoundedRect(QRectF(4, 4, 16, 16), 2, 2);
+  } else if (action == QStringLiteral("tool-text")) {
+    painter.drawLine(QPointF(5, 5), QPointF(19, 5));
+    painter.drawLine(QPointF(12, 5), QPointF(12, 19));
+    painter.drawLine(QPointF(9, 19), QPointF(15, 19));
+  } else if (action == QStringLiteral("tool-ocr")) {
+    QPainterPath path;
+    path.moveTo(9, 4);
+    path.lineTo(5, 4);
+    path.lineTo(5, 8);
+    path.moveTo(15, 4);
+    path.lineTo(19, 4);
+    path.lineTo(19, 8);
+    path.moveTo(9, 20);
+    path.lineTo(5, 20);
+    path.lineTo(5, 16);
+    path.moveTo(15, 20);
+    path.lineTo(19, 20);
+    path.lineTo(19, 16);
+    path.moveTo(8, 9);
+    path.lineTo(16, 9);
+    path.moveTo(8, 13);
+    path.lineTo(16, 13);
+    path.moveTo(8, 17);
+    path.lineTo(13, 17);
+    painter.drawPath(path);
+  } else if (action == QStringLiteral("custom-color")) {
+    QConicalGradient gradient(QPointF(12, 12), 90);
+    gradient.setColorAt(0.0, QColor(QStringLiteral("#ff375f")));
+    gradient.setColorAt(0.17, QColor(QStringLiteral("#ff9f0a")));
+    gradient.setColorAt(0.34, QColor(QStringLiteral("#ffd60a")));
+    gradient.setColorAt(0.51, QColor(QStringLiteral("#30d158")));
+    gradient.setColorAt(0.68, QColor(QStringLiteral("#0a84ff")));
+    gradient.setColorAt(0.85, QColor(QStringLiteral("#bf5af2")));
+    gradient.setColorAt(1.0, QColor(QStringLiteral("#ff375f")));
+    painter.setPen(QPen(color, 1.5));
+    painter.setBrush(gradient);
+    painter.drawEllipse(QPointF(12, 12), 8, 8);
+    painter.setPen(QPen(Qt::white, 1.5, Qt::SolidLine, Qt::RoundCap));
+    painter.drawLine(QPointF(12, 8), QPointF(12, 16));
+    painter.drawLine(QPointF(8, 12), QPointF(16, 12));
+  } else if (action == QStringLiteral("background")) {
+    painter.drawRoundedRect(QRectF(3, 4, 18, 16), 2, 2);
+    painter.drawEllipse(QPointF(8, 9), 1.5, 1.5);
+    QPainterPath path;
+    path.moveTo(3, 17);
+    path.lineTo(8, 12);
+    path.lineTo(11, 15);
+    path.lineTo(14, 12);
+    path.lineTo(21, 19);
+    painter.drawPath(path);
+  } else if (action == QStringLiteral("undo") ||
+             action == QStringLiteral("redo")) {
+    const bool forward = action == QStringLiteral("redo");
+    const qreal tip = forward ? 20 : 4;
+    const qreal elbow = forward ? 9.5 : 14.5;
+    QPainterPath head;
+    head.moveTo(tip + (forward ? -5 : 5), 4);
+    head.lineTo(tip, 9);
+    head.lineTo(tip + (forward ? -5 : 5), 14);
+    painter.drawPath(head);
+    QPainterPath shaft;
+    shaft.moveTo(tip, 9);
+    shaft.lineTo(elbow, 9);
+    shaft.arcTo(QRectF(elbow - 5.5, 9, 11, 11), 90, forward ? 180 : -180);
+    shaft.lineTo(elbow + (forward ? 3.5 : -3.5), 20);
+    painter.drawPath(shaft);
+  } else if (action == QStringLiteral("copy") ||
+             action == QStringLiteral("both")) {
+    painter.drawRoundedRect(QRectF(8, 8, 12, 12), 2, 2);
+    QPainterPath path;
+    path.moveTo(16, 8);
+    path.lineTo(16, 6);
+    path.quadTo(16, 4, 14, 4);
+    path.lineTo(6, 4);
+    path.quadTo(4, 4, 4, 6);
+    path.lineTo(4, 14);
+    path.quadTo(4, 16, 6, 16);
+    path.lineTo(8, 16);
+    painter.drawPath(path);
+    if (action == QStringLiteral("both")) {
+      painter.setBrush(QColor(QStringLiteral("#0a84ff")));
+      painter.setPen(
+          QPen(Qt::white, 1.8, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+      painter.drawEllipse(QPointF(18, 18), 4.5, 4.5);
+      painter.drawLine(QPointF(16, 18), QPointF(17.5, 19.5));
+      painter.drawLine(QPointF(17.5, 19.5), QPointF(20.5, 16.5));
+    }
+  } else if (action == QStringLiteral("edit")) {
+    QPainterPath pencil;
+    pencil.moveTo(4, 20);
+    pencil.lineTo(8.5, 18.8);
+    pencil.lineTo(19, 8.3);
+    pencil.quadTo(20.5, 6.8, 19, 5.3);
+    pencil.quadTo(17.5, 3.8, 16, 5.3);
+    pencil.lineTo(5.5, 15.8);
+    pencil.closeSubpath();
+    painter.drawPath(pencil);
+    painter.drawLine(QPointF(14.5, 6.8), QPointF(17.5, 9.8));
+  } else if (action == QStringLiteral("path")) {
+    QPainterPath link;
+    link.moveTo(9, 7);
+    link.lineTo(7, 7);
+    link.cubicTo(3, 7, 3, 17, 7, 17);
+    link.lineTo(9, 17);
+    link.moveTo(15, 7);
+    link.lineTo(17, 7);
+    link.cubicTo(21, 7, 21, 17, 17, 17);
+    link.lineTo(15, 17);
+    painter.drawPath(link);
+    painter.drawLine(QPointF(8, 12), QPointF(16, 12));
+  } else if (action == QStringLiteral("drag-handle")) {
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(color);
+    for (const qreal x : {9.0, 15.0}) {
+      for (const qreal y : {6.0, 12.0, 18.0})
+        painter.drawEllipse(QPointF(x, y), 1.7, 1.7);
+    }
+  } else if (action == QStringLiteral("save")) {
+    painter.drawLine(QPointF(12, 4), QPointF(12, 15));
+    painter.drawLine(QPointF(8, 11), QPointF(12, 15));
+    painter.drawLine(QPointF(12, 15), QPointF(16, 11));
+    QPainterPath tray;
+    tray.moveTo(5, 18);
+    tray.lineTo(5, 20);
+    tray.lineTo(19, 20);
+    tray.lineTo(19, 18);
+    painter.drawPath(tray);
+  } else if (action == QStringLiteral("pin")) {
+    painter.drawRoundedRect(QRectF(8, 4, 8, 6), 2, 2);
+    painter.drawLine(QPointF(5, 10), QPointF(19, 10));
+    painter.drawLine(QPointF(12, 10), QPointF(12, 20));
+  } else if (action == QStringLiteral("close")) {
+    painter.drawLine(QPointF(6, 6), QPointF(18, 18));
+    painter.drawLine(QPointF(18, 6), QPointF(6, 18));
+  }
+  painter.restore();
+}

--- a/icons.hpp
+++ b/icons.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+class QColor;
+class QRectF;
+class QString;
+class QPainter;
+
+void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
+                     const QString &action, const QString &label,
+                     const QColor &color);

--- a/pin.cpp
+++ b/pin.cpp
@@ -1,0 +1,247 @@
+#include <QApplication>
+#include <QBuffer>
+#include <QEnterEvent>
+#include <QFontMetrics>
+#include <QGuiApplication>
+#include <QImage>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QProcess>
+#include <QScreen>
+#include <QTimer>
+#include <QWheelEvent>
+#include <QWidget>
+#include <QWindow>
+
+#include <algorithm>
+#include <utility>
+
+namespace {
+
+constexpr int kMinimumEdge = 80;
+constexpr qreal kCloseButtonSize = 22;
+constexpr qreal kCloseButtonInset = 8;
+constexpr qreal kResizeGripSize = 18;
+constexpr qreal kInitialScreenShare = 0.4;
+constexpr qreal kWheelStep = 0.1;
+constexpr int kToastMs = 1200;
+
+// wl-copy backgrounds itself and keeps serving the selection after this process
+// exits, which QClipboard cannot do on Wayland.
+bool copyPngToClipboard(const QImage &image, QString &error) {
+  QByteArray png;
+  QBuffer buffer(&png);
+  buffer.open(QIODevice::WriteOnly);
+  if (!image.save(&buffer, "PNG")) {
+    error = QStringLiteral("Could not encode PNG");
+    return false;
+  }
+
+  QProcess copy;
+  copy.start(QStringLiteral("wl-copy"),
+             {QStringLiteral("--type"), QStringLiteral("image/png")});
+  if (!copy.waitForStarted(2000)) {
+    error = copy.errorString();
+    return false;
+  }
+  copy.write(png);
+  copy.closeWriteChannel();
+  if (!copy.waitForFinished(5000) || copy.exitCode() != 0) {
+    error = QString::fromUtf8(copy.readAllStandardError()).trimmed();
+    if (error.isEmpty())
+      error = QStringLiteral("wl-copy failed");
+    return false;
+  }
+  return true;
+}
+
+class PinWindow final : public QWidget {
+public:
+  explicit PinWindow(QImage image) : image_(std::move(image)) {
+    setWindowTitle(QStringLiteral("omasnap-pin"));
+    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+    setMouseTracking(true);
+    resize(initialSize());
+  }
+
+protected:
+  void paintEvent(QPaintEvent *) override {
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+    painter.drawImage(rect(), image_);
+    if (!toast_.isEmpty())
+      paintToast(painter);
+    if (!hovered_)
+      return;
+
+    const QRectF close = closeButtonRect();
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor(12, 12, 16, 190));
+    painter.drawRoundedRect(close, 6, 6);
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(QPen(QColor(255, 255, 255, 225), 1.6));
+    const QPointF center = close.center();
+    const qreal arm = 4.5;
+    painter.drawLine(center + QPointF(-arm, -arm), center + QPointF(arm, arm));
+    painter.drawLine(center + QPointF(arm, -arm), center + QPointF(-arm, arm));
+  }
+
+  void paintToast(QPainter &painter) const {
+    const QFontMetrics metrics(painter.font());
+    const QRectF pill((width() - metrics.horizontalAdvance(toast_) - 28) / 2.0,
+                      height() - 42, metrics.horizontalAdvance(toast_) + 28,
+                      26);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor(12, 12, 16, 205));
+    painter.drawRoundedRect(pill, 13, 13);
+    painter.setPen(QColor(240, 240, 245));
+    painter.drawText(pill, Qt::AlignCenter, toast_);
+  }
+
+  void mousePressEvent(QMouseEvent *event) override {
+    if (event->button() == Qt::MiddleButton ||
+        closeButtonRect().contains(event->position())) {
+      close();
+      return;
+    }
+    if (event->button() != Qt::LeftButton)
+      return;
+
+    QWindow *handle = windowHandle();
+    if (!handle)
+      return;
+    if (resizeGripRect().contains(event->position()))
+      handle->startSystemResize(Qt::BottomEdge | Qt::RightEdge);
+    else
+      handle->startSystemMove();
+  }
+
+  void mouseMoveEvent(QMouseEvent *event) override {
+    setCursor(resizeGripRect().contains(event->position()) ? Qt::SizeFDiagCursor
+                                                           : Qt::ArrowCursor);
+  }
+
+  void wheelEvent(QWheelEvent *event) override {
+    const int steps = event->angleDelta().y();
+    if (steps == 0)
+      return;
+    const qreal factor = steps > 0 ? 1 + kWheelStep : 1 - kWheelStep;
+    resize(scaledSize(qRound(width() * factor)));
+    event->accept();
+  }
+
+  void keyPressEvent(QKeyEvent *event) override {
+    if (event->key() == Qt::Key_Escape) {
+      close();
+      return;
+    }
+    if (event->matches(QKeySequence::Copy)) {
+      QString error;
+      showToast(copyPngToClipboard(image_, error)
+                    ? QStringLiteral("Copied to clipboard")
+                    : error);
+      return;
+    }
+    QWidget::keyPressEvent(event);
+  }
+
+  void enterEvent(QEnterEvent *) override {
+    hovered_ = true;
+    update();
+  }
+
+  void leaveEvent(QEvent *) override {
+    hovered_ = false;
+    setCursor(Qt::ArrowCursor);
+    update();
+  }
+
+private:
+  [[nodiscard]] QSize availableSize() const {
+    const QScreen *target =
+        screen() ? screen() : QGuiApplication::primaryScreen();
+    return target ? target->availableGeometry().size() : QSize(1920, 1080);
+  }
+
+  // The rendered capture is in device pixels, so a scaled output would
+  // otherwise open at twice its apparent size.
+  [[nodiscard]] QSize initialSize() const {
+    const QScreen *target =
+        screen() ? screen() : QGuiApplication::primaryScreen();
+    const qreal ratio =
+        target ? std::max<qreal>(1.0, target->devicePixelRatio()) : 1.0;
+    const QSizeF logical = QSizeF(image_.size()) / ratio;
+    const QSizeF limit = QSizeF(availableSize()) * kInitialScreenShare;
+    const qreal fit = std::min({1.0, limit.width() / logical.width(),
+                                limit.height() / logical.height()});
+    return scaledSize(qRound(logical.width() * fit));
+  }
+
+  [[nodiscard]] QSize scaledSize(int targetWidth) const {
+    const QSize available = availableSize();
+    const int maximumWidth = std::max(
+        kMinimumEdge,
+        qRound(image_.height() >= image_.width()
+                   ? available.height() * static_cast<qreal>(image_.width()) /
+                         image_.height()
+                   : available.width()));
+    const int clamped = std::clamp(targetWidth, kMinimumEdge, maximumWidth);
+    const int height = std::max(
+        kMinimumEdge,
+        qRound(clamped * static_cast<qreal>(image_.height()) / image_.width()));
+    return QSize(clamped, height);
+  }
+
+  void showToast(QString message) {
+    toast_ = std::move(message);
+    update();
+    QTimer::singleShot(kToastMs, this, [this] {
+      toast_.clear();
+      update();
+    });
+  }
+
+  [[nodiscard]] QRectF closeButtonRect() const {
+    return QRectF(width() - kCloseButtonSize - kCloseButtonInset,
+                  kCloseButtonInset, kCloseButtonSize, kCloseButtonSize);
+  }
+
+  [[nodiscard]] QRectF resizeGripRect() const {
+    return QRectF(width() - kResizeGripSize, height() - kResizeGripSize,
+                  kResizeGripSize, kResizeGripSize);
+  }
+
+  QImage image_;
+  QString toast_;
+  bool hovered_ = false;
+};
+
+} // namespace
+
+int main(int argc, char **argv) {
+  // The capture process exports this for its own layer-shell overlay;
+  // inheriting it here would turn the pin into a layer surface with no window
+  // rules.
+  qunsetenv("QT_WAYLAND_SHELL_INTEGRATION");
+  QCoreApplication::setApplicationName(QStringLiteral("omasnap-pin"));
+  QGuiApplication::setDesktopFileName(QStringLiteral("omasnap-pin"));
+  QApplication application(argc, argv);
+
+  const QStringList arguments = QCoreApplication::arguments();
+  if (arguments.size() < 2) {
+    qWarning("usage: omasnap-pin <image>");
+    return 2;
+  }
+  QImage image(arguments.at(1));
+  if (image.isNull()) {
+    qWarning("omasnap-pin: could not load %s", qUtf8Printable(arguments.at(1)));
+    return 1;
+  }
+
+  PinWindow window(std::move(image));
+  window.show();
+  return application.exec();
+}

--- a/pin.cpp
+++ b/pin.cpp
@@ -1,15 +1,27 @@
+#include "icons.hpp"
+
+#include <LayerShellQt/Window>
 #include <QApplication>
 #include <QBuffer>
+#include <QDir>
+#include <QDrag>
 #include <QEnterEvent>
+#include <QFile>
+#include <QFileInfo>
 #include <QFontMetrics>
 #include <QGuiApplication>
 #include <QImage>
 #include <QKeyEvent>
+#include <QMimeData>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPixmap>
 #include <QProcess>
 #include <QScreen>
 #include <QTimer>
+
+#include <QMargins>
+#include <QUrl>
 #include <QWheelEvent>
 #include <QWidget>
 #include <QWindow>
@@ -19,11 +31,26 @@
 
 namespace {
 
+// Prefer the sibling binary so an uninstalled build tree edits with the same
+// build's editor instead of an older installed one.
+QString omasnapBinary() {
+  const QString sibling = QDir(QCoreApplication::applicationDirPath())
+                              .filePath(QStringLiteral("omasnap"));
+  return QFileInfo::exists(sibling) ? sibling : QStringLiteral("omasnap");
+}
+
 constexpr int kMinimumEdge = 80;
 constexpr qreal kCloseButtonSize = 22;
 constexpr qreal kCloseButtonInset = 8;
-constexpr qreal kResizeGripSize = 18;
-constexpr qreal kInitialScreenShare = 0.4;
+constexpr qreal kControlGap = 6;
+constexpr qreal kDragButtonWidth = kCloseButtonSize * 2 + kControlGap;
+constexpr qreal kCornerMargin = 14;
+constexpr qreal kInitialScreenShare = 0.3;
+
+// Hard caps for the corner pin: never wider than a third of the screen nor
+// taller than half.
+constexpr qreal kMaxWidthShare = 1.0 / 3.0;
+constexpr qreal kMaxHeightShare = 0.5;
 constexpr qreal kWheelStep = 0.1;
 constexpr int kToastMs = 1200;
 
@@ -56,9 +83,30 @@ bool copyPngToClipboard(const QImage &image, QString &error) {
   return true;
 }
 
+bool copyTextToClipboard(const QString &text, QString &error) {
+  QProcess copy;
+  copy.start(
+      QStringLiteral("wl-copy"),
+      {QStringLiteral("--type"), QStringLiteral("text/plain;charset=utf-8")});
+  if (!copy.waitForStarted(2000)) {
+    error = copy.errorString();
+    return false;
+  }
+  copy.write(text.toUtf8());
+  copy.closeWriteChannel();
+  if (!copy.waitForFinished(5000) || copy.exitCode() != 0) {
+    error = QString::fromUtf8(copy.readAllStandardError()).trimmed();
+    if (error.isEmpty())
+      error = QStringLiteral("wl-copy failed");
+    return false;
+  }
+  return true;
+}
+
 class PinWindow final : public QWidget {
 public:
-  explicit PinWindow(QImage image) : image_(std::move(image)) {
+  explicit PinWindow(QImage image, QString path)
+      : image_(std::move(image)), path_(std::move(path)) {
     setWindowTitle(QStringLiteral("omasnap-pin"));
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
     setMouseTracking(true);
@@ -75,17 +123,36 @@ protected:
     if (!hovered_)
       return;
 
-    const QRectF close = closeButtonRect();
     painter.setRenderHint(QPainter::Antialiasing, true);
+    drawControlButton(painter, dragButtonRect(), QStringLiteral("drag-handle"));
+    drawControlButton(painter, editButtonRect(), QStringLiteral("edit"));
+    drawControlButton(painter, pathButtonRect(), QStringLiteral("path"));
+    drawControlButton(painter, copyButtonRect(), QStringLiteral("copy"));
+    drawControlButton(painter, closeButtonRect(), QStringLiteral("close"));
+    if (!hoverTip_.isEmpty())
+      paintHoverTip(painter);
+  }
+
+  // Layer surfaces cannot reliably map an independent QToolTip toplevel, so
+  // the hint is drawn inside the window like the toast pill.
+  void paintHoverTip(QPainter &painter) const {
+    const QFontMetrics metrics(painter.font());
+    const qreal width = metrics.horizontalAdvance(hoverTip_) + 22;
+    const QRectF pill(std::max(0.0, this->width() - width - kCloseButtonInset),
+                      kCloseButtonInset + kCloseButtonSize + 5, width, 22);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor(12, 12, 16, 210));
+    painter.drawRoundedRect(pill, 11, 11);
+    painter.setPen(QColor(240, 240, 245));
+    painter.drawText(pill, Qt::AlignCenter, hoverTip_);
+  }
+
+  void drawControlButton(QPainter &painter, const QRectF &rect,
+                         const QString &action) const {
     painter.setPen(Qt::NoPen);
     painter.setBrush(QColor(12, 12, 16, 190));
-    painter.drawRoundedRect(close, 6, 6);
-    painter.setBrush(Qt::NoBrush);
-    painter.setPen(QPen(QColor(255, 255, 255, 225), 1.6));
-    const QPointF center = close.center();
-    const qreal arm = 4.5;
-    painter.drawLine(center + QPointF(-arm, -arm), center + QPointF(arm, arm));
-    painter.drawLine(center + QPointF(arm, -arm), center + QPointF(-arm, arm));
+    painter.drawRoundedRect(rect, 6, 6);
+    drawToolbarIcon(painter, rect, action, {}, QColor(245, 245, 247));
   }
 
   void paintToast(QPainter &painter) const {
@@ -102,26 +169,78 @@ protected:
   }
 
   void mousePressEvent(QMouseEvent *event) override {
-    if (event->button() == Qt::MiddleButton ||
-        closeButtonRect().contains(event->position())) {
+    if (event->button() == Qt::MiddleButton) {
       close();
       return;
     }
-    if (event->button() != Qt::LeftButton)
-      return;
+    const QPointF position = event->position();
+    if (event->button() == Qt::LeftButton) {
+      if (closeButtonRect().contains(position)) {
+        close();
+        return;
+      }
+      if (dragButtonRect().contains(position)) {
+        beginFileDrag();
+        return;
+      }
+      if (copyButtonRect().contains(position)) {
+        QString error;
+        showToast(copyPngToClipboard(image_, error)
+                      ? QStringLiteral("Copied to clipboard")
+                      : error);
+        return;
+      }
+      if (pathButtonRect().contains(position)) {
+        QString error;
+        showToast(copyTextToClipboard(path_, error)
+                      ? QStringLiteral("Copied path")
+                      : error);
+        return;
+      }
+      if (editButtonRect().contains(position)) {
+        reopenInEditor();
+        return;
+      }
+    }
+  }
 
-    QWindow *handle = windowHandle();
-    if (!handle)
-      return;
-    if (resizeGripRect().contains(event->position()))
-      handle->startSystemResize(Qt::BottomEdge | Qt::RightEdge);
+  // Send the pinned image back to the omasnap editor, replacing the pin.
+  void reopenInEditor() {
+    if (!QProcess::startDetached(omasnapBinary(), {path_}))
+      showToast(QStringLiteral("Could not start omasnap"));
     else
-      handle->startSystemMove();
+      close();
   }
 
   void mouseMoveEvent(QMouseEvent *event) override {
-    setCursor(resizeGripRect().contains(event->position()) ? Qt::SizeFDiagCursor
-                                                           : Qt::ArrowCursor);
+    const QPointF position = event->position();
+    setCursor(controlRectAt(position) >= 0 ? Qt::PointingHandCursor
+                                           : Qt::ArrowCursor);
+
+    const int control = controlRectAt(position);
+    if (control != hoveredControl_) {
+      hoveredControl_ = control;
+      hoverTip_ = control >= 0 ? controlTip(control) : QString();
+      update();
+    }
+  }
+
+  // A layer surface can still initiate a Wayland uri-list drag just like a
+  // file manager; the six-dot control is the drag handle.
+  void beginFileDrag() {
+    QMimeData *mime = new QMimeData;
+    const QList<QUrl> urls{QUrl::fromLocalFile(path_)};
+    mime->setUrls(urls);
+    mime->setText(urls.constFirst().toLocalFile());
+    QFile file(path_);
+    if (file.open(QIODevice::ReadOnly))
+      mime->setData(QStringLiteral("image/png"), file.readAll());
+
+    QDrag *drag = new QDrag(this);
+    drag->setMimeData(mime);
+    drag->setPixmap(QPixmap::fromImage(image_.scaled(
+        256, 256, Qt::KeepAspectRatio, Qt::SmoothTransformation)));
+    drag->exec(Qt::CopyAction | Qt::MoveAction);
   }
 
   void wheelEvent(QWheelEvent *event) override {
@@ -129,7 +248,12 @@ protected:
     if (steps == 0)
       return;
     const qreal factor = steps > 0 ? 1 + kWheelStep : 1 - kWheelStep;
-    resize(scaledSize(qRound(width() * factor)));
+    const QSize nextSize = scaledSize(qRound(width() * factor));
+    resize(nextSize);
+    if (QWindow *handle = windowHandle()) {
+      if (LayerShellQt::Window *layer = LayerShellQt::Window::get(handle))
+        layer->setDesiredSize(nextSize);
+    }
     event->accept();
   }
 
@@ -150,16 +274,36 @@ protected:
 
   void enterEvent(QEnterEvent *) override {
     hovered_ = true;
+    hoveredControl_ = -1;
     update();
   }
 
   void leaveEvent(QEvent *) override {
     hovered_ = false;
+    hoveredControl_ = -1;
+    hoverTip_.clear();
     setCursor(Qt::ArrowCursor);
     update();
   }
 
 private:
+  [[nodiscard]] QString controlTip(int index) const {
+    switch (index) {
+    case 0:
+      return QStringLiteral("Close · Esc or middle-click");
+    case 1:
+      return QStringLiteral("Copy image to clipboard");
+    case 2:
+      return QStringLiteral("Copy file path");
+    case 3:
+      return QStringLiteral("Edit in omasnap");
+    case 4:
+      return QStringLiteral("Drag this image out");
+    default:
+      return {};
+    }
+  }
+
   [[nodiscard]] QSize availableSize() const {
     const QScreen *target =
         screen() ? screen() : QGuiApplication::primaryScreen();
@@ -180,19 +324,23 @@ private:
     return scaledSize(qRound(logical.width() * fit));
   }
 
+  // Fit a target width into the max width/height caps while keeping the
+  // capture's aspect ratio.
   [[nodiscard]] QSize scaledSize(int targetWidth) const {
+    const qreal aspect = image_.height() / static_cast<qreal>(image_.width());
     const QSize available = availableSize();
-    const int maximumWidth = std::max(
-        kMinimumEdge,
-        qRound(image_.height() >= image_.width()
-                   ? available.height() * static_cast<qreal>(image_.width()) /
-                         image_.height()
-                   : available.width()));
-    const int clamped = std::clamp(targetWidth, kMinimumEdge, maximumWidth);
-    const int height = std::max(
-        kMinimumEdge,
-        qRound(clamped * static_cast<qreal>(image_.height()) / image_.width()));
-    return QSize(clamped, height);
+    const qreal maxW =
+        std::max<qreal>(kMinimumEdge, available.width() * kMaxWidthShare);
+    const qreal maxH =
+        std::max<qreal>(kMinimumEdge, available.height() * kMaxHeightShare);
+    qreal width = std::clamp(static_cast<qreal>(targetWidth),
+                             static_cast<qreal>(kMinimumEdge), maxW);
+    qreal height = width * aspect;
+    if (height > maxH) {
+      height = maxH;
+      width = height / aspect;
+    }
+    return QSize(qRound(width), qRound(height));
   }
 
   void showToast(QString message) {
@@ -204,28 +352,52 @@ private:
     });
   }
 
-  [[nodiscard]] QRectF closeButtonRect() const {
-    return QRectF(width() - kCloseButtonSize - kCloseButtonInset,
-                  kCloseButtonInset, kCloseButtonSize, kCloseButtonSize);
+  // The wide drag handle stands alone in the top-left; edit, path, copy, and
+  // close remain grouped in the top-right.
+  [[nodiscard]] QRectF closeButtonRect() const { return controlRect(0); }
+
+  [[nodiscard]] QRectF copyButtonRect() const { return controlRect(1); }
+
+  [[nodiscard]] QRectF pathButtonRect() const { return controlRect(2); }
+
+  [[nodiscard]] QRectF editButtonRect() const { return controlRect(3); }
+
+  [[nodiscard]] QRectF dragButtonRect() const { return controlRect(4); }
+
+  [[nodiscard]] QRectF controlRect(int index) const {
+    const qreal right = width() - kCloseButtonSize - kCloseButtonInset;
+    if (index < 4) {
+      return QRectF(right - index * (kCloseButtonSize + kControlGap),
+                    kCloseButtonInset, kCloseButtonSize, kCloseButtonSize);
+    }
+    return QRectF(kCloseButtonInset, kCloseButtonInset, kDragButtonWidth,
+                  kCloseButtonSize);
   }
 
-  [[nodiscard]] QRectF resizeGripRect() const {
-    return QRectF(width() - kResizeGripSize, height() - kResizeGripSize,
-                  kResizeGripSize, kResizeGripSize);
+  [[nodiscard]] int controlRectAt(const QPointF &position) const {
+    for (int index = 0; index < 5; ++index) {
+      if (controlRect(index).contains(position))
+        return index;
+    }
+    return -1;
   }
 
   QImage image_;
+  QString path_;
   QString toast_;
+  QString hoverTip_;
   bool hovered_ = false;
+  int hoveredControl_ = -1;
 };
 
 } // namespace
 
 int main(int argc, char **argv) {
-  // The capture process exports this for its own layer-shell overlay;
-  // inheriting it here would turn the pin into a layer surface with no window
-  // rules.
-  qunsetenv("QT_WAYLAND_SHELL_INTEGRATION");
+  // Unlike the capture overlay's full-screen layer, the pin is a small
+  // layer-shell surface anchored to the bottom-right. Layer surfaces are
+  // natively visible on every desktop, so the pin needs no compositor
+  // window rules, and its size stays within the caps set by the window.
+  qputenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell");
   QCoreApplication::setApplicationName(QStringLiteral("omasnap-pin"));
   QGuiApplication::setDesktopFileName(QStringLiteral("omasnap-pin"));
   QApplication application(argc, argv);
@@ -241,7 +413,28 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  PinWindow window(std::move(image));
+  PinWindow window(std::move(image), arguments.at(1));
+  static_cast<void>(window.winId());
+  QWindow *handle = window.windowHandle();
+  LayerShellQt::Window *layer =
+      handle ? LayerShellQt::Window::get(handle) : nullptr;
+  if (!handle || !layer) {
+    qCritical("omasnap-pin: could not create layer surface");
+    return 1;
+  }
+
+  layer->setScope(QStringLiteral("omasnap-pin"));
+  LayerShellQt::Window::Anchors anchors;
+  anchors.setFlag(LayerShellQt::Window::AnchorBottom);
+  anchors.setFlag(LayerShellQt::Window::AnchorRight);
+  layer->setAnchors(anchors);
+  layer->setMargins(QMargins(0, 0, kCornerMargin, kCornerMargin));
+  layer->setExclusiveZone(0);
+  layer->setDesiredSize(window.size());
+  layer->setKeyboardInteractivity(
+      LayerShellQt::Window::KeyboardInteractivityOnDemand);
+  layer->setActivateOnShow(false);
+  layer->setLayer(LayerShellQt::Window::LayerOverlay);
   window.show();
   return application.exec();
 }


### PR DESCRIPTION
Resubmission of #7 on the stack, adapted to the hardened runtime directory and native Wayland layer-shell behavior.

- Adds `omasnap-pin` as a small overlay layer surface anchored 14 logical pixels from the bottom-right. It remains visible on every workspace without compositor rules, preserves aspect ratio, and caps size at one third of screen width and one half of screen height.
- Hover controls use the same vector icon renderer as the main toolbar: a standalone double-wide six-dot drag handle in the top-left, plus edit, copy-path, copy-image, and close controls in the top-right. Wheel resizes within the caps; the edit control replaces the pin with the same full-resolution image reopened in Omasnap.
- `P` renders the capture under `/run/user/<UID>/omasnap`, hands it to `omasnap-pin`, and closes the editor. Pins remain independent of the capture process; pinning does not touch the clipboard or screenshot directory.
- Image/path copying uses `wl-copy`, so clipboard data survives pin exit. Pin files and pruning reuse the hardened 0700 runtime directory.

Verification:
- Warning-clean CMake/Ninja build.
- Complete offscreen interaction smoke passed.
- Live Hyprland checks confirmed layer namespace `omasnap-pin`, 14px bottom/right margins, 1/3 width and 1/2 height caps, shared toolbar icon rendering, and edit-to-editor round-trip.

Closes #7