### PR TITLE
feat: OCR fallback to OMARCHY_OCR_LANGS for non-English text

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Install the complete build/runtime dependency set:
 sudo pacman -S --needed \
   base-devel cmake ninja pkgconf qt6-base layer-shell-qt \
   wayland wayland-protocols hyprland grim wl-clipboard \
-  tesseract tesseract-data-eng
+  tesseract tesseract-data-eng tesseract-data-tha
 ```
 
 Build and install:
@@ -163,10 +163,14 @@ Environment overrides:
 ```bash
 OMASNAP_SCREENSHOT_DIR="$HOME/Pictures/Captures" omasnap
 OMASNAP_OCR_LANGS="eng+deu" omasnap
+# Thai plus English:
+OMASNAP_OCR_LANGS="tha+eng" omasnap
 ```
 
 Install the corresponding Tesseract language data before adding a language to
-`OMASNAP_OCR_LANGS`.
+`OMASNAP_OCR_LANGS`. When unset, omasnap falls back to Omarchy's
+`OMARCHY_OCR_LANGS` (which commonly includes the user's script, e.g.
+`tha+eng`), then to `eng`.
 
 ## Controls
 

--- a/capture.cpp
+++ b/capture.cpp
@@ -657,8 +657,10 @@ QString recognizeText(const QImage &image, QString &error) {
     return {};
   }
 
-  const QString languages =
-      qEnvironmentVariable("OMASNAP_OCR_LANGS", QStringLiteral("eng"));
+  QString languages = qEnvironmentVariable("OMASNAP_OCR_LANGS");
+  if (languages.isEmpty())
+    languages = qEnvironmentVariable("OMARCHY_OCR_LANGS", QStringLiteral("eng"));
+  languages = languages.trimmed();
   const ProcessResult result = runProcess(
       QStringLiteral("tesseract"),
       {path, QStringLiteral("stdout"), QStringLiteral("--oem"),
@@ -668,8 +670,8 @@ QString recognizeText(const QImage &image, QString &error) {
        QStringLiteral("preserve_interword_spaces=1")},
       {}, 30000);
   if (!result.finished || result.exitCode != 0) {
-    error = QStringLiteral("OCR failed: %1")
-                .arg(QString::fromUtf8(result.error).trimmed());
+    error = QStringLiteral("OCR failed for languages %1: %2")
+                .arg(languages, QString::fromUtf8(result.error).trimmed());
     return {};
   }
   const QString text = QString::fromUtf8(result.output).trimmed();

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -662,6 +662,21 @@ int main(int argc, char **argv) {
   if (!recognizeText(ocrImage, ocrError)
            .contains(QStringLiteral("OCR smoke test 42")))
     return 5;
+  const QByteArray savedOmasnapLangs = qgetenv("OMASNAP_OCR_LANGS");
+  const QByteArray savedOmarchyLangs = qgetenv("OMARCHY_OCR_LANGS");
+  qputenv("OMASNAP_OCR_LANGS", "");
+  qputenv("OMARCHY_OCR_LANGS", "eng");
+  const QString fallbackOcr = recognizeText(ocrImage, ocrError);
+  if (savedOmasnapLangs.isEmpty())
+    qunsetenv("OMASNAP_OCR_LANGS");
+  else
+    qputenv("OMASNAP_OCR_LANGS", savedOmasnapLangs);
+  if (savedOmarchyLangs.isEmpty())
+    qunsetenv("OMARCHY_OCR_LANGS");
+  else
+    qputenv("OMARCHY_OCR_LANGS", savedOmarchyLangs);
+  if (!fallbackOcr.contains(QStringLiteral("OCR smoke test 42")))
+    return 65;
   QTest::mouseMove(&editor, QPoint(400, 300), 20);
   QTest::keyClick(&editor, Qt::Key_T);
   QTest::keyClick(&editor, Qt::Key_Escape);

--- a/install-omarchy
+++ b/install-omarchy
@@ -13,7 +13,7 @@ fi
 omarchy-pkg-add \
   base-devel cmake ninja pkgconf qt6-base layer-shell-qt \
   wayland wayland-protocols grim wl-clipboard \
-  tesseract tesseract-data-eng
+  tesseract tesseract-data-eng tesseract-data-tha
 
 cmake -S "$repo_dir" -B "$build_dir" -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Resubmission of #8 on the stack.

- recognizeText honors OMASNAP_OCR_LANGS, else falls back to OMARCHY_OCR_LANGS (commonly tha+eng on Omarchy), else eng; trims whitespace; error names the language set.
- Adds tesseract-data-tha to install-omarchy + manual deps, documents the fallback.
- Smoke covers the OMARCHY_OCR_LANGS fallback path.

diff vs base: 4 files, +28/-7. Smoke passes offscreen.