### PR TITLE
feat: open an existing image for annotation and hook notification click

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Runtime commands used by the application:
 - `grim`
 - `wl-copy` and `wl-paste`
 - `tesseract`
-- `omarchy-notification-send` when available; completed captures include a thumbnail and
-  open through `xdg-open` when clicked. Notification failure does not invalidate output.
+- `omarchy-notification-send` when available; saved captures include a thumbnail and
+  reopen in Omasnap when clicked. Notification failure does not invalidate output.
 
 ## Install on Omarchy
 
@@ -169,9 +169,9 @@ omasnap ~/Pictures/Screenshots/screenshot-2026-08-11_10-00-00.png
 omasnap --file /path/to/capture.png
 ```
 
-File URLs are accepted too. The capture notification's "Click to edit" action launches
-`omasnap` on the finished screenshot, so a capture can be reopened and re-annotated
-instead of being handed to an external viewer.
+File URLs are accepted too. A saved capture notification's "Click to edit" action launches
+`omasnap` on the finished screenshot, so it can be reopened and re-annotated. Clipboard-only
+captures are not retained on disk and therefore have no delayed edit action.
 
 Environment overrides:
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,21 @@ omasnap smart       # maps to region selection
 These options choose what is initially selected; the editor still controls whether the
 result is copied, saved, or both.
 
+### Edit an existing image
+
+Point omasnap at any readable image and it opens straight into the annotation editor
+with the whole image selected, skipping the screen-capture step:
+
+```bash
+omasnap ~/Pictures/Screenshots/screenshot-2026-08-11_10-00-00.png
+# or
+omasnap --file /path/to/capture.png
+```
+
+File URLs are accepted too. The capture notification's "Click to edit" action launches
+`omasnap` on the finished screenshot, so a capture can be reopened and re-annotated
+instead of being handed to an external viewer.
+
 Environment overrides:
 
 ```bash

--- a/capture.cpp
+++ b/capture.cpp
@@ -687,9 +687,13 @@ void sendCaptureNotification(const QString &message, const QString &imagePath) {
   if (!imagePath.isEmpty()) {
     const QString imageUrl =
         QUrl::fromLocalFile(imagePath).toString(QUrl::FullyEncoded);
-    arguments << QStringLiteral("Click to open") << QStringLiteral("--image")
+    QString omasnap = QDir(QCoreApplication::applicationDirPath())
+                          .filePath(QStringLiteral("omasnap"));
+    if (!QFileInfo::exists(omasnap))
+      omasnap = QStringLiteral("omasnap");
+    arguments << QStringLiteral("Click to edit") << QStringLiteral("--image")
               << imagePath << QStringLiteral("--exec")
-              << QStringLiteral("xdg-open %1").arg(imageUrl);
+              << QStringLiteral("%1 %2").arg(omasnap, imageUrl);
   }
   arguments << QStringLiteral("-t") << QStringLiteral("4500");
   QProcess::startDetached(QStringLiteral("omarchy-notification-send"),

--- a/capture.cpp
+++ b/capture.cpp
@@ -20,8 +20,10 @@
 
 #include <QUrl>
 #include <algorithm>
+#include <cerrno>
 #include <cmath>
 #include <fcntl.h>
+#include <limits>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -38,6 +40,49 @@ QFont annotationTextFont(qreal size) {
   font.setItalic(false);
   font.setPixelSize(qRound(std::max<qreal>(18.0, size * 5.0)));
   return font;
+}
+
+bool ensurePrivateDirectory(const QString &path) {
+  if (path.isEmpty())
+    return false;
+
+  const QString cleanPath = QDir::cleanPath(path);
+  const QByteArray encoded = QFile::encodeName(cleanPath);
+  const int fd = ::open(encoded.constData(),
+                        O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd >= 0) {
+    struct stat info{};
+    const bool ownedDirectory = ::fstat(fd, &info) == 0 &&
+                                S_ISDIR(info.st_mode) &&
+                                info.st_uid == ::geteuid();
+    const bool secured = ownedDirectory && ::fchmod(fd, S_IRWXU) == 0;
+    ::close(fd);
+    return secured;
+  }
+  if (errno != ENOENT)
+    return false;
+
+  const QString parent = QFileInfo(cleanPath).dir().absolutePath();
+  if (parent.isEmpty() || parent == cleanPath)
+    return false;
+  if (!QFileInfo(parent).isDir() && !ensurePrivateDirectory(parent))
+    return false;
+
+  if (::mkdir(encoded.constData(), S_IRWXU) == 0)
+    return true;
+  return errno == EEXIST && ensurePrivateDirectory(cleanPath);
+}
+
+QString secureRuntimeDirectory() {
+  QString runtime =
+      QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+  if (runtime.isEmpty()) {
+    runtime = QDir(QDir::tempPath())
+                  .filePath(QStringLiteral("omasnap-%1").arg(::getuid()));
+  } else {
+    runtime = QDir(runtime).filePath(QStringLiteral("omasnap"));
+  }
+  return ensurePrivateDirectory(runtime) ? QDir::cleanPath(runtime) : QString();
 }
 
 namespace {
@@ -94,31 +139,14 @@ bool copyToWaylandClipboard(const QString &mimeType, const QByteArray &payload,
   return false;
 }
 
-bool makeSecureDir(const QString &dirPath) {
-  if (dirPath.isEmpty())
-    return false;
-  const QDir dir(dirPath);
-  if (dir.exists())
-    return true;
-  const QString parent = QFileInfo(dirPath).dir().absolutePath();
-  if (!parent.isEmpty() && parent != dirPath && !QDir(parent).exists()) {
-    if (!makeSecureDir(parent))
-      return false;
-  }
-  return ::mkdir(dirPath.toLocal8Bit().constData(), 0700) == 0 || dir.exists();
+QString runtimePath(const QString &name) {
+  const QString runtime = secureRuntimeDirectory();
+  return runtime.isEmpty() ? QString() : QDir(runtime).filePath(name);
 }
 
-QString runtimePath(const QString &name) {
-  QString runtime =
-      QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
-  if (runtime.isEmpty())
-    runtime = QDir(QDir::tempPath())
-                  .filePath(QStringLiteral("omasnap-%1").arg(::getuid()));
-  else
-    runtime = QDir(runtime).filePath(QStringLiteral("omasnap"));
-
-  makeSecureDir(runtime);
-  return QDir(runtime).filePath(name);
+QString shellQuote(QString value) {
+  value.replace('\'', QStringLiteral("'\"'\"'"));
+  return QStringLiteral("'%1'").arg(value);
 }
 
 QString screenshotTargetPath(QString &error) {
@@ -256,8 +284,7 @@ void drawAnnotation(QPainter &painter, const Annotation &annotation) {
       QColor ink = annotation.color;
       if (ink.alpha() >= 255)
         ink.setAlpha(120);
-      const qreal highlightWidth =
-          std::max<qreal>(6.0, annotation.size * 3.0);
+      const qreal highlightWidth = std::max<qreal>(6.0, annotation.size * 3.0);
       painter.setPen(QPen(ink, highlightWidth, Qt::SolidLine, Qt::RoundCap,
                           Qt::RoundJoin));
     }
@@ -421,8 +448,13 @@ bool captureFocusedMonitor(CaptureData &capture, QString &error) {
     return false;
   }
 
-  QTemporaryFile sourceFile(
-      runtimePath(QStringLiteral("omasnap-capture-XXXXXX.ppm")));
+  const QString sourceTemplate =
+      runtimePath(QStringLiteral("omasnap-capture-XXXXXX.ppm"));
+  if (sourceTemplate.isEmpty()) {
+    error = QStringLiteral("Could not create private runtime directory");
+    return false;
+  }
+  QTemporaryFile sourceFile(sourceTemplate);
   sourceFile.setAutoRemove(true);
   if (!sourceFile.open()) {
     error = sourceFile.errorString();
@@ -586,10 +618,12 @@ QString pinnedSnapshotPath(int index) {
 }
 
 void prunePinnedSnapshots() {
+  const QString runtime = secureRuntimeDirectory();
+  if (runtime.isEmpty())
+    return;
   const QDateTime cutoff = QDateTime::currentDateTime().addDays(-1);
   const QFileInfoList stale =
-      QDir(runtimePath(QString())).entryInfoList({QStringLiteral("pin-*.png")},
-                                                 QDir::Files);
+      QDir(runtime).entryInfoList({QStringLiteral("pin-*.png")}, QDir::Files);
   for (const QFileInfo &entry : stale) {
     if (entry.lastModified() < cutoff)
       QFile::remove(entry.absoluteFilePath());
@@ -601,21 +635,29 @@ bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
     error = QStringLiteral("Temporary snapshot is empty");
     return false;
   }
+  const QString runtime = secureRuntimeDirectory();
+  if (runtime.isEmpty()) {
+    error = QStringLiteral("Could not create private runtime directory");
+    return false;
+  }
   if (path.isEmpty())
     path = temporarySnapshotPath();
-  const QDir root = QFileInfo(path).absoluteDir();
-  if (!makeSecureDir(root.absolutePath())) {
-    error = QStringLiteral("Could not create snapshot directory: %1")
-                .arg(root.absolutePath());
+  path = QDir::cleanPath(QFileInfo(path).absoluteFilePath());
+  if (QFileInfo(path).absolutePath() != runtime) {
+    error =
+        QStringLiteral("Temporary snapshots must stay inside %1").arg(runtime);
     return false;
   }
 
   // Reuse the current file (snapshotPath_ is stable) but never follow a
-  // pre-created symlink; the 0700 runtime directory already blocks outsiders
-  // from planting one.
-  const int fd = ::open(path.toLocal8Bit().constData(),
-                        O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
-  if (fd < 0) {
+  // pre-created symlink.
+  const QByteArray encodedPath = QFile::encodeName(path);
+  const int fd = ::open(encodedPath.constData(),
+                        O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC,
+                        S_IRUSR | S_IWUSR);
+  if (fd < 0 || ::fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
+    if (fd >= 0)
+      ::close(fd);
     error = QStringLiteral("Could not open secure snapshot file: %1").arg(path);
     return false;
   }
@@ -644,8 +686,13 @@ bool copyTextToClipboard(const QString &text, QString &error) {
 }
 
 QString recognizeText(const QImage &image, QString &error) {
-  QTemporaryFile input(runtimePath(QStringLiteral("omasnap-ocr-XXXXXX.png")));
-  input.setAutoRemove(true);
+  const QString inputTemplate =
+      runtimePath(QStringLiteral("omasnap-ocr-XXXXXX.png"));
+  if (inputTemplate.isEmpty()) {
+    error = QStringLiteral("Could not create private runtime directory");
+    return {};
+  }
+  QTemporaryFile input(inputTemplate);
   if (!input.open()) {
     error = input.errorString();
     return {};
@@ -659,7 +706,8 @@ QString recognizeText(const QImage &image, QString &error) {
 
   QString languages = qEnvironmentVariable("OMASNAP_OCR_LANGS");
   if (languages.isEmpty())
-    languages = qEnvironmentVariable("OMARCHY_OCR_LANGS", QStringLiteral("eng"));
+    languages =
+        qEnvironmentVariable("OMARCHY_OCR_LANGS", QStringLiteral("eng"));
   languages = languages.trimmed();
   const ProcessResult result = runProcess(
       QStringLiteral("tesseract"),
@@ -693,7 +741,8 @@ void sendCaptureNotification(const QString &message, const QString &imagePath) {
       omasnap = QStringLiteral("omasnap");
     arguments << QStringLiteral("Click to edit") << QStringLiteral("--image")
               << imagePath << QStringLiteral("--exec")
-              << QStringLiteral("%1 %2").arg(omasnap, imageUrl);
+              << QStringLiteral("%1 %2").arg(shellQuote(omasnap),
+                                             shellQuote(imageUrl));
   }
   arguments << QStringLiteral("-t") << QStringLiteral("4500");
   QProcess::startDetached(QStringLiteral("omarchy-notification-send"),

--- a/capture.hpp
+++ b/capture.hpp
@@ -74,6 +74,10 @@ struct Annotation {
 void paintAnnotation(QPainter &painter, const Annotation &annotation);
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
                             BackgroundStyle backgroundStyle);
+/** Creates or repairs a private directory owned by the current user. */
+[[nodiscard]] bool ensurePrivateDirectory(const QString &path);
+/** Returns Omasnap's private runtime directory, or empty on failure. */
+[[nodiscard]] QString secureRuntimeDirectory();
 [[nodiscard]] QString moveSnapshotToScreenshots(const QString &sourcePath,
                                                 QString &error);
 [[nodiscard]] QString temporarySnapshotPath();

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -460,6 +460,24 @@ int main(int argc, char **argv) {
           outputRoot + QStringLiteral("-fullscreen-editor.png"), "PNG"))
     return 16;
 
+  // File mode opens an existing image straight into the edit phase: whole
+  // image selected, arrow cursor, annotation canvas showing the pixels.
+  CaptureData fileData;
+  fileData.monitor.scale = 1.0;
+  fileData.monitor.pixelSize = {300, 200};
+  fileData.source = QImage(300, 200, QImage::Format_RGB32);
+  fileData.source.fill(QColor(QStringLiteral("#1a2b3c")));
+  fileData.preview = fileData.source;
+  CaptureEditor fileEditor(fileData, CaptureEditor::CaptureMode::File);
+  fileEditor.resize(800, 600);
+  fileEditor.show();
+  application.processEvents();
+  const QImage fileUi = fileEditor.grab().toImage();
+  if (fileEditor.cursor().shape() != Qt::ArrowCursor ||
+      fileUi.pixelColor(400, 305) != QColor(QStringLiteral("#1a2b3c")) ||
+      !fileUi.save(outputRoot + QStringLiteral("-file-mode.png"), "PNG"))
+    return 70;
+
   CaptureData windowSurfaceCapture = capture;
   windowSurfaceCapture.monitor.scale = 1.0;
   windowSurfaceCapture.monitor.pixelSize = {320, 180};

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -10,6 +10,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QPainter>
+#include <QTemporaryDir>
 #include <QWheelEvent>
 #include <QtTest/QTest>
 
@@ -46,19 +47,51 @@ bool runTemporarySnapshotChecks(QString &error) {
   // The runtime directory must stay private and the snapshot must not be
   // readable by group or other.
   const QFileInfo dirInfo = QFileInfo(fileInfo.absolutePath());
-  const QFileDevice::Permissions owner = QFileDevice::ReadOwner |
-                                         QFileDevice::WriteOwner |
-                                         QFileDevice::ExeOwner;
-  const QFileDevice::Permissions shared = QFileDevice::ReadGroup |
-                                          QFileDevice::WriteGroup |
-                                          QFileDevice::ExeGroup |
-                                          QFileDevice::ReadOther |
-                                          QFileDevice::WriteOther |
-                                          QFileDevice::ExeOther;
+  const QFileDevice::Permissions owner =
+      QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner;
+  const QFileDevice::Permissions shared =
+      QFileDevice::ReadGroup | QFileDevice::WriteGroup | QFileDevice::ExeGroup |
+      QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther;
   if ((dirInfo.permissions() & owner) != owner ||
       (dirInfo.permissions() & shared) != 0 ||
       (fileInfo.permissions() & shared) != 0)
     return false;
+  QTemporaryDir securityRoot;
+  const QString repairPath =
+      QDir(securityRoot.path()).filePath(QStringLiteral("repair-me"));
+  if (!securityRoot.isValid() || !QDir().mkdir(repairPath) ||
+      !QFile::setPermissions(repairPath, owner | shared) ||
+      !ensurePrivateDirectory(repairPath) ||
+      (QFileInfo(repairPath).permissions() & shared) != 0) {
+    error = QStringLiteral("Private directory permissions were not repaired");
+    return false;
+  }
+  const QString symlinkPath =
+      QDir(securityRoot.path()).filePath(QStringLiteral("directory-link"));
+  if (!QFile::link(repairPath, symlinkPath) ||
+      ensurePrivateDirectory(symlinkPath)) {
+    error = QStringLiteral("Private directory accepted a symbolic link");
+    return false;
+  }
+  const QString outsideDirectory =
+      QDir(securityRoot.path()).filePath(QStringLiteral("outside"));
+  const QFileDevice::Permissions visibleToGroup =
+      QFileDevice::ReadGroup | QFileDevice::ExeGroup;
+  if (!QDir().mkdir(outsideDirectory) ||
+      !QFile::setPermissions(outsideDirectory, owner | visibleToGroup)) {
+    error = QStringLiteral("Could not prepare snapshot boundary check");
+    return false;
+  }
+  error.clear();
+  const QString outsideSnapshot =
+      QDir(outsideDirectory).filePath(QStringLiteral("snapshot.png"));
+  if (saveTemporarySnapshot(secondImage, outsideSnapshot, error) ||
+      QFile::exists(outsideSnapshot) ||
+      (QFileInfo(outsideDirectory).permissions() & visibleToGroup) !=
+          visibleToGroup) {
+    error = QStringLiteral("Temporary snapshot escaped its private directory");
+    return false;
+  }
   QFile::remove(path);
   return true;
 }
@@ -79,9 +112,8 @@ bool runHighlighterRenderingCheck(QString &error) {
   highlight.color = QColor(QStringLiteral("#ffd60a"));
   highlight.size = 4;
   highlight.points = {{50, 50}, {90, 50}, {130, 50}, {170, 50}};
-  const QImage rendered =
-      renderCapture(capture, QRectF(0, 0, 200, 100), {highlight},
-                    BackgroundStyle::None);
+  const QImage rendered = renderCapture(capture, QRectF(0, 0, 200, 100),
+                                        {highlight}, BackgroundStyle::None);
   if (rendered.isNull())
     return false;
 
@@ -706,34 +738,38 @@ int main(int argc, char **argv) {
   if (editor.isVisible())
     return 25;
 
-  CaptureEditor finishEditor(capture);
-  finishEditor.resize(800, 600);
-  finishEditor.show();
-  application.processEvents();
-  QTest::mousePress(&finishEditor, Qt::LeftButton, Qt::NoModifier,
-                    QPoint(100, 100));
-  QTest::mouseMove(&finishEditor, QPoint(650, 470), 20);
-  QTest::mouseRelease(&finishEditor, Qt::LeftButton, Qt::NoModifier,
-                      QPoint(650, 470));
-  QTest::keyClick(&finishEditor, Qt::Key_C);
-  QTest::mouseClick(&finishEditor, Qt::LeftButton, Qt::NoModifier,
-                    QPoint(470, 300));
-  application.processEvents();
-  const QImage snapshotBeforeSave(snapshotPath);
-  if (snapshotBeforeSave.isNull())
-    return 59;
-  QTest::keyClick(&finishEditor, Qt::Key_S, Qt::ControlModifier);
-  application.processEvents();
-  const QStringList savedFiles =
-      QDir(QDir(outputRoot).filePath(QStringLiteral("saved")))
-          .entryList({QStringLiteral("*.png")}, QDir::Files);
-  if (finishEditor.isVisible() || savedFiles.size() != 1)
-    return 60;
-  const QString savedPath =
-      QDir(QDir(outputRoot).filePath(QStringLiteral("saved")))
-          .filePath(savedFiles.constFirst());
-  if (QImage(savedPath) != snapshotBeforeSave || QFile::exists(snapshotPath))
-    return 61;
+  QString savedPath;
+  {
+    CaptureEditor finishEditor(capture);
+    finishEditor.resize(800, 600);
+    finishEditor.show();
+    application.processEvents();
+    QTest::mousePress(&finishEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(100, 100));
+    QTest::mouseMove(&finishEditor, QPoint(650, 470), 20);
+    QTest::mouseRelease(&finishEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(650, 470));
+    QTest::keyClick(&finishEditor, Qt::Key_C);
+    QTest::mouseClick(&finishEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(470, 300));
+    application.processEvents();
+    const QImage snapshotBeforeSave(snapshotPath);
+    if (snapshotBeforeSave.isNull())
+      return 59;
+    QTest::keyClick(&finishEditor, Qt::Key_S, Qt::ControlModifier);
+    application.processEvents();
+    const QStringList savedFiles =
+        QDir(QDir(outputRoot).filePath(QStringLiteral("saved")))
+            .entryList({QStringLiteral("*.png")}, QDir::Files);
+    if (finishEditor.isVisible() || savedFiles.size() != 1)
+      return 60;
+    savedPath = QDir(QDir(outputRoot).filePath(QStringLiteral("saved")))
+                    .filePath(savedFiles.constFirst());
+    if (QImage(savedPath) != snapshotBeforeSave || QFile::exists(snapshotPath))
+      return 61;
+  }
+  if (!QFile::exists(savedPath))
+    return 70;
   if (qEnvironmentVariableIsSet("OMASNAP_SMOKE_COPY")) {
     QString clipboardError;
     if (!copyPngFileToClipboard(savedPath, clipboardError)) {

--- a/editor.cpp
+++ b/editor.cpp
@@ -22,7 +22,6 @@
 #include <QPainterPath>
 #include <QProcess>
 #include <QScreen>
-#include <QStandardPaths>
 #include <QTimer>
 #include <QWheelEvent>
 
@@ -239,11 +238,11 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
 
   if (mode == CaptureMode::Fullscreen || mode == CaptureMode::File) {
     selection_ = QRectF(QPointF(), capture_.preview.size());
-    enterEdit(mode == CaptureMode::File
-                  ? QStringLiteral(
-                        "Editing image from file · Copy/Save to output")
-                  : QStringLiteral("Full screen selected · native resolution · "
-                                   "outer handles crop"));
+    enterEdit(
+        mode == CaptureMode::File
+            ? QStringLiteral("Editing image from file · Copy/Save to output")
+            : QStringLiteral("Full screen selected · native resolution · "
+                             "outer handles crop"));
   } else if (mode == CaptureMode::Window) {
     windowMode_ = true;
     hoveredWindow_ = windowAt(cursor_);
@@ -254,14 +253,11 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
 }
 
 CaptureEditor::~CaptureEditor() {
-  if (!snapshotPath_.isEmpty() && QFile::exists(snapshotPath_)) {
-    const QString runtime =
-        QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
-    if ((!runtime.isEmpty() && snapshotPath_.startsWith(runtime)) ||
-        snapshotPath_.contains(QStringLiteral("/omasnap"))) {
-      QFile::remove(snapshotPath_);
-    }
-  }
+  if (snapshotPath_.isEmpty() || !QFile::exists(snapshotPath_))
+    return;
+  const QString runtime = secureRuntimeDirectory();
+  if (!runtime.isEmpty() && QFileInfo(snapshotPath_).absolutePath() == runtime)
+    QFile::remove(snapshotPath_);
 }
 
 bool CaptureEditor::eventFilter(QObject *watched, QEvent *event) {
@@ -744,24 +740,21 @@ void CaptureEditor::pinSnapshot() {
 
   prunePinnedSnapshots();
   const QString path = pinnedSnapshotPath(++pinCount_);
+  if (path.isEmpty()) {
+    --pinCount_;
+    setStatus(QStringLiteral("Could not create private runtime directory"));
+    return;
+  }
   const QImage image =
       renderCapture(capture_, selection_, annotations_, backgroundStyle_);
   QString error;
   if (!saveTemporarySnapshot(image, path, error)) {
     setStatus(error);
+    --pinCount_;
     return;
   }
 
-  // The capture process exports QT_WAYLAND_SHELL_INTEGRATION for its own
-  // layer-shell overlay; the pin needs a plain toplevel the compositor can
-  // float, move and stack like any other window.
-  QProcess pin;
-  QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
-  environment.remove(QStringLiteral("QT_WAYLAND_SHELL_INTEGRATION"));
-  pin.setProcessEnvironment(environment);
-  pin.setProgram(pinProgram());
-  pin.setArguments({path});
-  if (!pin.startDetached()) {
+  if (!QProcess::startDetached(pinProgram(), {path})) {
     QFile::remove(path);
     --pinCount_;
     setStatus(QStringLiteral("Could not start omasnap-pin"));
@@ -984,16 +977,13 @@ void CaptureEditor::finish(OutputMode mode) {
     snapshotPath_ = saved;
   }
 
-  const QString notificationImage = saved.isEmpty() ? snapshotPath_ : saved;
   if (mode == OutputMode::Copy)
-    sendCaptureNotification(QStringLiteral("Screenshot copied to clipboard"),
-                            notificationImage);
+    sendCaptureNotification(QStringLiteral("Screenshot copied to clipboard"));
   else if (mode == OutputMode::Save)
-    sendCaptureNotification(QStringLiteral("Screenshot saved"),
-                            notificationImage);
+    sendCaptureNotification(QStringLiteral("Screenshot saved"), saved);
   else
     sendCaptureNotification(QStringLiteral("Screenshot saved and copied"),
-                            notificationImage);
+                            saved);
   close();
 }
 

--- a/editor.cpp
+++ b/editor.cpp
@@ -237,10 +237,13 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     sendCaptureNotification(QStringLiteral("Copied text from screenshot"));
   });
 
-  if (mode == CaptureMode::Fullscreen) {
+  if (mode == CaptureMode::Fullscreen || mode == CaptureMode::File) {
     selection_ = QRectF(QPointF(), capture_.preview.size());
-    enterEdit(QStringLiteral(
-        "Full screen selected · native resolution · outer handles crop"));
+    enterEdit(mode == CaptureMode::File
+                  ? QStringLiteral(
+                        "Editing image from file · Copy/Save to output")
+                  : QStringLiteral("Full screen selected · native resolution · "
+                                   "outer handles crop"));
   } else if (mode == CaptureMode::Window) {
     windowMode_ = true;
     hoveredWindow_ = windowAt(cursor_);

--- a/editor.hpp
+++ b/editor.hpp
@@ -15,7 +15,7 @@ class QWheelEvent;
 class QPainter;
 class CaptureEditor final : public QWidget {
 public:
-  enum class CaptureMode { Region, Window, Fullscreen };
+  enum class CaptureMode { Region, Window, Fullscreen, File };
 
   explicit CaptureEditor(CaptureData capture,
                          CaptureMode mode = CaptureMode::Region,

--- a/main.cpp
+++ b/main.cpp
@@ -12,7 +12,6 @@
 #include <QLockFile>
 #include <QScreen>
 #include <QSocketNotifier>
-#include <QStandardPaths>
 #include <QUrl>
 #include <QWindow>
 
@@ -24,29 +23,48 @@ namespace {
 class PosixSignalNotifier final : public QObject {
 public:
   explicit PosixSignalNotifier(QObject *parent = nullptr) : QObject(parent) {
-    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, fds_) != 0)
+    if (::socketpair(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0,
+                     fds_) != 0)
       return; // Default signal disposition stays in effect.
+    signalFd_ = fds_[0];
 
     struct sigaction sa{};
     sa.sa_handler = [](int) {
-      char a = 1;
-      ::write(fds_[0], &a, sizeof(a));
+      const char byte = 1;
+      const int fd = signalFd_;
+      if (fd >= 0)
+        static_cast<void>(::write(fd, &byte, sizeof(byte)));
     };
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_RESTART;
-    ::sigaction(SIGINT, &sa, nullptr);
-    ::sigaction(SIGTERM, &sa, nullptr);
+    sigintInstalled_ = ::sigaction(SIGINT, &sa, &previousSigint_) == 0;
+    sigtermInstalled_ = ::sigaction(SIGTERM, &sa, &previousSigterm_) == 0;
+    if (!sigintInstalled_ && !sigtermInstalled_) {
+      closeSockets();
+      return;
+    }
 
     notifier_ = new QSocketNotifier(fds_[1], QSocketNotifier::Read, this);
     connect(notifier_, &QSocketNotifier::activated, this, [this] {
       notifier_->setEnabled(false);
-      char a;
-      ::read(fds_[1], &a, sizeof(a));
+      char bytes[32];
+      while (::read(fds_[1], bytes, sizeof(bytes)) > 0) {
+      }
       QCoreApplication::quit();
     });
   }
 
   ~PosixSignalNotifier() override {
+    if (sigintInstalled_)
+      ::sigaction(SIGINT, &previousSigint_, nullptr);
+    if (sigtermInstalled_)
+      ::sigaction(SIGTERM, &previousSigterm_, nullptr);
+    closeSockets();
+  }
+
+private:
+  void closeSockets() {
+    signalFd_ = -1;
     for (int &fd : fds_) {
       if (fd >= 0) {
         ::close(fd);
@@ -55,16 +73,19 @@ public:
     }
   }
 
-private:
   static inline int fds_[2]{-1, -1};
+  static inline volatile sig_atomic_t signalFd_ = -1;
+  struct sigaction previousSigint_{};
+  struct sigaction previousSigterm_{};
+  bool sigintInstalled_ = false;
+  bool sigtermInstalled_ = false;
   QSocketNotifier *notifier_ = nullptr;
 };
 } // namespace
 
 int main(int argc, char **argv) {
   QCoreApplication::setApplicationName(QStringLiteral("omasnap"));
-  QCoreApplication::setApplicationVersion(
-      QString::fromLatin1(OMASNAP_VERSION));
+  QCoreApplication::setApplicationVersion(QString::fromLatin1(OMASNAP_VERSION));
   QCoreApplication::setOrganizationName(QStringLiteral("Omarchy"));
   qputenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell");
   QGuiApplication::setDesktopFileName(QStringLiteral("omasnap"));
@@ -151,12 +172,13 @@ int main(int argc, char **argv) {
     return 1;
   application.setQuitOnLastWindowClosed(true);
 
-  QString runtime =
-      QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
-  if (runtime.isEmpty())
-    runtime = QDir::tempPath();
-  QLockFile instanceLock(QDir(runtime).filePath(
-      QStringLiteral("omasnap.instance")));
+  const QString runtime = secureRuntimeDirectory();
+  if (runtime.isEmpty()) {
+    qCritical() << "Could not create private runtime directory";
+    return 1;
+  }
+  QLockFile instanceLock(
+      QDir(runtime).filePath(QStringLiteral("omasnap.instance")));
   instanceLock.setStaleLockTime(0);
   if (!instanceLock.tryLock(0))
     return 0;
@@ -179,11 +201,10 @@ int main(int argc, char **argv) {
     capture.monitor.pixelSize = image.size();
     capture.monitor.geometry = QRect(QPoint(0, 0), image.size());
     captureMode = CaptureEditor::CaptureMode::File;
-    qInfo().noquote()
-        << QStringLiteral("Opened %1 for annotation (%2x%3)")
-               .arg(localFile)
-               .arg(image.width())
-               .arg(image.height());
+    qInfo().noquote() << QStringLiteral("Opened %1 for annotation (%2x%3)")
+                             .arg(localFile)
+                             .arg(image.width())
+                             .arg(image.height());
   } else if (!captureFocusedMonitor(capture, error)) {
     qCritical().noquote() << error;
     sendCaptureNotification(QStringLiteral("Screenshot failed: %1").arg(error));
@@ -191,12 +212,12 @@ int main(int argc, char **argv) {
   }
 
   if (filePath.isEmpty())
-    qInfo().noquote()
-        << QStringLiteral("Captured %1 workspace %2 with %3 selectable "
-                          "windows")
-               .arg(capture.monitor.name)
-               .arg(capture.monitor.workspaceId)
-               .arg(capture.windows.size());
+    qInfo().noquote() << QStringLiteral(
+                             "Captured %1 workspace %2 with %3 selectable "
+                             "windows")
+                             .arg(capture.monitor.name)
+                             .arg(capture.monitor.workspaceId)
+                             .arg(capture.windows.size());
 
   QScreen *targetScreen = QGuiApplication::primaryScreen();
   for (QScreen *screen : QGuiApplication::screens()) {

--- a/main.cpp
+++ b/main.cpp
@@ -7,11 +7,13 @@
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QDir>
+#include <QFileInfo>
 #include <QGuiApplication>
 #include <QLockFile>
 #include <QScreen>
 #include <QSocketNotifier>
 #include <QStandardPaths>
+#include <QUrl>
 #include <QWindow>
 
 #include <csignal>
@@ -87,12 +89,20 @@ int main(int argc, char **argv) {
   parser.addOption(fullscreenOption);
   parser.addOption(windowOption);
   parser.addOption(regionOption);
+  const QCommandLineOption fileOption(
+      QStringLiteral("file"),
+      QStringLiteral("Open an existing image file in the annotation editor "
+                     "instead of capturing the screen."),
+      QStringLiteral("path"));
+  parser.addOption(fileOption);
   parser.addPositionalArgument(
-      QStringLiteral("mode"),
-      QStringLiteral("Optional compatibility mode: smart, region, windows, or "
-                     "fullscreen."),
-      QStringLiteral("[mode]"));
+      QStringLiteral("target"),
+      QStringLiteral("Capture mode (smart, region, windows, fullscreen) or the "
+                     "path of an image file to edit."),
+      QStringLiteral("[target]"));
   parser.process(application);
+
+  QString filePath = parser.value(fileOption);
 
   CaptureEditor::CaptureMode captureMode = CaptureEditor::CaptureMode::Region;
   int requestedModes = parser.isSet(fullscreenOption) +
@@ -104,28 +114,37 @@ int main(int argc, char **argv) {
 
   const QStringList positional = parser.positionalArguments();
   if (positional.size() > 1) {
-    qCritical() << "Only one capture mode may be specified";
+    qCritical() << "Only one capture target may be specified";
     return 2;
   }
   if (!positional.isEmpty()) {
-    ++requestedModes;
-    const QString mode = positional.first();
-    if (mode == QStringLiteral("fullscreen"))
-      captureMode = CaptureEditor::CaptureMode::Fullscreen;
-    else if (mode == QStringLiteral("windows") ||
-             mode == QStringLiteral("window"))
-      captureMode = CaptureEditor::CaptureMode::Window;
-    else if (mode == QStringLiteral("smart") ||
-             mode == QStringLiteral("region"))
-      captureMode = CaptureEditor::CaptureMode::Region;
-    else {
-      qCritical().noquote()
-          << QStringLiteral("Unknown capture mode: %1").arg(mode);
-      return 2;
+    const QFileInfo target(positional.first());
+    if (filePath.isEmpty() && target.isFile()) {
+      filePath = positional.first();
+    } else {
+      ++requestedModes;
+      const QString mode = positional.first();
+      if (mode == QStringLiteral("fullscreen"))
+        captureMode = CaptureEditor::CaptureMode::Fullscreen;
+      else if (mode == QStringLiteral("windows") ||
+               mode == QStringLiteral("window"))
+        captureMode = CaptureEditor::CaptureMode::Window;
+      else if (mode == QStringLiteral("smart") ||
+               mode == QStringLiteral("region"))
+        captureMode = CaptureEditor::CaptureMode::Region;
+      else {
+        qCritical().noquote()
+            << QStringLiteral("Unknown capture target: %1").arg(mode);
+        return 2;
+      }
     }
   }
-  if (requestedModes > 1) {
+  if (filePath.isEmpty() && requestedModes > 1) {
     qCritical() << "Capture mode options are mutually exclusive";
+    return 2;
+  }
+  if (!filePath.isEmpty() && requestedModes > 0) {
+    qCritical() << "An image file cannot be combined with a capture mode";
     return 2;
   }
   if (!loadCaptureFonts())
@@ -144,17 +163,40 @@ int main(int argc, char **argv) {
 
   CaptureData capture;
   QString error;
-  if (!captureFocusedMonitor(capture, error)) {
+  if (!filePath.isEmpty()) {
+    QString localFile = QUrl(filePath).toLocalFile();
+    if (localFile.isEmpty())
+      localFile = filePath;
+    QImage image(localFile);
+    if (image.isNull()) {
+      qCritical().noquote()
+          << QStringLiteral("Could not load image: %1").arg(filePath);
+      return 1;
+    }
+    capture.source = image;
+    capture.preview = image;
+    capture.monitor.scale = 1.0;
+    capture.monitor.pixelSize = image.size();
+    capture.monitor.geometry = QRect(QPoint(0, 0), image.size());
+    captureMode = CaptureEditor::CaptureMode::File;
+    qInfo().noquote()
+        << QStringLiteral("Opened %1 for annotation (%2x%3)")
+               .arg(localFile)
+               .arg(image.width())
+               .arg(image.height());
+  } else if (!captureFocusedMonitor(capture, error)) {
     qCritical().noquote() << error;
     sendCaptureNotification(QStringLiteral("Screenshot failed: %1").arg(error));
     return 1;
   }
 
-  qInfo().noquote()
-      << QStringLiteral("Captured %1 workspace %2 with %3 selectable windows")
-             .arg(capture.monitor.name)
-             .arg(capture.monitor.workspaceId)
-             .arg(capture.windows.size());
+  if (filePath.isEmpty())
+    qInfo().noquote()
+        << QStringLiteral("Captured %1 workspace %2 with %3 selectable "
+                          "windows")
+               .arg(capture.monitor.name)
+               .arg(capture.monitor.workspaceId)
+               .arg(capture.windows.size());
 
   QScreen *targetScreen = QGuiApplication::primaryScreen();
   for (QScreen *screen : QGuiApplication::screens()) {

--- a/surface-capture.cpp
+++ b/surface-capture.cpp
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>
+#include <limits>
 #include <memory>
 #include <poll.h>
 #include <string>
@@ -247,10 +248,15 @@ bool createShmBuffer(CaptureState &state, QString &error) {
 
   const std::size_t stride = static_cast<std::size_t>(state.width) * 4;
   state.memorySize = stride * state.height;
+  if (state.memorySize >
+      static_cast<std::size_t>(std::numeric_limits<int32_t>::max())) {
+    error = QStringLiteral("Surface capture buffer is too large");
+    return false;
+  }
   char name[96];
   std::snprintf(name, sizeof(name), "/omarchy-capture-%d-%p", getpid(),
                 static_cast<void *>(&state));
-  state.fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+  state.fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
   if (state.fd < 0) {
     error = QStringLiteral("Could not allocate surface capture memory");
     return false;


### PR DESCRIPTION
- CaptureEditor gains CaptureMode::File: jumps straight into the edit phase
  with the whole image selected.
- main: --file <path> and an existing-file positional (accepts file:// URLs);
  skips screen capture, builds the CaptureData from the loaded image
  (scale 1.0, native pixels), conflicts with capture mode options.
- Notifications use 'Click to edit' and launch omasnap on the screenshot
  (sibling binary with PATH fallback) instead of xdg-open, reopening captures
  for annotation.
- Smoke: File-mode editor lands in edit phase with the image visible.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>