### PR TITLE
feat: add secure redaction tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   capture stays in the window picker; Omasnap never substitutes a crop of the desktop.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
 - Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
-  rectangles, numbered markers, and editable Neucha text.
+  rectangles, numbered markers, editable Neucha text, and secure redaction with
+  opaque or randomized non-spatial mosaic output.
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
@@ -210,6 +211,7 @@ Install the corresponding Tesseract language data before adding a language to
 | `F` | Freehand stroke |
 | `C` | Numbered marker |
 | `R` | Rectangle |
+| `D` | Redact; press again to toggle randomized pixelation or solid redaction |
 | `T` | Neucha text |
 | `O` | Drag an OCR region and copy recognized text |
 | `B` | Cycle backdrop |

--- a/capture.cpp
+++ b/capture.cpp
@@ -252,6 +252,12 @@ QVector<WindowTarget> parseWindows(const QByteArray &json,
 }
 
 void drawAnnotation(QPainter &painter, const Annotation &annotation) {
+  // Redactions replace source pixels in renderCapture before ordinary vector
+  // annotations are painted. They must never be approximated by a translucent
+  // overlay here because that could leave recoverable source data in exports.
+  if (annotation.kind == Annotation::Kind::Redaction)
+    return;
+
   const qreal width = std::max<qreal>(2.0, annotation.size);
   QPen pen(annotation.color, width, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
   painter.setPen(pen);
@@ -337,6 +343,138 @@ void drawAnnotation(QPainter &painter, const Annotation &annotation) {
   painter.setPen(annotation.color);
   painter.setBrush(Qt::NoBrush);
   painter.drawText(annotation.start, annotation.text);
+}
+
+quint32 nextRedactionRandom(quint32 &state) {
+  if (state == 0)
+    state = 0x6d2b79f5U;
+  state ^= state << 13;
+  state ^= state >> 17;
+  state ^= state << 5;
+  return state;
+}
+
+QRect redactionPixelRect(const Annotation &annotation, const QSize &imageSize,
+                         qreal scaleX, qreal scaleY,
+                         const QPointF &originOffset) {
+  const QRectF logical(annotation.start, annotation.end);
+  const QRectF normalized = logical.normalized();
+  const int left = static_cast<int>(
+      std::floor(normalized.left() * scaleX + originOffset.x()));
+  const int top = static_cast<int>(
+      std::floor(normalized.top() * scaleY + originOffset.y()));
+  const int right = static_cast<int>(
+      std::ceil(normalized.right() * scaleX + originOffset.x()));
+  const int bottom = static_cast<int>(
+      std::ceil(normalized.bottom() * scaleY + originOffset.y()));
+  return QRect(left, top, std::max(0, right - left), std::max(0, bottom - top))
+      .intersected(QRect(QPoint(), imageSize));
+}
+
+QVector<QColor> aggregateRedactionPalette(const QImage &image,
+                                          const QRect &region) {
+  struct Bucket {
+    quint64 red = 0;
+    quint64 green = 0;
+    quint64 blue = 0;
+    quint64 count = 0;
+  };
+  std::array<Bucket, 64> buckets{};
+  // A bounded, uniform sample keeps live dragging responsive on 4K captures.
+  // Coordinates are used only to choose samples; their positions are discarded
+  // before the synthetic mosaic is generated.
+  constexpr int maximumSamples = 4096;
+  const qreal regionArea =
+      static_cast<qreal>(region.width()) * static_cast<qreal>(region.height());
+  const qreal sampleStride = std::max<qreal>(
+      1.0, std::sqrt(regionArea / static_cast<qreal>(maximumSamples)));
+  for (qreal sampleY = region.top() + sampleStride / 2.0;
+       sampleY < region.bottom() + 1.0; sampleY += sampleStride) {
+    for (qreal sampleX = region.left() + sampleStride / 2.0;
+         sampleX < region.right() + 1.0; sampleX += sampleStride) {
+      const QColor color = image.pixelColor(
+          std::clamp(static_cast<int>(sampleX), region.left(), region.right()),
+          std::clamp(static_cast<int>(sampleY), region.top(), region.bottom()));
+      const int bucketIndex = (color.red() >> 6) * 16 +
+                              (color.green() >> 6) * 4 + (color.blue() >> 6);
+      Bucket &bucket = buckets.at(static_cast<std::size_t>(bucketIndex));
+      bucket.red += static_cast<quint64>(color.red());
+      bucket.green += static_cast<quint64>(color.green());
+      bucket.blue += static_cast<quint64>(color.blue());
+      ++bucket.count;
+    }
+  }
+
+  std::array<int, 64> order{};
+  for (int index = 0; index < static_cast<int>(order.size()); ++index)
+    order.at(static_cast<std::size_t>(index)) = index;
+  std::ranges::sort(order, [&buckets](int first, int second) {
+    return buckets.at(static_cast<std::size_t>(first)).count >
+           buckets.at(static_cast<std::size_t>(second)).count;
+  });
+
+  QVector<QColor> palette;
+  palette.reserve(6);
+  for (const int bucketIndex : order) {
+    const Bucket &bucket = buckets.at(static_cast<std::size_t>(bucketIndex));
+    if (bucket.count == 0)
+      break;
+    palette.push_back(QColor(static_cast<int>(bucket.red / bucket.count),
+                             static_cast<int>(bucket.green / bucket.count),
+                             static_cast<int>(bucket.blue / bucket.count),
+                             255));
+    if (palette.size() == 6)
+      break;
+  }
+  if (palette.isEmpty())
+    palette.push_back(QColor(QStringLiteral("#121216")));
+  return palette;
+}
+
+void applyRedactions(QImage &image, const QVector<Annotation> &annotations,
+                     qreal scaleX, qreal scaleY,
+                     const QPointF &originOffset = {}) {
+  for (const Annotation &annotation : annotations) {
+    if (annotation.kind != Annotation::Kind::Redaction)
+      continue;
+    const QRect region = redactionPixelRect(annotation, image.size(), scaleX,
+                                            scaleY, originOffset);
+    if (region.isEmpty())
+      continue;
+    QVector<QColor> palette;
+    if (annotation.redactionStyle == RedactionStyle::Pixelate)
+      palette = aggregateRedactionPalette(image, region);
+
+    // Finish all source reads before activating a painter on the same image.
+    QPainter painter(&image);
+    painter.setCompositionMode(QPainter::CompositionMode_Source);
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    if (annotation.redactionStyle == RedactionStyle::Solid) {
+      painter.fillRect(region, QColor(QStringLiteral("#121216")));
+      continue;
+    }
+
+    quint32 randomState = annotation.redactionSeed;
+    if (randomState == 0) {
+      randomState = static_cast<quint32>(region.x()) * 73856093U ^
+                    static_cast<quint32>(region.y()) * 19349663U ^
+                    static_cast<quint32>(region.width()) * 83492791U ^
+                    static_cast<quint32>(region.height()) * 2654435761U;
+    }
+    const int blockWidth = std::max(1, qRound(12.0 * scaleX));
+    const int blockHeight = std::max(1, qRound(12.0 * scaleY));
+    for (int y = region.top(); y <= region.bottom(); y += blockHeight) {
+      for (int x = region.left(); x <= region.right(); x += blockWidth) {
+        const QColor color = palette.at(
+            static_cast<qsizetype>(nextRedactionRandom(randomState) %
+                                   static_cast<quint32>(palette.size())));
+        painter.fillRect(QRect(x, y,
+                               std::min(blockWidth, region.right() - x + 1),
+                               std::min(blockHeight, region.bottom() - y + 1)),
+                         color);
+      }
+    }
+  }
 }
 
 QRect pixelSelection(const CaptureData &capture, const QRectF &selection) {
@@ -514,14 +652,27 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   const bool highDpi = capture.monitor.scale > 1.0;
   const qreal scaleX = highDpi ? capture.monitor.scale : sourceScaleX;
   const qreal scaleY = highDpi ? capture.monitor.scale : sourceScaleY;
+  const QPointF sourceOriginOffset(
+      selection.left() * sourceScaleX - pixels.left(),
+      selection.top() * sourceScaleY - pixels.top());
+  bool resized = false;
   if (highDpi) {
     const QSize impliedSize(std::max(1, qRound(selection.width() * scaleX)),
                             std::max(1, qRound(selection.height() * scaleY)));
     if (cropped.size() != impliedSize) {
+      // Remove sensitive source pixels before SmoothTransformation can blend
+      // them outside the final redaction boundary. The crop may begin between
+      // native pixels, so preserve that fractional origin in local coordinates.
+      applyRedactions(cropped, annotations, sourceScaleX, sourceScaleY,
+                      sourceOriginOffset);
       cropped = cropped.scaled(impliedSize, Qt::IgnoreAspectRatio,
                                Qt::SmoothTransformation);
+      resized = true;
     }
   }
+  applyRedactions(cropped, annotations, resized ? scaleX : sourceScaleX,
+                  resized ? scaleY : sourceScaleY,
+                  resized ? QPointF{} : sourceOriginOffset);
   const bool hasBackground = backgroundStyle != BackgroundStyle::None;
   const int marginX =
       hasBackground ? static_cast<int>(std::round(64.0 * scaleX)) : 0;

--- a/capture.hpp
+++ b/capture.hpp
@@ -35,6 +35,7 @@ struct CaptureData {
 };
 
 enum class BackgroundStyle { None, Aurora, Sunset, Lagoon, Violet };
+enum class RedactionStyle { Solid, Pixelate };
 
 struct Annotation {
   enum class Kind {
@@ -44,7 +45,8 @@ struct Annotation {
     Highlighter,
     Marker,
     Rectangle,
-    Text
+    Text,
+    Redaction
   };
 
   Kind kind = Kind::Arrow;
@@ -55,6 +57,10 @@ struct Annotation {
   qreal size = 4.0;
   int number = 0;
   QVector<QPointF> points;
+  RedactionStyle redactionStyle = RedactionStyle::Pixelate;
+  quint32 redactionSeed = 0;
+
+  bool operator==(const Annotation &) const = default;
 };
 
 [[nodiscard]] bool loadCaptureFonts();

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -139,6 +139,203 @@ bool runHighlighterRenderingCheck(QString &error) {
   }
   return true;
 }
+
+bool runSecureRedactionChecks(QString &error) {
+  error = QStringLiteral("Secure redaction rendering check failed");
+  CaptureData capture;
+  capture.monitor.scale = 1.0;
+  capture.monitor.pixelSize = {96, 72};
+  capture.source = QImage(96, 72, QImage::Format_RGB32);
+  for (int y = 0; y < capture.source.height(); ++y) {
+    for (int x = 0; x < capture.source.width(); ++x) {
+      capture.source.setPixelColor(
+          x, y, QColor((x * 3) % 256, (y * 5) % 256, ((x + y) * 7) % 256));
+    }
+  }
+  capture.preview = capture.source;
+
+  Annotation pixelate;
+  pixelate.kind = Annotation::Kind::Redaction;
+  pixelate.start = {12, 12};
+  pixelate.end = {84, 60};
+  pixelate.redactionStyle = RedactionStyle::Pixelate;
+  pixelate.redactionSeed = 0x1234abcdU;
+  const QRect redactionBounds(12, 12, 72, 48);
+  const QImage first = renderCapture(capture, QRectF(0, 0, 96, 72), {pixelate},
+                                     BackgroundStyle::None);
+  const QImage repeated = renderCapture(capture, QRectF(0, 0, 96, 72),
+                                        {pixelate}, BackgroundStyle::None);
+  if (first.isNull() || first != repeated ||
+      first.pixelColor(2, 2) != capture.source.pixelColor(2, 2))
+    return false;
+
+  // Every exported mosaic cell is a flat synthetic color. No fine-grained
+  // source pixels survive inside a cell.
+  constexpr int blockSize = 12;
+  for (int top = redactionBounds.top(); top <= redactionBounds.bottom();
+       top += blockSize) {
+    for (int left = redactionBounds.left(); left <= redactionBounds.right();
+         left += blockSize) {
+      const QColor cell = first.pixelColor(left, top);
+      if (cell.alpha() != 255)
+        return false;
+      const int bottom =
+          std::min(top + blockSize - 1, redactionBounds.bottom());
+      const int right = std::min(left + blockSize - 1, redactionBounds.right());
+      for (int y = top; y <= bottom; ++y) {
+        for (int x = left; x <= right; ++x) {
+          if (first.pixelColor(x, y) != cell)
+            return false;
+        }
+      }
+    }
+  }
+
+  // Mirroring the source preserves the region's aggregate palette but changes
+  // every spatial relationship. Identical redaction output proves the mosaic
+  // does not retain source-block positions.
+  CaptureData mirroredCapture = capture;
+  for (int y = 0; y < capture.source.height(); ++y) {
+    for (int x = 0; x < capture.source.width(); ++x) {
+      mirroredCapture.source.setPixelColor(
+          x, y, capture.source.pixelColor(capture.source.width() - x - 1, y));
+    }
+  }
+  mirroredCapture.preview = mirroredCapture.source;
+  const QImage mirrored = renderCapture(mirroredCapture, QRectF(0, 0, 96, 72),
+                                        {pixelate}, BackgroundStyle::None);
+  if (first.copy(redactionBounds) != mirrored.copy(redactionBounds))
+    return false;
+
+  Annotation differentSeed = pixelate;
+  ++differentSeed.redactionSeed;
+  const QImage reseeded = renderCapture(capture, QRectF(0, 0, 96, 72),
+                                        {differentSeed}, BackgroundStyle::None);
+  if (first.copy(redactionBounds) == reseeded.copy(redactionBounds))
+    return false;
+
+  Annotation solid = pixelate;
+  solid.redactionStyle = RedactionStyle::Solid;
+  const QImage solidOutput = renderCapture(capture, QRectF(0, 0, 96, 72),
+                                           {solid}, BackgroundStyle::None);
+  const QColor solidColor(QStringLiteral("#121216"));
+  for (int y = redactionBounds.top(); y <= redactionBounds.bottom(); ++y) {
+    for (int x = redactionBounds.left(); x <= redactionBounds.right(); ++x) {
+      if (solidOutput.pixelColor(x, y) != solidColor)
+        return false;
+    }
+  }
+
+  Annotation line;
+  line.kind = Annotation::Kind::Line;
+  line.start = {12, 36};
+  line.end = {83, 36};
+  line.color = Qt::white;
+  line.size = 4;
+  const QImage annotated = renderCapture(capture, QRectF(0, 0, 96, 72),
+                                         {solid, line}, BackgroundStyle::None);
+  if (annotated.pixelColor(48, 36) != QColor(Qt::white))
+    return false;
+
+  Annotation clipped = solid;
+  clipped.start = {-10, -10};
+  clipped.end = {20, 20};
+  const QImage clippedOutput = renderCapture(capture, QRectF(0, 0, 96, 72),
+                                             {clipped}, BackgroundStyle::None);
+  if (clippedOutput.pixelColor(0, 0) != solidColor ||
+      clippedOutput.pixelColor(21, 21) != capture.source.pixelColor(21, 21))
+    return false;
+
+  CaptureData highDpi = capture;
+  highDpi.monitor.scale = 2.0;
+  highDpi.monitor.pixelSize = {192, 144};
+  highDpi.source = capture.source.scaled(192, 144, Qt::IgnoreAspectRatio,
+                                         Qt::SmoothTransformation);
+  highDpi.preview = capture.source;
+  Annotation highDpiSolid = solid;
+  highDpiSolid.start = {10, 10};
+  highDpiSolid.end = {30, 30};
+  const QImage highDpiOutput = renderCapture(
+      highDpi, QRectF(0, 0, 96, 72), {highDpiSolid}, BackgroundStyle::None);
+  if (highDpiOutput.size() != QSize(192, 144) ||
+      highDpiOutput.pixelColor(20, 20) != solidColor ||
+      highDpiOutput.pixelColor(59, 59) != solidColor ||
+      highDpiOutput.pixelColor(61, 61) == solidColor)
+    return false;
+
+  // Fractional crop rounding can force a one-pixel smooth resize. Redact the
+  // native source first so protected colors cannot bleed just outside the
+  // final mask through the resampling kernel.
+  CaptureData fractional;
+  fractional.monitor.scale = 1.25;
+  fractional.preview = QImage(100, 100, QImage::Format_RGB32);
+  fractional.preview.fill(Qt::white);
+  fractional.source = QImage(125, 125, QImage::Format_RGB32);
+  fractional.source.fill(Qt::white);
+  for (int y = 13; y <= 38; ++y) {
+    for (int x = 13; x <= 38; ++x)
+      fractional.source.setPixelColor(x, y, Qt::red);
+  }
+  Annotation fractionalSolid;
+  fractionalSolid.kind = Annotation::Kind::Redaction;
+  fractionalSolid.redactionStyle = RedactionStyle::Solid;
+  fractionalSolid.start = {10, 10};
+  fractionalSolid.end = {30, 30};
+  const QImage fractionalOutput =
+      renderCapture(fractional, QRectF(1, 1, 81, 81), {fractionalSolid},
+                    BackgroundStyle::None);
+  const QColor outsideHorizontal = fractionalOutput.pixelColor(12, 11);
+  const QColor outsideVertical = fractionalOutput.pixelColor(11, 12);
+  if (fractionalOutput.size() != QSize(101, 101) ||
+      outsideHorizontal.red() != outsideHorizontal.green() ||
+      outsideHorizontal.green() != outsideHorizontal.blue() ||
+      outsideVertical.red() != outsideVertical.green() ||
+      outsideVertical.green() != outsideVertical.blue() ||
+      fractionalOutput.pixelColor(12, 12) != solidColor)
+    return false;
+
+  CaptureData matchingFractional;
+  matchingFractional.monitor.scale = 1.25;
+  matchingFractional.preview = QImage(160, 160, QImage::Format_RGB32);
+  matchingFractional.preview.fill(Qt::white);
+  matchingFractional.source = QImage(200, 200, QImage::Format_RGB32);
+  matchingFractional.source.fill(Qt::white);
+  for (int y = 13; y <= 26; ++y) {
+    for (int x = 13; x <= 26; ++x)
+      matchingFractional.source.setPixelColor(x, y, Qt::red);
+  }
+  Annotation matchingSolid;
+  matchingSolid.kind = Annotation::Kind::Redaction;
+  matchingSolid.redactionStyle = RedactionStyle::Solid;
+  matchingSolid.start = {10.75, 10.75};
+  matchingSolid.end = {20.75, 20.75};
+  const QImage matchingOutput =
+      renderCapture(matchingFractional, QRectF(0.08, 0.08, 79.68, 79.68),
+                    {matchingSolid}, BackgroundStyle::None);
+  if (matchingOutput.size() != QSize(100, 100) ||
+      matchingOutput.pixelColor(26, 26) != solidColor)
+    return false;
+
+  CaptureData nonIntegralSourceScale;
+  nonIntegralSourceScale.monitor.scale = 1.5;
+  nonIntegralSourceScale.preview = QImage(1707, 100, QImage::Format_RGB32);
+  nonIntegralSourceScale.preview.fill(Qt::white);
+  nonIntegralSourceScale.source = QImage(2561, 150, QImage::Format_RGB32);
+  nonIntegralSourceScale.source.fill(Qt::white);
+  for (int y = 0; y < nonIntegralSourceScale.source.height(); ++y)
+    nonIntegralSourceScale.source.setPixelColor(1500, y, Qt::red);
+  Annotation sourceScaleSolid;
+  sourceScaleSolid.kind = Annotation::Kind::Redaction;
+  sourceScaleSolid.redactionStyle = RedactionStyle::Solid;
+  sourceScaleSolid.start = {0, 0};
+  sourceScaleSolid.end = {1000, 100};
+  const QImage sourceScaleOutput =
+      renderCapture(nonIntegralSourceScale, QRectF(0, 0, 1707, 100),
+                    {sourceScaleSolid}, BackgroundStyle::None);
+  if (sourceScaleOutput.pixelColor(1500, 50) != solidColor)
+    return false;
+  return true;
+}
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
 int main(int argc, char **argv) {
@@ -153,6 +350,10 @@ int main(int argc, char **argv) {
   if (!runHighlighterRenderingCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 69;
+  }
+  if (!runSecureRedactionChecks(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 71;
   }
   const QString outputRoot =
       argc > 1 ? QString::fromLocal8Bit(argv[1])
@@ -441,11 +642,155 @@ int main(int argc, char **argv) {
           outputRoot + QStringLiteral("-window-keyboard.png"), "PNG"))
     return 2;
 
+  {
+    CaptureEditor redactionEditor(capture);
+    redactionEditor.resize(800, 600);
+    redactionEditor.show();
+    application.processEvents();
+    QTest::mousePress(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(100, 100));
+    QTest::mouseMove(&redactionEditor, QPoint(650, 470), 20);
+    QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(650, 470));
+    const QImage beforeRedaction(snapshotPath);
+    QTest::keyClick(&redactionEditor, Qt::Key_D);
+    QTest::mousePress(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(300, 200));
+    QTest::mouseMove(&redactionEditor, QPoint(420, 200), 20);
+    QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(420, 200));
+    application.processEvents();
+    if (QImage(snapshotPath) != beforeRedaction)
+      return 72;
+    QTest::mousePress(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(300, 200));
+    QTest::mouseMove(&redactionEditor, QPoint(420, 260), 20);
+    QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(420, 260));
+    application.processEvents();
+    const QImage pixelatedRedaction(snapshotPath);
+    if (pixelatedRedaction.isNull() || pixelatedRedaction == beforeRedaction)
+      return 73;
+
+    QTest::mouseClick(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(360, 230));
+    QTest::keyClick(&redactionEditor, Qt::Key_D);
+    application.processEvents();
+    const QImage solidRedaction(snapshotPath);
+    if (solidRedaction.isNull() || solidRedaction == pixelatedRedaction)
+      return 74;
+    QTest::keyClick(&redactionEditor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != pixelatedRedaction)
+      return 75;
+    QTest::keyClick(&redactionEditor, Qt::Key_Y, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != solidRedaction)
+      return 76;
+
+    QTest::mousePress(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(360, 230));
+    QTest::mouseMove(&redactionEditor, QPoint(380, 245), 20);
+    QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(380, 245));
+    application.processEvents();
+    const QImage movedRedaction(snapshotPath);
+    if (movedRedaction.isNull() || movedRedaction == solidRedaction)
+      return 77;
+    QTest::keyClick(&redactionEditor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != solidRedaction)
+      return 78;
+
+    QTest::mousePress(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(300, 200));
+    QTest::mouseMove(&redactionEditor, QPoint(280, 190), 20);
+    QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(280, 190));
+    application.processEvents();
+    if (QImage(snapshotPath) == solidRedaction ||
+        !redactionEditor.grab().save(
+            outputRoot + QStringLiteral("-secure-redaction.png"), "PNG"))
+      return 79;
+    QTest::mousePress(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(280, 190));
+    QTest::mouseMove(&redactionEditor, QPoint(420, 190), 20);
+    QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(420, 190));
+    application.processEvents();
+    if (QImage(snapshotPath) == beforeRedaction)
+      return 81;
+  }
+
+  {
+    CaptureEditor overlapEditor(capture);
+    overlapEditor.resize(800, 600);
+    overlapEditor.show();
+    application.processEvents();
+    QTest::mousePress(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(100, 100));
+    QTest::mouseMove(&overlapEditor, QPoint(650, 470), 20);
+    QTest::mouseRelease(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(650, 470));
+    QTest::keyClick(&overlapEditor, Qt::Key_L);
+    QTest::mousePress(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(300, 300));
+    QTest::mouseMove(&overlapEditor, QPoint(500, 300), 20);
+    QTest::mouseRelease(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(500, 300));
+    QTest::keyClick(&overlapEditor, Qt::Key_D);
+    QTest::mousePress(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(350, 270));
+    QTest::mouseMove(&overlapEditor, QPoint(450, 330), 20);
+    QTest::mouseRelease(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(450, 330));
+    QTest::mouseClick(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(400, 300));
+    application.processEvents();
+    const QImage overlapUi = overlapEditor.grab().toImage();
+    if (overlapUi.pixelColor(300, 300) != QColor(QStringLiteral("#0a84ff")) ||
+        overlapUi.pixelColor(500, 300) != QColor(QStringLiteral("#0a84ff")) ||
+        !overlapUi.save(outputRoot + QStringLiteral("-redaction-overlap.png"),
+                        "PNG"))
+      return 80;
+
+    QTest::keyClick(&overlapEditor, Qt::Key_R);
+    QTest::mousePress(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(330, 250));
+    QTest::mouseMove(&overlapEditor, QPoint(470, 350), 20);
+    QTest::mouseRelease(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(470, 350));
+    QTest::mouseClick(&overlapEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(400, 285));
+    application.processEvents();
+    const QImage enclosedRedactionUi = overlapEditor.grab().toImage();
+    if (enclosedRedactionUi.pixelColor(350, 270) !=
+            QColor(QStringLiteral("#0a84ff")) ||
+        enclosedRedactionUi.pixelColor(450, 330) !=
+            QColor(QStringLiteral("#0a84ff")))
+      return 84;
+  }
+
   CaptureEditor fullscreenEditor(capture,
                                  CaptureEditor::CaptureMode::Fullscreen);
   fullscreenEditor.resize(800, 600);
   fullscreenEditor.show();
   application.processEvents();
+  CaptureEditor compactToolbarEditor(capture,
+                                     CaptureEditor::CaptureMode::Fullscreen);
+  compactToolbarEditor.resize(720, 600);
+  compactToolbarEditor.show();
+  application.processEvents();
+  QTest::mouseMove(&compactToolbarEditor, QPoint(20, 45), 20);
+  application.processEvents();
+  QTest::mouseMove(&compactToolbarEditor, QPoint(700, 45), 20);
+  application.processEvents();
+  const QImage compactToolbarUi = compactToolbarEditor.grab().toImage();
+  if (compactToolbarUi.pixelColor(20, 45).alpha() < 240 ||
+      compactToolbarUi.pixelColor(700, 45).alpha() < 240 ||
+      !compactToolbarUi.save(
+          outputRoot + QStringLiteral("-compact-toolbar.png"), "PNG"))
+    return 83;
   CaptureEditor windowModeEditor(capture, CaptureEditor::CaptureMode::Window);
   windowModeEditor.resize(800, 600);
   windowModeEditor.show();

--- a/editor.cpp
+++ b/editor.cpp
@@ -21,6 +21,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QProcess>
+#include <QRandomGenerator>
 #include <QScreen>
 #include <QTimer>
 #include <QWheelEvent>
@@ -35,11 +36,20 @@ constexpr std::array<const char *, 6> kColorNames{
     "#ff375f", "#ff9f0a", "#ffd60a", "#30d158", "#0a84ff", "#bf5af2"};
 constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
-constexpr qreal kToolbarWidth = 680;
+constexpr qreal kToolbarWidth = 760;
+constexpr qreal kMinimumRedactionExtent = 5.0;
+
+qreal toolbarScale(qreal availableWidth) {
+  constexpr qreal sideMargins = 16.0;
+  return std::min<qreal>(
+      1.0,
+      std::max<qreal>(0.1, (availableWidth - sideMargins) / kToolbarWidth));
+}
 
 bool hasEndpointHandles(Annotation::Kind kind) {
   return kind == Annotation::Kind::Arrow || kind == Annotation::Kind::Line ||
-         kind == Annotation::Kind::Rectangle;
+         kind == Annotation::Kind::Rectangle ||
+         kind == Annotation::Kind::Redaction;
 }
 
 bool showsSelectionBounds(Annotation::Kind kind) {
@@ -73,12 +83,34 @@ QString toolAction(CaptureEditor::Tool tool) {
     return QStringLiteral("tool-marker");
   case CaptureEditor::Tool::Rectangle:
     return QStringLiteral("tool-rectangle");
+  case CaptureEditor::Tool::Redact:
+    return QStringLiteral("tool-redact");
   case CaptureEditor::Tool::Text:
     return QStringLiteral("tool-text");
   case CaptureEditor::Tool::Ocr:
     return QStringLiteral("tool-ocr");
   }
   return {};
+}
+
+QString redactionStyleName(RedactionStyle style) {
+  return style == RedactionStyle::Solid ? QStringLiteral("Solid")
+                                        : QStringLiteral("Pixelate");
+}
+
+qreal constrainedRedactionCoordinate(qreal candidate, qreal fixed,
+                                     qreal original) {
+  return original <= fixed
+             ? std::min(candidate, fixed - kMinimumRedactionExtent)
+             : std::max(candidate, fixed + kMinimumRedactionExtent);
+}
+
+QPointF constrainedRedactionEndpoint(const QPointF &candidate,
+                                     const QPointF &fixed,
+                                     const QPointF &original) {
+  return {
+      constrainedRedactionCoordinate(candidate.x(), fixed.x(), original.x()),
+      constrainedRedactionCoordinate(candidate.y(), fixed.y(), original.y())};
 }
 
 void drawStatusPill(QPainter &painter, const QRect &bounds,
@@ -301,14 +333,13 @@ QRectF CaptureEditor::annotationBounds(const Annotation &annotation) const {
 }
 
 int CaptureEditor::annotationAt(const QPointF &point) const {
-  for (int index = annotations_.size() - 1; index >= 0; --index) {
-    const Annotation &annotation = annotations_.at(index);
+  const auto containsPoint = [this, &point](const Annotation &annotation) {
     if (annotation.kind == Annotation::Kind::Arrow ||
         annotation.kind == Annotation::Kind::Line) {
       const QPointF delta = annotation.end - annotation.start;
       const qreal lengthSquared = delta.x() * delta.x() + delta.y() * delta.y();
       if (lengthSquared <= 0)
-        continue;
+        return false;
       const QPointF fromStart = point - annotation.start;
       const qreal t =
           std::clamp((fromStart.x() * delta.x() + fromStart.y() * delta.y()) /
@@ -317,7 +348,7 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
       const QPointF closest = annotation.start + delta * t;
       if (QLineF(point, closest).length() <=
           std::max<qreal>(8.0, annotation.size + 4.0))
-        return index;
+        return true;
     } else if (isStrokeKind(annotation.kind)) {
       const qreal tolerance = strokeHitTolerance(annotation);
       for (int pointIndex = 1; pointIndex < annotation.points.size();
@@ -336,12 +367,35 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
                        0.0, 1.0);
         const QPointF closest = segment.p1() + delta * t;
         if (QLineF(point, closest).length() <= tolerance)
-          return index;
+          return true;
       }
-    } else if (annotationBounds(annotation)
-                   .adjusted(-7, -7, 7, 7)
-                   .contains(point)) {
-      return index;
+    } else {
+      const QRectF bounds = annotationBounds(annotation);
+      if (annotation.kind == Annotation::Kind::Rectangle) {
+        const qreal tolerance = std::max<qreal>(7.0, annotation.size + 3.0);
+        const QRectF outer =
+            bounds.adjusted(-tolerance, -tolerance, tolerance, tolerance);
+        const QRectF inner =
+            bounds.adjusted(tolerance, tolerance, -tolerance, -tolerance);
+        return outer.contains(point) &&
+               (inner.isEmpty() || !inner.contains(point));
+      }
+      if (bounds.adjusted(-7, -7, 7, 7).contains(point))
+        return true;
+    }
+    return false;
+  };
+
+  // Redactions are always rendered into the source underlay, regardless of
+  // insertion order. Search visible vector annotations first so hit testing
+  // follows that same paint order when their bounds overlap a redaction.
+  for (const bool redactionsOnly : {false, true}) {
+    for (int index = annotations_.size() - 1; index >= 0; --index) {
+      const Annotation &annotation = annotations_.at(index);
+      if ((annotation.kind == Annotation::Kind::Redaction) != redactionsOnly)
+        continue;
+      if (containsPoint(annotation))
+        return index;
     }
   }
   return -1;
@@ -353,13 +407,22 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
   recordEdit();
   Annotation &annotation = annotations_[selectedAnnotation_];
   const QPointF center = annotationBounds(annotation).center();
-  const auto scaledPoint = [center, factor](const QPointF &point) {
-    return center + (point - center) * factor;
+  qreal geometryFactor = factor;
+  if (annotation.kind == Annotation::Kind::Redaction) {
+    const QRectF bounds = annotationBounds(annotation);
+    if (bounds.width() > 0 && bounds.height() > 0) {
+      geometryFactor =
+          std::max({factor, kMinimumRedactionExtent / bounds.width(),
+                    kMinimumRedactionExtent / bounds.height()});
+    }
+  }
+  const auto scaledPoint = [center, geometryFactor](const QPointF &point) {
+    return center + (point - center) * geometryFactor;
   };
   if (hasEndpointHandles(annotation.kind)) {
     annotation.start = scaledPoint(annotation.start);
     annotation.end = scaledPoint(annotation.end);
-    annotation.size = std::clamp(annotation.size * factor, 2.0, 30.0);
+    annotation.size = std::clamp(annotation.size * geometryFactor, 2.0, 30.0);
   } else if (isStrokeKind(annotation.kind)) {
     for (QPointF &point : annotation.points)
       point = scaledPoint(point);
@@ -380,12 +443,14 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
 }
 
 QRectF CaptureEditor::colorPaletteRect() const {
-  constexpr qreal toolbarWidth = kToolbarWidth;
-  constexpr qreal buttonHeight = 36;
+  const qreal scale = toolbarScale(width());
+  const qreal toolbarWidth = kToolbarWidth * scale;
+  const qreal buttonHeight = 36 * scale;
   const qreal toolbarX = (width() - toolbarWidth) / 2.0;
   const qreal toolbarY =
       std::max<qreal>(10, editImageRect().top() - buttonHeight - 10);
-  const QRectF anchor(toolbarX + 320, toolbarY, 36, buttonHeight);
+  const QRectF anchor(toolbarX + 360 * scale, toolbarY, 36 * scale,
+                      buttonHeight);
   const qreal paletteWidth = 204;
   const qreal x = std::clamp(anchor.center().x() - paletteWidth / 2.0, 8.0,
                              std::max(8.0, width() - paletteWidth - 8.0));
@@ -403,12 +468,14 @@ QRectF CaptureEditor::customColorPanelRect() const {
 }
 
 QRectF CaptureEditor::textSizePanelRect() const {
-  constexpr qreal toolbarWidth = kToolbarWidth;
-  constexpr qreal buttonHeight = 36;
+  const qreal scale = toolbarScale(width());
+  const qreal toolbarWidth = kToolbarWidth * scale;
+  const qreal buttonHeight = 36 * scale;
   const qreal toolbarX = (width() - toolbarWidth) / 2.0;
   const qreal toolbarY =
       std::max<qreal>(10, editImageRect().top() - buttonHeight - 10);
-  const QRectF anchor(toolbarX + 280, toolbarY, 36, buttonHeight);
+  const QRectF anchor(toolbarX + 320 * scale, toolbarY, 36 * scale,
+                      buttonHeight);
   return {anchor.center().x() - 51, anchor.bottom() + 6, 102, 34};
 }
 
@@ -432,7 +499,9 @@ void CaptureEditor::applyCustomColor(const QPointF &position) {
   }
   customColor_ = QColor::fromHsvF(customHue_, saturation, value);
   usingCustomColor_ = true;
-  if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size()) {
+  if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+      annotations_.at(selectedAnnotation_).kind !=
+          Annotation::Kind::Redaction) {
     recordEdit();
     annotations_[selectedAnnotation_].color = customColor_;
     persistSnapshot();
@@ -570,16 +639,18 @@ int CaptureEditor::windowInDirection(int current, int key) const {
 
 QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   QVector<ToolbarButton> buttons;
-  const qreal height = 36;
-  const qreal gap = 4;
-  const qreal total = kToolbarWidth;
+  const qreal scale = toolbarScale(width());
+  const qreal height = 36 * scale;
+  const qreal gap = 4 * scale;
+  const qreal total = kToolbarWidth * scale;
   qreal x = (width() - total) / 2.0;
   const qreal y = std::max<qreal>(10, editImageRect().top() - height - 10);
   auto add = [&](qreal buttonWidth, QString action, QString label,
                  QString tooltip, QColor color = {}) {
-    buttons.push_back({QRectF(x, y, buttonWidth, height), std::move(action),
+    const qreal scaledWidth = buttonWidth * scale;
+    buttons.push_back({QRectF(x, y, scaledWidth, height), std::move(action),
                        std::move(label), std::move(tooltip), color});
-    x += buttonWidth + gap;
+    x += scaledWidth + gap;
   };
 
   add(36, QStringLiteral("tool-select"), {},
@@ -601,6 +672,9 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
           .arg(qRound(annotationSize_)));
   add(36, QStringLiteral("tool-rectangle"), {},
       QStringLiteral("Rectangle · R"));
+  add(36, QStringLiteral("tool-redact"), {},
+      QStringLiteral("Redact · D · %1 · D again toggles")
+          .arg(redactionStyleName(redactionStyle_)));
   add(36, QStringLiteral("tool-text"), {},
       QStringLiteral("Neucha text · T · %1 · Wheel")
           .arg(QString::fromLatin1(
@@ -993,7 +1067,18 @@ void CaptureEditor::handleToolbar(const QString &action) {
     tool_ = Tool::Marker;
   else if (action == QStringLiteral("tool-rectangle"))
     tool_ = Tool::Rectangle;
-  else if (action == QStringLiteral("tool-text"))
+  else if (action == QStringLiteral("tool-redact")) {
+    if (tool_ == Tool::Redact) {
+      redactionStyle_ = redactionStyle_ == RedactionStyle::Solid
+                            ? RedactionStyle::Pixelate
+                            : RedactionStyle::Solid;
+    } else {
+      tool_ = Tool::Redact;
+    }
+    selectedAnnotation_ = -1;
+    setStatus(QStringLiteral("Redact: %1 · drag sensitive content · D toggles")
+                  .arg(redactionStyleName(redactionStyle_)));
+  } else if (action == QStringLiteral("tool-text"))
     tool_ = Tool::Text;
   else if (action == QStringLiteral("tool-ocr"))
     tool_ = Tool::Ocr;
@@ -1003,7 +1088,9 @@ void CaptureEditor::handleToolbar(const QString &action) {
     colorIndex_ = std::clamp(action.sliced(6).toInt(), 0, 5);
     usingCustomColor_ = false;
     customColorPickerOpen_ = false;
-    if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size()) {
+    if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+        annotations_.at(selectedAnnotation_).kind !=
+            Annotation::Kind::Redaction) {
       recordEdit();
       annotations_[selectedAnnotation_].color = annotationColor();
       persistSnapshot();
@@ -1124,6 +1211,32 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Marker;
   } else if (event->key() == Qt::Key_R) {
     tool_ = Tool::Rectangle;
+  } else if (event->key() == Qt::Key_D) {
+    if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+        annotations_.at(selectedAnnotation_).kind ==
+            Annotation::Kind::Redaction) {
+      recordEdit();
+      Annotation &redaction = annotations_[selectedAnnotation_];
+      redaction.redactionStyle =
+          redaction.redactionStyle == RedactionStyle::Solid
+              ? RedactionStyle::Pixelate
+              : RedactionStyle::Solid;
+      setStatus(QStringLiteral("Selected redaction: %1 · D toggles")
+                    .arg(redactionStyleName(redaction.redactionStyle)));
+      persistSnapshot();
+    } else {
+      if (tool_ == Tool::Redact) {
+        redactionStyle_ = redactionStyle_ == RedactionStyle::Solid
+                              ? RedactionStyle::Pixelate
+                              : RedactionStyle::Solid;
+      } else {
+        tool_ = Tool::Redact;
+      }
+      selectedAnnotation_ = -1;
+      setStatus(
+          QStringLiteral("Redact: %1 · drag sensitive content · D toggles")
+              .arg(redactionStyleName(redactionStyle_)));
+    }
   } else if (event->key() == Qt::Key_T) {
     tool_ = Tool::Text;
   } else if (event->key() == Qt::Key_O) {
@@ -1141,7 +1254,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if (event->key() >= Qt::Key_1 && event->key() <= Qt::Key_6) {
     colorIndex_ = event->key() - Qt::Key_1;
     usingCustomColor_ = false;
-    if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size()) {
+    if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+        annotations_.at(selectedAnnotation_).kind !=
+            Annotation::Kind::Redaction) {
       recordEdit();
       annotations_[selectedAnnotation_].color = annotationColor();
       persistSnapshot();
@@ -1225,11 +1340,20 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
             strokePoint += delta;
         }
       } else if (interaction_ == Interaction::ResizeStart) {
-        if (hasEndpointHandles(annotation.kind))
-          annotation.start = point;
+        if (hasEndpointHandles(annotation.kind)) {
+          annotation.start =
+              annotation.kind == Annotation::Kind::Redaction
+                  ? constrainedRedactionEndpoint(point, annotation.end,
+                                                 originalAnnotation_.start)
+                  : point;
+        }
       } else if (interaction_ == Interaction::ResizeEnd) {
         if (hasEndpointHandles(annotation.kind)) {
-          annotation.end = point;
+          annotation.end =
+              annotation.kind == Annotation::Kind::Redaction
+                  ? constrainedRedactionEndpoint(point, annotation.start,
+                                                 originalAnnotation_.end)
+                  : point;
         } else if (isStrokeKind(annotation.kind)) {
           const QRectF originalBounds = annotationBounds(originalAnnotation_);
           const qreal scaleX =
@@ -1434,6 +1558,11 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
   } else {
     dragStart_ = point;
     dragging_ = true;
+    if (tool_ == Tool::Redact) {
+      activeRedactionSeed_ = QRandomGenerator::system()->generate();
+      if (activeRedactionSeed_ == 0)
+        activeRedactionSeed_ = 1;
+    }
     if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
       freehandPoints_.clear();
       freehandPoints_.reserve(256);
@@ -1521,23 +1650,42 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     update();
     return;
   }
-  if (QLineF(dragStart_, end).length() > 4) {
+  const QRectF draggedRect(dragStart_, end);
+  const bool validRedaction =
+      tool_ != Tool::Redact ||
+      (draggedRect.normalized().width() >= kMinimumRedactionExtent &&
+       draggedRect.normalized().height() >= kMinimumRedactionExtent);
+  if (QLineF(dragStart_, end).length() > 4 && validRedaction) {
     recordEdit();
     Annotation annotation;
-    annotation.kind = tool_ == Tool::Rectangle
-                          ? Annotation::Kind::Rectangle
-                          : (tool_ == Tool::Line ? Annotation::Kind::Line
-                                                 : Annotation::Kind::Arrow);
+    if (tool_ == Tool::Redact) {
+      annotation.kind = Annotation::Kind::Redaction;
+      annotation.redactionStyle = redactionStyle_;
+      annotation.redactionSeed = activeRedactionSeed_;
+    } else {
+      annotation.kind = tool_ == Tool::Rectangle
+                            ? Annotation::Kind::Rectangle
+                            : (tool_ == Tool::Line ? Annotation::Kind::Line
+                                                   : Annotation::Kind::Arrow);
+    }
     annotation.start = dragStart_;
     annotation.end = end;
     annotation.color = annotationColor();
     annotation.size = annotationSize_;
     annotations_.push_back(std::move(annotation));
     selectedAnnotation_ = -1;
+    const bool redacted = tool_ == Tool::Redact;
     tool_ = Tool::Select;
-    setStatus(QStringLiteral("Layer added · Select tool chooses layers"));
+    setStatus(redacted
+                  ? QStringLiteral("%1 redaction added · select to move or "
+                                   "resize · D toggles style")
+                        .arg(redactionStyleName(redactionStyle_))
+                  : QStringLiteral("Layer added · Select tool chooses layers"));
     persistSnapshot();
     updatePointerCursor();
+  } else if (tool_ == Tool::Redact) {
+    setStatus(QStringLiteral(
+        "Redaction needs both width and height · drag a rectangle"));
   }
   dragging_ = false;
   update();
@@ -1695,9 +1843,35 @@ void CaptureEditor::paintEdit(QPainter &painter) {
 
   QPainterPath clip;
   clip.addRoundedRect(image, hasBackground ? 10 : 0, hasBackground ? 10 : 0);
+  QVector<Annotation> redactions;
+  for (const Annotation &annotation : annotations_) {
+    if (annotation.kind == Annotation::Kind::Redaction)
+      redactions.push_back(annotation);
+  }
+  if (dragging_ && tool_ == Tool::Redact) {
+    Annotation preview;
+    preview.kind = Annotation::Kind::Redaction;
+    preview.start = dragStart_;
+    preview.end = toAnnotationPoint(cursor_);
+    preview.redactionStyle = redactionStyle_;
+    preview.redactionSeed = activeRedactionSeed_;
+    redactions.push_back(std::move(preview));
+  }
   painter.save();
   painter.setClipPath(clip);
-  painter.drawImage(image, capture_.source, sourceRect(selection_));
+  if (redactions.isEmpty()) {
+    painter.drawImage(image, capture_.source, sourceRect(selection_));
+  } else {
+    if (redactionPreviewCache_.isNull() ||
+        cachedRedactionSelection_ != selection_ ||
+        cachedPreviewRedactions_ != redactions) {
+      cachedRedactionSelection_ = selection_;
+      cachedPreviewRedactions_ = redactions;
+      redactionPreviewCache_ = renderCapture(capture_, selection_, redactions,
+                                             BackgroundStyle::None);
+    }
+    painter.drawImage(image, redactionPreviewCache_);
+  }
   painter.restore();
 
   painter.save();
@@ -1706,10 +1880,11 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   painter.save();
   painter.setClipRect(QRectF(QPointF(), selection_.size()));
   for (int index = 0; index < annotations_.size(); ++index) {
-    if (index != editingAnnotation_)
+    if (index != editingAnnotation_ &&
+        annotations_.at(index).kind != Annotation::Kind::Redaction)
       paintAnnotation(painter, annotations_.at(index));
   }
-  if (dragging_ && tool_ != Tool::Select) {
+  if (dragging_ && tool_ != Tool::Select && tool_ != Tool::Redact) {
     Annotation preview;
     if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
       preview.kind = tool_ == Tool::Highlighter ? Annotation::Kind::Highlighter
@@ -1887,7 +2062,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
        {QStringLiteral("L"), QStringLiteral("Line")},
        {QStringLiteral("F / H"), QStringLiteral("Freehand / Highlighter")},
        {QStringLiteral("C"), QStringLiteral("Marker")},
-       {QStringLiteral("R"), QStringLiteral("Rectangle")},
+       {QStringLiteral("R / D"), QStringLiteral("Rectangle / Redact")},
        {QStringLiteral("T"), QStringLiteral("Text")},
        {QStringLiteral("Double click"), QStringLiteral("Edit text layer")},
        {QStringLiteral("1–6"), QStringLiteral("Color")},
@@ -1905,17 +2080,24 @@ void CaptureEditor::paintEdit(QPainter &painter) {
                        hoveredButton->tooltip);
   } else if (tool_ == Tool::Arrow || tool_ == Tool::Line ||
              tool_ == Tool::Freehand || tool_ == Tool::Highlighter ||
-             tool_ == Tool::Marker || tool_ == Tool::Text) {
+             tool_ == Tool::Marker || tool_ == Tool::Redact ||
+             tool_ == Tool::Text) {
     const QString selectedAction = toolAction(tool_);
     for (const ToolbarButton &button : buttons) {
       if (button.action == selectedAction) {
-        const QString tooltip =
-            tool_ == Tool::Text
-                ? QStringLiteral("Neucha · S  M  L · current %1 · Scroll wheel")
-                      .arg(QString::fromLatin1(kTextSizeNames.at(
-                          static_cast<std::size_t>(textSizeIndex_))))
-                : QStringLiteral("Size %1 · Scroll wheel")
-                      .arg(qRound(annotationSize_));
+        QString tooltip;
+        if (tool_ == Tool::Text) {
+          tooltip =
+              QStringLiteral("Neucha · S  M  L · current %1 · Scroll wheel")
+                  .arg(QString::fromLatin1(kTextSizeNames.at(
+                      static_cast<std::size_t>(textSizeIndex_))));
+        } else if (tool_ == Tool::Redact) {
+          tooltip = QStringLiteral("Redact · %1 · D toggles style")
+                        .arg(redactionStyleName(redactionStyle_));
+        } else {
+          tooltip = QStringLiteral("Size %1 · Scroll wheel")
+                        .arg(qRound(annotationSize_));
+        }
         drawInstantTooltip(painter, rect(), button.rect, tooltip);
         break;
       }

--- a/editor.hpp
+++ b/editor.hpp
@@ -41,6 +41,7 @@ public:
     Highlighter,
     Marker,
     Rectangle,
+    Redact,
     Text,
     Ocr
   };
@@ -151,6 +152,11 @@ private:
   int nextMarker_ = 1;
   qreal annotationSize_ = 4.0;
   int textSizeIndex_ = 1;
+  RedactionStyle redactionStyle_ = RedactionStyle::Pixelate;
+  quint32 activeRedactionSeed_ = 0;
+  QRectF cachedRedactionSelection_;
+  QVector<Annotation> cachedPreviewRedactions_;
+  QImage redactionPreviewCache_;
   QVector<Annotation> annotations_;
   int selectedAnnotation_ = -1;
   int editingAnnotation_ = -1;

--- a/icons.cpp
+++ b/icons.cpp
@@ -56,6 +56,24 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
                      QStringLiteral("1"));
   } else if (action == QStringLiteral("tool-rectangle")) {
     painter.drawRoundedRect(QRectF(4, 4, 16, 16), 2, 2);
+  } else if (action == QStringLiteral("tool-redact")) {
+    QPainterPath shield;
+    shield.moveTo(12, 3);
+    shield.lineTo(20, 6);
+    shield.lineTo(19, 13);
+    shield.cubicTo(18.5, 17, 15.5, 20, 12, 21);
+    shield.cubicTo(8.5, 20, 5.5, 17, 5, 13);
+    shield.lineTo(4, 6);
+    shield.closeSubpath();
+    painter.drawPath(shield);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(color);
+    for (int y = 8; y <= 14; y += 3) {
+      for (int x = 8; x <= 14; x += 3) {
+        if ((x + y) % 2 == 0)
+          painter.drawRect(QRectF(x, y, 3, 3));
+      }
+    }
   } else if (action == QStringLiteral("tool-text")) {
     painter.drawLine(QPointF(5, 5), QPointF(19, 5));
     painter.drawLine(QPointF(12, 5), QPointF(12, 19));


### PR DESCRIPTION
## Summary

- Add solid and randomized non-spatial pixelation redaction tools.
- Apply redactions to source pixels before scaling and before other annotations.
- Support selection, move, resize, delete, undo, redo, and style toggling.
- Add responsive controls and smoke coverage for redaction rendering and interaction.

## Why

Screenshots need a safe way to remove sensitive pixels before copy, save, or pin. Applying the mask before fractional-DPI scaling also prevents source colors from bleeding across redaction boundaries.

## Checks

- `cmake --build build --parallel`
- `QT_QPA_PLATFORM=offscreen ./build/omasnap-smoke`
- `codex-review clean: no accepted/actionable findings reported`
