### PR TITLE
feat: add spotlight/loupe annotation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   capture stays in the window picker; Omasnap never substitutes a crop of the desktop.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
 - Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
-  rectangles, numbered markers, and editable Neucha text.
+  spotlight/loupe lenses, rectangles, numbered markers, and editable Neucha text.
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
@@ -208,6 +208,8 @@ Install the corresponding Tesseract language data before adding a language to
 | `A` | Arrow |
 | `L` | Straight line |
 | `F` | Freehand stroke |
+| `H` | Translucent highlighter stroke |
+| `S` | Spotlight/loupe; wheel adjusts magnification after selection |
 | `C` | Numbered marker |
 | `R` | Rectangle |
 | `T` | Neucha text |
@@ -270,8 +272,8 @@ QT_QPA_PLATFORM=offscreen \
 
 The smoke executable exercises region/window/fullscreen startup modes, capture selection,
 temporary snapshot updates, annotation tools, undo/redo, vector movement and scaling,
-text editing, OCR, native-DPI output, endpoint-only line selection, and external crop
-handles.
+spotlight/loupe rendering, text editing, OCR, native-DPI output, endpoint-only line
+selection, and external crop handles.
 
 `.github/workflows/build-linux.yml` performs the same release build and interaction smoke
 in an Arch Linux container, stages the CMake installation, and uploads a versioned Linux

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   capture stays in the window picker; Omasnap never substitutes a crop of the desktop.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
 - Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
-  spotlight/loupe lenses, rectangles, numbered markers, and editable Neucha text.
+  ellipse, rectangle, or rounded-rectangle spotlight/loupe lenses, numbered markers,
+  and editable Neucha text.
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
@@ -209,7 +210,7 @@ Install the corresponding Tesseract language data before adding a language to
 | `L` | Straight line |
 | `F` | Freehand stroke |
 | `H` | Translucent highlighter stroke |
-| `S` | Spotlight/loupe; wheel adjusts magnification after selection |
+| `S` | Spotlight/loupe; choose its shape from the popover, then use the wheel for magnification |
 | `C` | Numbered marker |
 | `R` | Rectangle |
 | `T` | Neucha text |

--- a/capture.cpp
+++ b/capture.cpp
@@ -370,6 +370,23 @@ void paintAnnotation(QPainter &painter, const Annotation &annotation) {
   drawAnnotation(painter, annotation);
 }
 
+QPainterPath spotlightPath(const Annotation &annotation) {
+  const QRectF bounds = QRectF(annotation.start, annotation.end).normalized();
+  QPainterPath path;
+  if (annotation.spotlightShape == SpotlightShape::Ellipse) {
+    path.addEllipse(bounds);
+  } else if (annotation.spotlightShape == SpotlightShape::RoundedRectangle) {
+    const qreal shorterEdge = std::min(bounds.width(), bounds.height());
+    const qreal radius =
+        std::min(shorterEdge / 2.0,
+                 std::clamp(shorterEdge * 0.12, 3.0, 28.0));
+    path.addRoundedRect(bounds, radius, radius);
+  } else {
+    path.addRect(bounds);
+  }
+  return path;
+}
+
 void paintSpotlights(QPainter &painter, const QImage &source,
                      const QRectF &targetBounds, const QRectF &sourceRect,
                      const QVector<Annotation> &annotations) {
@@ -387,8 +404,10 @@ void paintSpotlights(QPainter &painter, const QImage &source,
             targetBounds);
     if (lens.width() < 1 || lens.height() < 1)
       continue;
-    QPainterPath opening;
-    opening.addEllipse(lens);
+    QPainterPath opening = spotlightPath(annotation);
+    QPainterPath targetClip;
+    targetClip.addRect(targetBounds);
+    opening = opening.intersected(targetClip);
     dimmed = dimmed.subtracted(opening);
     spotlights.push_back(&annotation);
   }
@@ -422,8 +441,7 @@ void paintSpotlights(QPainter &painter, const QImage &source,
     sample.moveTop(std::clamp(sample.top(), sourceRect.top(),
                               sourceRect.bottom() - sample.height()));
 
-    QPainterPath lensClip;
-    lensClip.addEllipse(lens);
+    const QPainterPath lensClip = spotlightPath(*annotation);
     painter.save();
     painter.setClipPath(lensClip, Qt::IntersectClip);
     painter.drawImage(lens, source, sample);
@@ -435,7 +453,7 @@ void paintSpotlights(QPainter &painter, const QImage &source,
     painter.setPen(QPen(outline, std::max<qreal>(2.0, annotation->size / 2.0),
                         Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
     painter.setBrush(Qt::NoBrush);
-    painter.drawEllipse(lens);
+    painter.drawPath(lensClip);
   }
   painter.restore();
 }

--- a/capture.cpp
+++ b/capture.cpp
@@ -252,6 +252,9 @@ QVector<WindowTarget> parseWindows(const QByteArray &json,
 }
 
 void drawAnnotation(QPainter &painter, const Annotation &annotation) {
+  if (annotation.kind == Annotation::Kind::Spotlight)
+    return;
+
   const qreal width = std::max<qreal>(2.0, annotation.size);
   QPen pen(annotation.color, width, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
   painter.setPen(pen);
@@ -365,6 +368,76 @@ QRect pixelSelection(const CaptureData &capture, const QRectF &selection) {
 
 void paintAnnotation(QPainter &painter, const Annotation &annotation) {
   drawAnnotation(painter, annotation);
+}
+
+void paintSpotlights(QPainter &painter, const QImage &source,
+                     const QRectF &targetBounds, const QRectF &sourceRect,
+                     const QVector<Annotation> &annotations) {
+  if (source.isNull() || targetBounds.isEmpty() || sourceRect.isEmpty())
+    return;
+
+  QVector<const Annotation *> spotlights;
+  QPainterPath dimmed;
+  dimmed.addRect(targetBounds);
+  for (const Annotation &annotation : annotations) {
+    if (annotation.kind != Annotation::Kind::Spotlight)
+      continue;
+    const QRectF lens =
+        QRectF(annotation.start, annotation.end).normalized().intersected(
+            targetBounds);
+    if (lens.width() < 1 || lens.height() < 1)
+      continue;
+    QPainterPath opening;
+    opening.addEllipse(lens);
+    dimmed = dimmed.subtracted(opening);
+    spotlights.push_back(&annotation);
+  }
+  if (spotlights.isEmpty())
+    return;
+
+  painter.save();
+  painter.setClipRect(targetBounds);
+  painter.fillPath(dimmed, QColor(0, 0, 0, 154));
+  for (const Annotation *annotation : spotlights) {
+    const QRectF lens = QRectF(annotation->start, annotation->end).normalized();
+    const qreal magnification =
+        std::clamp(annotation->magnification, 1.0, 4.0);
+    QSizeF sampleSize(sourceRect.width() * lens.width() /
+                          targetBounds.width() / magnification,
+                      sourceRect.height() * lens.height() /
+                          targetBounds.height() / magnification);
+    sampleSize.setWidth(std::min(sampleSize.width(), sourceRect.width()));
+    sampleSize.setHeight(std::min(sampleSize.height(), sourceRect.height()));
+    const QPointF normalizedCenter(
+        (lens.center().x() - targetBounds.left()) / targetBounds.width(),
+        (lens.center().y() - targetBounds.top()) / targetBounds.height());
+    const QPointF sampleCenter(
+        sourceRect.left() + normalizedCenter.x() * sourceRect.width(),
+        sourceRect.top() + normalizedCenter.y() * sourceRect.height());
+    QRectF sample(sampleCenter.x() - sampleSize.width() / 2.0,
+                  sampleCenter.y() - sampleSize.height() / 2.0,
+                  sampleSize.width(), sampleSize.height());
+    sample.moveLeft(std::clamp(sample.left(), sourceRect.left(),
+                               sourceRect.right() - sample.width()));
+    sample.moveTop(std::clamp(sample.top(), sourceRect.top(),
+                              sourceRect.bottom() - sample.height()));
+
+    QPainterPath lensClip;
+    lensClip.addEllipse(lens);
+    painter.save();
+    painter.setClipPath(lensClip, Qt::IntersectClip);
+    painter.drawImage(lens, source, sample);
+    painter.restore();
+
+    const QColor outline = annotation->color.isValid()
+                               ? annotation->color
+                               : QColor(Qt::white);
+    painter.setPen(QPen(outline, std::max<qreal>(2.0, annotation->size / 2.0),
+                        Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter.setBrush(Qt::NoBrush);
+    painter.drawEllipse(lens);
+  }
+  painter.restore();
 }
 
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
@@ -567,6 +640,8 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   painter.translate(marginX, marginY);
   painter.scale(scaleX, scaleY);
   painter.setClipRect(QRectF(QPointF(), selection.size()));
+  paintSpotlights(painter, cropped, QRectF(QPointF(), selection.size()),
+                  cropped.rect(), annotations);
   for (const Annotation &annotation : annotations)
     drawAnnotation(painter, annotation);
   painter.restore();

--- a/capture.cpp
+++ b/capture.cpp
@@ -415,7 +415,7 @@ void paintSpotlights(QPainter &painter, const QImage &source,
     return;
 
   painter.save();
-  painter.setClipRect(targetBounds);
+  painter.setClipRect(targetBounds, Qt::IntersectClip);
   painter.fillPath(dimmed, QColor(0, 0, 0, 154));
   for (const Annotation *annotation : spotlights) {
     const QRectF lens = QRectF(annotation->start, annotation->end).normalized();
@@ -658,8 +658,15 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   painter.translate(marginX, marginY);
   painter.scale(scaleX, scaleY);
   painter.setClipRect(QRectF(QPointF(), selection.size()));
+  painter.save();
+  QPainterPath spotlightClip;
+  spotlightClip.addRoundedRect(QRectF(QPointF(), selection.size()),
+                               hasBackground ? 14 : 0,
+                               hasBackground ? 14 : 0);
+  painter.setClipPath(spotlightClip, Qt::IntersectClip);
   paintSpotlights(painter, cropped, QRectF(QPointF(), selection.size()),
                   cropped.rect(), annotations);
+  painter.restore();
   for (const Annotation &annotation : annotations)
     drawAnnotation(painter, annotation);
   painter.restore();

--- a/capture.hpp
+++ b/capture.hpp
@@ -11,6 +11,7 @@
 
 class QFont;
 class QPainter;
+class QPainterPath;
 class QProcess;
 
 struct MonitorInfo {
@@ -35,6 +36,7 @@ struct CaptureData {
 };
 
 enum class BackgroundStyle { None, Aurora, Sunset, Lagoon, Violet };
+enum class SpotlightShape { Ellipse, Rectangle, RoundedRectangle };
 
 struct Annotation {
   enum class Kind {
@@ -57,6 +59,7 @@ struct Annotation {
   int number = 0;
   QVector<QPointF> points;
   qreal magnification = 2.0;
+  SpotlightShape spotlightShape = SpotlightShape::Ellipse;
 };
 
 [[nodiscard]] bool loadCaptureFonts();
@@ -74,6 +77,7 @@ struct Annotation {
 [[nodiscard]] bool copyPngFileToClipboard(const QString &path, QString &error);
 [[nodiscard]] bool copyTextToClipboard(const QString &text, QString &error);
 void paintAnnotation(QPainter &painter, const Annotation &annotation);
+[[nodiscard]] QPainterPath spotlightPath(const Annotation &annotation);
 void paintSpotlights(QPainter &painter, const QImage &source,
                      const QRectF &targetBounds, const QRectF &sourceRect,
                      const QVector<Annotation> &annotations);

--- a/capture.hpp
+++ b/capture.hpp
@@ -42,6 +42,7 @@ struct Annotation {
     Line,
     Freehand,
     Highlighter,
+    Spotlight,
     Marker,
     Rectangle,
     Text
@@ -55,6 +56,7 @@ struct Annotation {
   qreal size = 4.0;
   int number = 0;
   QVector<QPointF> points;
+  qreal magnification = 2.0;
 };
 
 [[nodiscard]] bool loadCaptureFonts();
@@ -72,6 +74,9 @@ struct Annotation {
 [[nodiscard]] bool copyPngFileToClipboard(const QString &path, QString &error);
 [[nodiscard]] bool copyTextToClipboard(const QString &text, QString &error);
 void paintAnnotation(QPainter &painter, const Annotation &annotation);
+void paintSpotlights(QPainter &painter, const QImage &source,
+                     const QRectF &targetBounds, const QRectF &sourceRect,
+                     const QVector<Annotation> &annotations);
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
                             BackgroundStyle backgroundStyle);
 /** Creates or repairs a private directory owned by the current user. */

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -139,6 +139,57 @@ bool runHighlighterRenderingCheck(QString &error) {
   }
   return true;
 }
+
+bool runSpotlightRenderingCheck(QString &error) {
+  error = QStringLiteral("Spotlight/loupe rendering check failed");
+  CaptureData capture;
+  capture.monitor.scale = 1.0;
+  capture.monitor.pixelSize = {200, 100};
+  capture.source = QImage(200, 100, QImage::Format_ARGB32_Premultiplied);
+  for (int y = 0; y < capture.source.height(); ++y) {
+    for (int x = 0; x < capture.source.width(); ++x)
+      capture.source.setPixelColor(x, y, QColor(x, x, x));
+  }
+  capture.preview = capture.source;
+
+  Annotation spotlight;
+  spotlight.kind = Annotation::Kind::Spotlight;
+  spotlight.start = {50, 20};
+  spotlight.end = {150, 80};
+  spotlight.color = Qt::white;
+  spotlight.size = 4;
+  spotlight.magnification = 2.0;
+  const QImage rendered = renderCapture(capture, QRectF(0, 0, 200, 100),
+                                        {spotlight}, BackgroundStyle::None);
+  if (rendered.isNull())
+    return false;
+
+  const int magnified = rendered.pixelColor(125, 50).red();
+  const int dimmed = rendered.pixelColor(10, 50).red();
+  const int dimmedCorner = rendered.pixelColor(55, 25).red();
+  if (magnified < 108 || magnified > 117 || dimmed > 5 ||
+      dimmedCorner > 28) {
+    error = QStringLiteral(
+        "Spotlight did not magnify its lens while dimming the surroundings");
+    return false;
+  }
+
+  CaptureData highDpi = capture;
+  highDpi.monitor.scale = 2.0;
+  highDpi.monitor.pixelSize = {400, 200};
+  highDpi.source = capture.source.scaled(
+      highDpi.monitor.pixelSize, Qt::IgnoreAspectRatio,
+      Qt::SmoothTransformation);
+  const QImage highDpiRendered = renderCapture(
+      highDpi, QRectF(0, 0, 200, 100), {spotlight}, BackgroundStyle::None);
+  const int highDpiMagnified = highDpiRendered.pixelColor(250, 100).red();
+  if (highDpiRendered.size() != QSize(400, 200) || highDpiMagnified < 108 ||
+      highDpiMagnified > 117) {
+    error = QStringLiteral("Spotlight magnification changed at native DPI");
+    return false;
+  }
+  return true;
+}
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
 int main(int argc, char **argv) {
@@ -153,6 +204,10 @@ int main(int argc, char **argv) {
   if (!runHighlighterRenderingCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 69;
+  }
+  if (!runSpotlightRenderingCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 71;
   }
   const QString outputRoot =
       argc > 1 ? QString::fromLocal8Bit(argv[1])
@@ -202,6 +257,82 @@ int main(int argc, char **argv) {
   capture.windows = {
       {{80, 80, 300, 220}, QStringLiteral("1"), QStringLiteral("first")},
       {{420, 120, 300, 320}, QStringLiteral("2"), QStringLiteral("second")}};
+
+  {
+    CaptureEditor spotlightEditor(capture);
+    spotlightEditor.resize(800, 600);
+    spotlightEditor.show();
+    application.processEvents();
+    QTest::mousePress(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(100, 100));
+    QTest::mouseMove(&spotlightEditor, QPoint(650, 470), 20);
+    QTest::mouseRelease(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(650, 470));
+    application.processEvents();
+    const QImage beforeSpotlight(snapshotPath);
+    QTest::keyClick(&spotlightEditor, Qt::Key_S);
+    QTest::mousePress(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(300, 220));
+    QTest::mouseMove(&spotlightEditor, QPoint(500, 380), 20);
+    QTest::mouseRelease(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(500, 380));
+    application.processEvents();
+    const QImage spotlightSnapshot(snapshotPath);
+    if (spotlightSnapshot.isNull() || spotlightSnapshot == beforeSpotlight)
+      return 72;
+    QWheelEvent magnifyWheel(QPointF(400, 300), QPointF(400, 300), {},
+                             {0, 120}, Qt::NoButton, Qt::NoModifier,
+                             Qt::NoScrollPhase, false);
+    QApplication::sendEvent(&spotlightEditor, &magnifyWheel);
+    application.processEvents();
+    if (QImage(snapshotPath) == spotlightSnapshot)
+      return 73;
+    QTest::keyClick(&spotlightEditor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != spotlightSnapshot)
+      return 74;
+    QTest::mousePress(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(500, 380));
+    QTest::mouseMove(&spotlightEditor, QPoint(530, 400), 20);
+    QTest::mouseRelease(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(530, 400));
+    application.processEvents();
+    if (QImage(snapshotPath) == spotlightSnapshot)
+      return 75;
+    QTest::keyClick(&spotlightEditor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != spotlightSnapshot)
+      return 76;
+    QTest::mousePress(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(400, 300));
+    QTest::mouseMove(&spotlightEditor, QPoint(420, 315), 20);
+    QTest::mouseRelease(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(420, 315));
+    application.processEvents();
+    if (QImage(snapshotPath) == spotlightSnapshot)
+      return 77;
+    QTest::keyClick(&spotlightEditor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != spotlightSnapshot)
+      return 78;
+    QTest::keyClick(&spotlightEditor, Qt::Key_Delete);
+    application.processEvents();
+    if (QImage(snapshotPath) != beforeSpotlight)
+      return 79;
+    spotlightEditor.close();
+  }
+  {
+    CaptureEditor narrowEditor(capture);
+    narrowEditor.resize(680, 600);
+    narrowEditor.show();
+    application.processEvents();
+    QTest::keyClick(&narrowEditor, Qt::Key_A, Qt::ControlModifier);
+    QTest::mouseMove(&narrowEditor, QPoint(655, 46), 20);
+    application.processEvents();
+    if (narrowEditor.cursor().shape() != Qt::PointingHandCursor)
+      return 80;
+    narrowEditor.close();
+  }
 
   CaptureEditor editor(capture);
   editor.resize(800, 600);
@@ -422,16 +553,16 @@ int main(int argc, char **argv) {
   application.processEvents();
   if (QImage(snapshotPath) == beforeBackdropSnapshot)
     return 55;
-  // Palette toolbar button (index 8 after Highlighter was inserted).
-  QTest::mouseMove(&editor, QPoint(398, 92), 20);
+  // Palette toolbar button (index 9 after Spotlight was inserted).
+  QTest::mouseMove(&editor, QPoint(418, 92), 20);
   application.processEvents();
   if (!editor.grab().save(outputRoot + QStringLiteral("-palette.png"), "PNG"))
     return 14;
   // Custom color control in the open palette strip.
-  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(470, 134));
-  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(320, 200));
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(500, 134));
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(360, 200));
   // Freehand toolbar button.
-  QTest::mouseMove(&editor, QPoint(198, 92), 20);
+  QTest::mouseMove(&editor, QPoint(180, 92), 20);
   application.processEvents();
   if (editor.cursor().shape() != Qt::PointingHandCursor)
     return 12;

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -303,12 +303,12 @@ int main(int argc, char **argv) {
     application.processEvents();
     const QImage beforeSpotlight(snapshotPath);
     QTest::keyClick(&spotlightEditor, Qt::Key_S);
-    QTest::mouseMove(&spotlightEditor, QPoint(256, 138), 20);
+    QTest::mouseMove(&spotlightEditor, QPoint(236, 138), 20);
     application.processEvents();
     if (spotlightEditor.cursor().shape() != Qt::PointingHandCursor)
       return 81;
     QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
-                      QPoint(256, 138));
+                      QPoint(236, 138));
     QTest::mousePress(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(300, 220));
     QTest::mouseMove(&spotlightEditor, QPoint(500, 380), 20);
@@ -318,10 +318,25 @@ int main(int argc, char **argv) {
     const QImage spotlightSnapshot(snapshotPath);
     if (spotlightSnapshot.isNull() || spotlightSnapshot == beforeSpotlight)
       return 72;
+    QTest::keyClick(&spotlightEditor, Qt::Key_S);
+    QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(236, 138));
+    QTest::mousePress(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(160, 180));
+    QTest::mouseMove(&spotlightEditor, QPoint(250, 260), 20);
+    QTest::mouseRelease(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(250, 260));
+    application.processEvents();
+    if (QImage(snapshotPath) == spotlightSnapshot)
+      return 87;
+    QTest::keyClick(&spotlightEditor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != spotlightSnapshot)
+      return 88;
     QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(400, 300));
     QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
-                      QPoint(220, 138));
+                      QPoint(200, 138));
     application.processEvents();
     const QImage ellipseSnapshot(snapshotPath);
     if (ellipseSnapshot == spotlightSnapshot)
@@ -337,7 +352,7 @@ int main(int argc, char **argv) {
     QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(400, 300));
     QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
-                      QPoint(292, 138));
+                      QPoint(272, 138));
     application.processEvents();
     if (QImage(snapshotPath) == ellipseSnapshot)
       return 85;
@@ -393,7 +408,7 @@ int main(int argc, char **argv) {
     narrowEditor.show();
     application.processEvents();
     QTest::keyClick(&narrowEditor, Qt::Key_A, Qt::ControlModifier);
-    QTest::mouseMove(&narrowEditor, QPoint(655, 46), 20);
+    QTest::mouseMove(&narrowEditor, QPoint(670, 46), 20);
     application.processEvents();
     if (narrowEditor.cursor().shape() != Qt::PointingHandCursor)
       return 80;
@@ -879,6 +894,24 @@ int main(int argc, char **argv) {
         return 65;
     }
   }
+
+  Annotation edgeSpotlight;
+  edgeSpotlight.kind = Annotation::Kind::Spotlight;
+  edgeSpotlight.start = {0, 0};
+  edgeSpotlight.end = {40, 40};
+  edgeSpotlight.color = QColor(QStringLiteral("#ff00ff"));
+  edgeSpotlight.size = 4;
+  edgeSpotlight.magnification = 2;
+  edgeSpotlight.spotlightShape = SpotlightShape::Rectangle;
+  const QImage roundedBaseline =
+      renderCapture(clippingCapture, QRectF(0, 0, 100, 100), {},
+                    BackgroundStyle::Aurora);
+  const QImage roundedSpotlight = renderCapture(
+      clippingCapture, QRectF(0, 0, 100, 100), {edgeSpotlight},
+      BackgroundStyle::Aurora);
+  if (roundedSpotlight.pixelColor(66, 66) !=
+      roundedBaseline.pixelColor(66, 66))
+    return 89;
 
   CaptureData highDpiCapture = capture;
   highDpiCapture.monitor.scale = 2.0;

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -10,11 +10,13 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QPainter>
+#include <QPainterPath>
 #include <QTemporaryDir>
 #include <QWheelEvent>
 #include <QtTest/QTest>
 
 #include <algorithm>
+#include <cstdio>
 
 namespace {
 /** Guards the working-snapshot lifecycle: create and overwrite in place. */
@@ -174,12 +176,42 @@ bool runSpotlightRenderingCheck(QString &error) {
     return false;
   }
 
+  const QPointF corner(51, 21);
+  if (spotlightPath(spotlight).contains(corner)) {
+    error = QStringLiteral("Ellipse spotlight included its bounding corner");
+    return false;
+  }
+  spotlight.spotlightShape = SpotlightShape::Rectangle;
+  const QImage rectangle = renderCapture(capture, QRectF(0, 0, 200, 100),
+                                         {spotlight}, BackgroundStyle::None);
+  if (!spotlightPath(spotlight).contains(corner) ||
+      rectangle.pixelColor(55, 25).red() < 60) {
+    error = QStringLiteral("Rectangle spotlight did not include its corners");
+    return false;
+  }
+  spotlight.spotlightShape = SpotlightShape::RoundedRectangle;
+  const QImage rounded = renderCapture(capture, QRectF(0, 0, 200, 100),
+                                       {spotlight}, BackgroundStyle::None);
+  const bool roundedCorner = spotlightPath(spotlight).contains(corner);
+  const bool roundedInterior =
+      spotlightPath(spotlight).contains(QPointF(60, 30));
+  const int roundedCornerRed = rounded.pixelColor(50, 20).red();
+  if (roundedCorner || !roundedInterior || roundedCornerRed > 35) {
+    error = QStringLiteral("Rounded spotlight geometry: corner=%1 interior=%2 "
+                           "corner-red=%3")
+                .arg(roundedCorner)
+                .arg(roundedInterior)
+                .arg(roundedCornerRed);
+    return false;
+  }
+
   CaptureData highDpi = capture;
   highDpi.monitor.scale = 2.0;
   highDpi.monitor.pixelSize = {400, 200};
   highDpi.source = capture.source.scaled(
       highDpi.monitor.pixelSize, Qt::IgnoreAspectRatio,
       Qt::SmoothTransformation);
+  spotlight.spotlightShape = SpotlightShape::Ellipse;
   const QImage highDpiRendered = renderCapture(
       highDpi, QRectF(0, 0, 200, 100), {spotlight}, BackgroundStyle::None);
   const int highDpiMagnified = highDpiRendered.pixelColor(250, 100).red();
@@ -206,7 +238,7 @@ int main(int argc, char **argv) {
     return 69;
   }
   if (!runSpotlightRenderingCheck(snapshotError)) {
-    qWarning().noquote() << snapshotError;
+    std::fprintf(stderr, "%s\n", qPrintable(snapshotError));
     return 71;
   }
   const QString outputRoot =
@@ -271,6 +303,12 @@ int main(int argc, char **argv) {
     application.processEvents();
     const QImage beforeSpotlight(snapshotPath);
     QTest::keyClick(&spotlightEditor, Qt::Key_S);
+    QTest::mouseMove(&spotlightEditor, QPoint(256, 138), 20);
+    application.processEvents();
+    if (spotlightEditor.cursor().shape() != Qt::PointingHandCursor)
+      return 81;
+    QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(256, 138));
     QTest::mousePress(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(300, 220));
     QTest::mouseMove(&spotlightEditor, QPoint(500, 380), 20);
@@ -280,6 +318,34 @@ int main(int argc, char **argv) {
     const QImage spotlightSnapshot(snapshotPath);
     if (spotlightSnapshot.isNull() || spotlightSnapshot == beforeSpotlight)
       return 72;
+    QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(400, 300));
+    QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(220, 138));
+    application.processEvents();
+    const QImage ellipseSnapshot(snapshotPath);
+    if (ellipseSnapshot == spotlightSnapshot)
+      return 82;
+    QTest::keyClick(&spotlightEditor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != spotlightSnapshot)
+      return 83;
+    QTest::keyClick(&spotlightEditor, Qt::Key_Y, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != ellipseSnapshot)
+      return 84;
+    QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(400, 300));
+    QTest::mouseClick(&spotlightEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(292, 138));
+    application.processEvents();
+    if (QImage(snapshotPath) == ellipseSnapshot)
+      return 85;
+    QTest::keyClick(&spotlightEditor, Qt::Key_Z, Qt::ControlModifier);
+    QTest::keyClick(&spotlightEditor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    if (QImage(snapshotPath) != spotlightSnapshot)
+      return 86;
     QWheelEvent magnifyWheel(QPointF(400, 300), QPointF(400, 300), {},
                              {0, 120}, Qt::NoButton, Qt::NoModifier,
                              Qt::NoScrollPhase, false);

--- a/editor.cpp
+++ b/editor.cpp
@@ -35,7 +35,7 @@ constexpr std::array<const char *, 6> kColorNames{
     "#ff375f", "#ff9f0a", "#ffd60a", "#30d158", "#0a84ff", "#bf5af2"};
 constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
-constexpr qreal kToolbarWidth = 720;
+constexpr qreal kToolbarWidth = 760;
 constexpr qreal kMinimumSpotlightExtent = 16;
 
 qreal toolbarScale(qreal availableWidth) {
@@ -1124,6 +1124,7 @@ void CaptureEditor::handleToolbar(const QString &action) {
     tool_ = Tool::Highlighter;
   else if (action == QStringLiteral("tool-spotlight")) {
     tool_ = Tool::Spotlight;
+    selectedAnnotation_ = -1;
     spotlightShapePanelOpen_ = true;
     colorPaletteOpen_ = false;
     customColorPickerOpen_ = false;
@@ -1268,6 +1269,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Highlighter;
   } else if (event->key() == Qt::Key_S) {
     tool_ = Tool::Spotlight;
+    selectedAnnotation_ = -1;
     spotlightShapePanelOpen_ = true;
     colorPaletteOpen_ = false;
     customColorPickerOpen_ = false;
@@ -1929,9 +1931,17 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   QVector<Annotation> spotlightAnnotations = annotations_;
   if (hasDragPreview && dragPreview.kind == Annotation::Kind::Spotlight)
     spotlightAnnotations.push_back(dragPreview);
+  painter.save();
+  QPainterPath spotlightClip;
+  const qreal spotlightClipRadius =
+      hasBackground ? 10.0 / std::max<qreal>(editScale(), 0.01) : 0.0;
+  spotlightClip.addRoundedRect(QRectF(QPointF(), selection_.size()),
+                               spotlightClipRadius, spotlightClipRadius);
+  painter.setClipPath(spotlightClip, Qt::IntersectClip);
   paintSpotlights(painter, capture_.source,
                   QRectF(QPointF(), selection_.size()), sourceRect(selection_),
                   spotlightAnnotations);
+  painter.restore();
   for (int index = 0; index < annotations_.size(); ++index) {
     if (index != editingAnnotation_)
       paintAnnotation(painter, annotations_.at(index));

--- a/editor.cpp
+++ b/editor.cpp
@@ -109,6 +109,30 @@ QString toolAction(CaptureEditor::Tool tool) {
   return {};
 }
 
+QString spotlightShapeAction(SpotlightShape shape) {
+  if (shape == SpotlightShape::Rectangle)
+    return QStringLiteral("spotlight-shape-rectangle");
+  if (shape == SpotlightShape::RoundedRectangle)
+    return QStringLiteral("spotlight-shape-rounded");
+  return QStringLiteral("spotlight-shape-ellipse");
+}
+
+QString spotlightShapeName(SpotlightShape shape) {
+  if (shape == SpotlightShape::Rectangle)
+    return QStringLiteral("Rectangle");
+  if (shape == SpotlightShape::RoundedRectangle)
+    return QStringLiteral("Rounded rectangle");
+  return QStringLiteral("Ellipse");
+}
+
+SpotlightShape spotlightShapeFromAction(const QString &action) {
+  if (action == QStringLiteral("spotlight-shape-rectangle"))
+    return SpotlightShape::Rectangle;
+  if (action == QStringLiteral("spotlight-shape-rounded"))
+    return SpotlightShape::RoundedRectangle;
+  return SpotlightShape::Ellipse;
+}
+
 void drawStatusPill(QPainter &painter, const QRect &bounds,
                     const QString &text) {
   QFont font(QStringLiteral("Noto Sans"));
@@ -367,13 +391,7 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
           return index;
       }
     } else if (annotation.kind == Annotation::Kind::Spotlight) {
-      const QRectF bounds = annotationBounds(annotation).adjusted(-7, -7, 7, 7);
-      if (bounds.width() <= 0 || bounds.height() <= 0)
-        continue;
-      const qreal x = (point.x() - bounds.center().x()) / (bounds.width() / 2.0);
-      const qreal y =
-          (point.y() - bounds.center().y()) / (bounds.height() / 2.0);
-      if (x * x + y * y <= 1.0)
+      if (spotlightPath(annotation).contains(point))
         return index;
     } else if (annotationBounds(annotation)
                    .adjusted(-7, -7, 7, 7)
@@ -447,6 +465,21 @@ QRectF CaptureEditor::customColorPanelRect() const {
   if (panel.bottom() > height() - 8)
     panel.moveBottom(height() - 8);
   return panel;
+}
+
+QRectF CaptureEditor::spotlightShapePanelRect() const {
+  const qreal scale = toolbarScale(width());
+  const qreal toolbarWidth = kToolbarWidth * scale;
+  const qreal buttonHeight = 36 * scale;
+  const qreal toolbarX = (width() - toolbarWidth) / 2.0;
+  const qreal toolbarY =
+      std::max<qreal>(10, editImageRect().top() - buttonHeight - 10);
+  const QRectF anchor(toolbarX + 200 * scale, toolbarY, 36 * scale,
+                      buttonHeight);
+  constexpr qreal panelWidth = 116;
+  const qreal x = std::clamp(anchor.center().x() - panelWidth / 2.0, 8.0,
+                             std::max(8.0, width() - panelWidth - 8.0));
+  return {x, anchor.bottom() + 6, panelWidth, 44};
 }
 
 QRectF CaptureEditor::textSizePanelRect() const {
@@ -648,7 +681,8 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
       QStringLiteral("Highlighter · H · Size %1 · Wheel")
           .arg(qRound(annotationSize_)));
   add(36, QStringLiteral("tool-spotlight"), {},
-      QStringLiteral("Spotlight/Loupe · S · %1× · Wheel after selection")
+      QStringLiteral("Spotlight/Loupe · S · %1 · %2×")
+          .arg(spotlightShapeName(spotlightShape_))
           .arg(spotlightMagnification_, 0, 'f', 1));
   add(36, QStringLiteral("tool-marker"), {},
       QStringLiteral("Number marker · C · Size %1 · Wheel")
@@ -674,6 +708,21 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(40, QStringLiteral("both"), {}, QStringLiteral("Copy and save · Enter"));
   add(36, QStringLiteral("save"), {}, QStringLiteral("Save only · Ctrl+S"));
   add(36, QStringLiteral("close"), {}, QStringLiteral("Close · Esc twice"));
+
+  if (spotlightShapePanelOpen_) {
+    const QRectF panel = spotlightShapePanelRect();
+    const std::array<std::pair<SpotlightShape, const char *>, 3> shapes{
+        std::pair{SpotlightShape::Ellipse, "Ellipse"},
+        std::pair{SpotlightShape::Rectangle, "Rectangle"},
+        std::pair{SpotlightShape::RoundedRectangle, "Rounded rectangle"}};
+    for (int index = 0; index < static_cast<int>(shapes.size()); ++index) {
+      const auto &[shape, name] = shapes.at(static_cast<std::size_t>(index));
+      buttons.push_back({{panel.left() + 4 + index * 36, panel.top() + 4, 32,
+                          36},
+                         spotlightShapeAction(shape), {},
+                         QString::fromLatin1(name), {}});
+    }
+  }
 
   if (colorPaletteOpen_) {
     const QRectF palette = colorPaletteRect();
@@ -711,6 +760,9 @@ void CaptureEditor::applyEditState(const EditState &state) {
   selection_ = state.selection;
   selectedAnnotation_ = std::clamp(state.selectedAnnotation, -1,
                                    static_cast<int>(annotations_.size()) - 1);
+  if (selectedAnnotation_ >= 0 &&
+      annotations_.at(selectedAnnotation_).kind == Annotation::Kind::Spotlight)
+    spotlightShape_ = annotations_.at(selectedAnnotation_).spotlightShape;
   nextMarker_ = state.nextMarker;
   editingAnnotation_ = -1;
   interaction_ = Interaction::None;
@@ -840,6 +892,7 @@ void CaptureEditor::handleEscape() {
   interaction_ = Interaction::None;
   colorPaletteOpen_ = false;
   customColorPickerOpen_ = false;
+  spotlightShapePanelOpen_ = false;
   freehandPoints_.clear();
   if (phase_ == Phase::Edit) {
     tool_ = Tool::Select;
@@ -1033,6 +1086,32 @@ void CaptureEditor::finish(OutputMode mode) {
 }
 
 void CaptureEditor::handleToolbar(const QString &action) {
+  if (action.startsWith(QStringLiteral("spotlight-shape-"))) {
+    const SpotlightShape shape = spotlightShapeFromAction(action);
+    spotlightShape_ = shape;
+    spotlightShapePanelOpen_ = false;
+    if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+        annotations_.at(selectedAnnotation_).kind ==
+            Annotation::Kind::Spotlight) {
+      if (annotations_.at(selectedAnnotation_).spotlightShape != shape) {
+        recordEdit();
+        annotations_[selectedAnnotation_].spotlightShape = shape;
+        persistSnapshot();
+      }
+      tool_ = Tool::Select;
+      setStatus(QStringLiteral("Spotlight shape · %1 · Ctrl+Z to undo")
+                    .arg(spotlightShapeName(shape)));
+    } else {
+      tool_ = Tool::Spotlight;
+      setStatus(QStringLiteral("Spotlight shape · %1 · drag to add")
+                    .arg(spotlightShapeName(shape)));
+    }
+    updatePointerCursor();
+    update();
+    return;
+  }
+  if (action != QStringLiteral("tool-spotlight"))
+    spotlightShapePanelOpen_ = false;
   if (action == QStringLiteral("tool-select"))
     tool_ = Tool::Select;
   else if (action == QStringLiteral("tool-arrow"))
@@ -1043,9 +1122,12 @@ void CaptureEditor::handleToolbar(const QString &action) {
     tool_ = Tool::Freehand;
   else if (action == QStringLiteral("tool-highlighter"))
     tool_ = Tool::Highlighter;
-  else if (action == QStringLiteral("tool-spotlight"))
+  else if (action == QStringLiteral("tool-spotlight")) {
     tool_ = Tool::Spotlight;
-  else if (action == QStringLiteral("tool-marker"))
+    spotlightShapePanelOpen_ = true;
+    colorPaletteOpen_ = false;
+    customColorPickerOpen_ = false;
+  } else if (action == QStringLiteral("tool-marker"))
     tool_ = Tool::Marker;
   else if (action == QStringLiteral("tool-rectangle"))
     tool_ = Tool::Rectangle;
@@ -1142,6 +1224,14 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     return;
   }
 
+  const bool selectsOtherTool =
+      event->key() == Qt::Key_V || event->key() == Qt::Key_A ||
+      event->key() == Qt::Key_L || event->key() == Qt::Key_F ||
+      event->key() == Qt::Key_H || event->key() == Qt::Key_C ||
+      event->key() == Qt::Key_M || event->key() == Qt::Key_R ||
+      event->key() == Qt::Key_T || event->key() == Qt::Key_O;
+  if (selectsOtherTool)
+    spotlightShapePanelOpen_ = false;
   const bool redoShortcut = event->matches(QKeySequence::Redo) ||
                             (event->key() == Qt::Key_Y &&
                              event->modifiers().testFlag(Qt::ControlModifier));
@@ -1178,6 +1268,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Highlighter;
   } else if (event->key() == Qt::Key_S) {
     tool_ = Tool::Spotlight;
+    spotlightShapePanelOpen_ = true;
+    colorPaletteOpen_ = false;
+    customColorPickerOpen_ = false;
   } else if (event->key() == Qt::Key_C || event->key() == Qt::Key_M) {
     tool_ = Tool::Marker;
   } else if (event->key() == Qt::Key_R) {
@@ -1386,6 +1479,9 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     dragging_ = true;
     return;
   }
+  if (spotlightShapePanelOpen_ &&
+      !spotlightShapePanelRect().contains(cursor_))
+    spotlightShapePanelOpen_ = false;
   if (customColorPickerOpen_) {
     if (customColorPanelRect().contains(cursor_)) {
       applyCustomColor(cursor_);
@@ -1463,6 +1559,10 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     }
     if (selectedAnnotation_ >= 0) {
       originalAnnotation_ = annotations_.at(selectedAnnotation_);
+      if (originalAnnotation_.kind == Annotation::Kind::Spotlight) {
+        spotlightShape_ = originalAnnotation_.spotlightShape;
+        spotlightShapePanelOpen_ = true;
+      }
       dragStartState_ = editState();
       dragStartStateValid_ = true;
       dragChanged_ = false;
@@ -1599,6 +1699,7 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       annotation.color = annotationColor();
       annotation.size = annotationSize_;
       annotation.magnification = spotlightMagnification_;
+      annotation.spotlightShape = spotlightShape_;
       annotations_.push_back(std::move(annotation));
       selectedAnnotation_ = annotations_.size() - 1;
       tool_ = Tool::Select;
@@ -1812,6 +1913,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       dragPreview.start = dragStart_;
       dragPreview.end = toAnnotationPoint(cursor_);
       dragPreview.magnification = spotlightMagnification_;
+      dragPreview.spotlightShape = spotlightShape_;
     } else {
       dragPreview.kind = (tool_ == Tool::Rectangle || tool_ == Tool::Ocr)
                              ? Annotation::Kind::Rectangle
@@ -1856,7 +1958,10 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       painter.setPen(
           QPen(QColor(255, 255, 255, 220), 1.0 / scale, Qt::DashLine));
       painter.setBrush(Qt::NoBrush);
-      painter.drawRect(bounds);
+      if (selected.kind == Annotation::Kind::Spotlight)
+        painter.drawPath(spotlightPath(selected));
+      else
+        painter.drawRect(bounds);
     }
     const qreal radius = 5.0 / scale;
     painter.setPen(QPen(Qt::white, 1.0 / scale));
@@ -1928,6 +2033,11 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     painter.drawLine(QPointF(hue.left() - 2, hueY),
                      QPointF(hue.right() + 2, hueY));
   }
+  if (spotlightShapePanelOpen_) {
+    painter.setPen(QPen(QColor(255, 255, 255, 34), 1));
+    painter.setBrush(QColor(22, 22, 28, 248));
+    painter.drawRoundedRect(spotlightShapePanelRect(), 9, 9);
+  }
 
   const QString currentTool = toolAction(tool_);
   QFont buttonFont = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
@@ -1943,6 +2053,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         (button.action == QStringLiteral("palette") && colorPaletteOpen_) ||
         (button.action == QStringLiteral("custom-color") &&
          usingCustomColor_) ||
+        button.action == spotlightShapeAction(spotlightShape_) ||
         (!usingCustomColor_ &&
          button.action == QStringLiteral("color-%1").arg(colorIndex_));
     const bool hovered = button.rect.contains(cursor_);

--- a/editor.cpp
+++ b/editor.cpp
@@ -35,11 +35,37 @@ constexpr std::array<const char *, 6> kColorNames{
     "#ff375f", "#ff9f0a", "#ffd60a", "#30d158", "#0a84ff", "#bf5af2"};
 constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
-constexpr qreal kToolbarWidth = 680;
+constexpr qreal kToolbarWidth = 720;
+constexpr qreal kMinimumSpotlightExtent = 16;
+
+qreal toolbarScale(qreal availableWidth) {
+  constexpr qreal sideMargins = 16.0;
+  return std::min<qreal>(
+      1.0,
+      std::max<qreal>(0.1, (availableWidth - sideMargins) / kToolbarWidth));
+}
+
+QPointF constrainedSpotlightEndpoint(const QPointF &point,
+                                     const QPointF &anchor,
+                                     const QPointF &original) {
+  const auto constrained = [](qreal value, qreal anchor, qreal original) {
+    if (std::abs(value - anchor) >= kMinimumSpotlightExtent)
+      return value;
+    qreal direction = original < anchor ? -1.0 : 1.0;
+    if (value < anchor)
+      direction = -1.0;
+    else if (value > anchor)
+      direction = 1.0;
+    return anchor + direction * kMinimumSpotlightExtent;
+  };
+  return {constrained(point.x(), anchor.x(), original.x()),
+          constrained(point.y(), anchor.y(), original.y())};
+}
 
 bool hasEndpointHandles(Annotation::Kind kind) {
   return kind == Annotation::Kind::Arrow || kind == Annotation::Kind::Line ||
-         kind == Annotation::Kind::Rectangle;
+         kind == Annotation::Kind::Rectangle ||
+         kind == Annotation::Kind::Spotlight;
 }
 
 bool showsSelectionBounds(Annotation::Kind kind) {
@@ -69,6 +95,8 @@ QString toolAction(CaptureEditor::Tool tool) {
     return QStringLiteral("tool-freehand");
   case CaptureEditor::Tool::Highlighter:
     return QStringLiteral("tool-highlighter");
+  case CaptureEditor::Tool::Spotlight:
+    return QStringLiteral("tool-spotlight");
   case CaptureEditor::Tool::Marker:
     return QStringLiteral("tool-marker");
   case CaptureEditor::Tool::Rectangle:
@@ -338,6 +366,15 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
         if (QLineF(point, closest).length() <= tolerance)
           return index;
       }
+    } else if (annotation.kind == Annotation::Kind::Spotlight) {
+      const QRectF bounds = annotationBounds(annotation).adjusted(-7, -7, 7, 7);
+      if (bounds.width() <= 0 || bounds.height() <= 0)
+        continue;
+      const qreal x = (point.x() - bounds.center().x()) / (bounds.width() / 2.0);
+      const qreal y =
+          (point.y() - bounds.center().y()) / (bounds.height() / 2.0);
+      if (x * x + y * y <= 1.0)
+        return index;
     } else if (annotationBounds(annotation)
                    .adjusted(-7, -7, 7, 7)
                    .contains(point)) {
@@ -352,6 +389,14 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
     return;
   recordEdit();
   Annotation &annotation = annotations_[selectedAnnotation_];
+  if (annotation.kind == Annotation::Kind::Spotlight) {
+    annotation.magnification =
+        std::clamp(annotation.magnification * factor, 1.0, 4.0);
+    setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
+                  .arg(annotation.magnification, 0, 'f', 1));
+    persistSnapshot();
+    return;
+  }
   const QPointF center = annotationBounds(annotation).center();
   const auto scaledPoint = [center, factor](const QPointF &point) {
     return center + (point - center) * factor;
@@ -380,12 +425,14 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
 }
 
 QRectF CaptureEditor::colorPaletteRect() const {
-  constexpr qreal toolbarWidth = kToolbarWidth;
-  constexpr qreal buttonHeight = 36;
+  const qreal scale = toolbarScale(width());
+  const qreal toolbarWidth = kToolbarWidth * scale;
+  const qreal buttonHeight = 36 * scale;
   const qreal toolbarX = (width() - toolbarWidth) / 2.0;
   const qreal toolbarY =
       std::max<qreal>(10, editImageRect().top() - buttonHeight - 10);
-  const QRectF anchor(toolbarX + 320, toolbarY, 36, buttonHeight);
+  const QRectF anchor(toolbarX + 360 * scale, toolbarY, 36 * scale,
+                      buttonHeight);
   const qreal paletteWidth = 204;
   const qreal x = std::clamp(anchor.center().x() - paletteWidth / 2.0, 8.0,
                              std::max(8.0, width() - paletteWidth - 8.0));
@@ -403,12 +450,14 @@ QRectF CaptureEditor::customColorPanelRect() const {
 }
 
 QRectF CaptureEditor::textSizePanelRect() const {
-  constexpr qreal toolbarWidth = kToolbarWidth;
-  constexpr qreal buttonHeight = 36;
+  const qreal scale = toolbarScale(width());
+  const qreal toolbarWidth = kToolbarWidth * scale;
+  const qreal buttonHeight = 36 * scale;
   const qreal toolbarX = (width() - toolbarWidth) / 2.0;
   const qreal toolbarY =
       std::max<qreal>(10, editImageRect().top() - buttonHeight - 10);
-  const QRectF anchor(toolbarX + 280, toolbarY, 36, buttonHeight);
+  const QRectF anchor(toolbarX + 320 * scale, toolbarY, 36 * scale,
+                      buttonHeight);
   return {anchor.center().x() - 51, anchor.bottom() + 6, 102, 34};
 }
 
@@ -570,16 +619,18 @@ int CaptureEditor::windowInDirection(int current, int key) const {
 
 QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   QVector<ToolbarButton> buttons;
-  const qreal height = 36;
-  const qreal gap = 4;
-  const qreal total = kToolbarWidth;
+  const qreal scale = toolbarScale(width());
+  const qreal height = 36 * scale;
+  const qreal gap = 4 * scale;
+  const qreal total = kToolbarWidth * scale;
   qreal x = (width() - total) / 2.0;
   const qreal y = std::max<qreal>(10, editImageRect().top() - height - 10);
   auto add = [&](qreal buttonWidth, QString action, QString label,
                  QString tooltip, QColor color = {}) {
-    buttons.push_back({QRectF(x, y, buttonWidth, height), std::move(action),
+    const qreal scaledWidth = buttonWidth * scale;
+    buttons.push_back({QRectF(x, y, scaledWidth, height), std::move(action),
                        std::move(label), std::move(tooltip), color});
-    x += buttonWidth + gap;
+    x += scaledWidth + gap;
   };
 
   add(36, QStringLiteral("tool-select"), {},
@@ -596,6 +647,9 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(36, QStringLiteral("tool-highlighter"), {},
       QStringLiteral("Highlighter · H · Size %1 · Wheel")
           .arg(qRound(annotationSize_)));
+  add(36, QStringLiteral("tool-spotlight"), {},
+      QStringLiteral("Spotlight/Loupe · S · %1× · Wheel after selection")
+          .arg(spotlightMagnification_, 0, 'f', 1));
   add(36, QStringLiteral("tool-marker"), {},
       QStringLiteral("Number marker · C · Size %1 · Wheel")
           .arg(qRound(annotationSize_)));
@@ -989,6 +1043,8 @@ void CaptureEditor::handleToolbar(const QString &action) {
     tool_ = Tool::Freehand;
   else if (action == QStringLiteral("tool-highlighter"))
     tool_ = Tool::Highlighter;
+  else if (action == QStringLiteral("tool-spotlight"))
+    tool_ = Tool::Spotlight;
   else if (action == QStringLiteral("tool-marker"))
     tool_ = Tool::Marker;
   else if (action == QStringLiteral("tool-rectangle"))
@@ -1120,6 +1176,8 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Freehand;
   } else if (event->key() == Qt::Key_H) {
     tool_ = Tool::Highlighter;
+  } else if (event->key() == Qt::Key_S) {
+    tool_ = Tool::Spotlight;
   } else if (event->key() == Qt::Key_C || event->key() == Qt::Key_M) {
     tool_ = Tool::Marker;
   } else if (event->key() == Qt::Key_R) {
@@ -1225,11 +1283,18 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
             strokePoint += delta;
         }
       } else if (interaction_ == Interaction::ResizeStart) {
-        if (hasEndpointHandles(annotation.kind))
+        if (hasEndpointHandles(annotation.kind)) {
           annotation.start = point;
+          if (annotation.kind == Annotation::Kind::Spotlight)
+            annotation.start = constrainedSpotlightEndpoint(
+                point, annotation.end, originalAnnotation_.start);
+        }
       } else if (interaction_ == Interaction::ResizeEnd) {
         if (hasEndpointHandles(annotation.kind)) {
           annotation.end = point;
+          if (annotation.kind == Annotation::Kind::Spotlight)
+            annotation.end = constrainedSpotlightEndpoint(
+                point, annotation.start, originalAnnotation_.end);
         } else if (isStrokeKind(annotation.kind)) {
           const QRectF originalBounds = annotationBounds(originalAnnotation_);
           const qreal scaleX =
@@ -1521,6 +1586,30 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     update();
     return;
   }
+  if (tool_ == Tool::Spotlight) {
+    const QRectF lens(dragStart_, end);
+    dragging_ = false;
+    if (lens.normalized().width() >= kMinimumSpotlightExtent &&
+        lens.normalized().height() >= kMinimumSpotlightExtent) {
+      recordEdit();
+      Annotation annotation;
+      annotation.kind = Annotation::Kind::Spotlight;
+      annotation.start = dragStart_;
+      annotation.end = end;
+      annotation.color = annotationColor();
+      annotation.size = annotationSize_;
+      annotation.magnification = spotlightMagnification_;
+      annotations_.push_back(std::move(annotation));
+      selectedAnnotation_ = annotations_.size() - 1;
+      tool_ = Tool::Select;
+      setStatus(QStringLiteral(
+                    "Spotlight added · wheel adjusts magnification · handles resize"));
+      persistSnapshot();
+      updatePointerCursor();
+    }
+    update();
+    return;
+  }
   if (QLineF(dragStart_, end).length() > 4) {
     recordEdit();
     Annotation annotation;
@@ -1563,6 +1652,11 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
     annotationSize_ = std::clamp(annotationSize_ + step, 2.0, 12.0);
     setStatus(QStringLiteral("Size %1 · mouse wheel changes size")
                   .arg(qRound(annotationSize_)));
+  } else if (tool_ == Tool::Spotlight) {
+    spotlightMagnification_ =
+        std::clamp(spotlightMagnification_ + step * 0.25, 1.0, 4.0);
+    setStatus(QStringLiteral("Spotlight magnification · %1×")
+                  .arg(spotlightMagnification_, 0, 'f', 2));
   } else {
     QWidget::wheelEvent(event);
     return;
@@ -1705,27 +1799,43 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   painter.scale(editScale(), editScale());
   painter.save();
   painter.setClipRect(QRectF(QPointF(), selection_.size()));
+  Annotation dragPreview;
+  bool hasDragPreview = dragging_ && tool_ != Tool::Select;
+  if (hasDragPreview) {
+    if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
+      dragPreview.kind = tool_ == Tool::Highlighter
+                             ? Annotation::Kind::Highlighter
+                             : Annotation::Kind::Freehand;
+      dragPreview.points = freehandPoints_;
+    } else if (tool_ == Tool::Spotlight) {
+      dragPreview.kind = Annotation::Kind::Spotlight;
+      dragPreview.start = dragStart_;
+      dragPreview.end = toAnnotationPoint(cursor_);
+      dragPreview.magnification = spotlightMagnification_;
+    } else {
+      dragPreview.kind = (tool_ == Tool::Rectangle || tool_ == Tool::Ocr)
+                             ? Annotation::Kind::Rectangle
+                             : (tool_ == Tool::Line ? Annotation::Kind::Line
+                                                    : Annotation::Kind::Arrow);
+      dragPreview.start = dragStart_;
+      dragPreview.end = toAnnotationPoint(cursor_);
+    }
+    dragPreview.color =
+        tool_ == Tool::Ocr ? QColor(Qt::white) : annotationColor();
+    dragPreview.size = tool_ == Tool::Ocr ? 2.0 : annotationSize_;
+  }
+  QVector<Annotation> spotlightAnnotations = annotations_;
+  if (hasDragPreview && dragPreview.kind == Annotation::Kind::Spotlight)
+    spotlightAnnotations.push_back(dragPreview);
+  paintSpotlights(painter, capture_.source,
+                  QRectF(QPointF(), selection_.size()), sourceRect(selection_),
+                  spotlightAnnotations);
   for (int index = 0; index < annotations_.size(); ++index) {
     if (index != editingAnnotation_)
       paintAnnotation(painter, annotations_.at(index));
   }
-  if (dragging_ && tool_ != Tool::Select) {
-    Annotation preview;
-    if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
-      preview.kind = tool_ == Tool::Highlighter ? Annotation::Kind::Highlighter
-                                                : Annotation::Kind::Freehand;
-      preview.points = freehandPoints_;
-    } else {
-      preview.kind = (tool_ == Tool::Rectangle || tool_ == Tool::Ocr)
-                         ? Annotation::Kind::Rectangle
-                         : (tool_ == Tool::Line ? Annotation::Kind::Line
-                                                : Annotation::Kind::Arrow);
-      preview.start = dragStart_;
-      preview.end = toAnnotationPoint(cursor_);
-    }
-    preview.color = tool_ == Tool::Ocr ? QColor(Qt::white) : annotationColor();
-    preview.size = tool_ == Tool::Ocr ? 2.0 : annotationSize_;
-    paintAnnotation(painter, preview);
+  if (hasDragPreview) {
+    paintAnnotation(painter, dragPreview);
   } else if (tool_ == Tool::Marker && image.contains(cursor_)) {
     Annotation preview;
     preview.kind = Annotation::Kind::Marker;
@@ -1886,7 +1996,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
        {QStringLiteral("A"), QStringLiteral("Arrow")},
        {QStringLiteral("L"), QStringLiteral("Line")},
        {QStringLiteral("F / H"), QStringLiteral("Freehand / Highlighter")},
-       {QStringLiteral("C"), QStringLiteral("Marker")},
+       {QStringLiteral("S / C"), QStringLiteral("Spotlight / Marker")},
        {QStringLiteral("R"), QStringLiteral("Rectangle")},
        {QStringLiteral("T"), QStringLiteral("Text")},
        {QStringLiteral("Double click"), QStringLiteral("Edit text layer")},
@@ -1905,17 +2015,24 @@ void CaptureEditor::paintEdit(QPainter &painter) {
                        hoveredButton->tooltip);
   } else if (tool_ == Tool::Arrow || tool_ == Tool::Line ||
              tool_ == Tool::Freehand || tool_ == Tool::Highlighter ||
-             tool_ == Tool::Marker || tool_ == Tool::Text) {
+             tool_ == Tool::Spotlight || tool_ == Tool::Marker ||
+             tool_ == Tool::Text) {
     const QString selectedAction = toolAction(tool_);
     for (const ToolbarButton &button : buttons) {
       if (button.action == selectedAction) {
-        const QString tooltip =
-            tool_ == Tool::Text
-                ? QStringLiteral("Neucha · S  M  L · current %1 · Scroll wheel")
-                      .arg(QString::fromLatin1(kTextSizeNames.at(
-                          static_cast<std::size_t>(textSizeIndex_))))
-                : QStringLiteral("Size %1 · Scroll wheel")
-                      .arg(qRound(annotationSize_));
+        QString tooltip;
+        if (tool_ == Tool::Text) {
+          tooltip =
+              QStringLiteral("Neucha · S  M  L · current %1 · Scroll wheel")
+                  .arg(QString::fromLatin1(kTextSizeNames.at(
+                      static_cast<std::size_t>(textSizeIndex_))));
+        } else if (tool_ == Tool::Spotlight) {
+          tooltip = QStringLiteral("Magnification %1× · Scroll wheel")
+                        .arg(spotlightMagnification_, 0, 'f', 2);
+        } else {
+          tooltip = QStringLiteral("Size %1 · Scroll wheel")
+                        .arg(qRound(annotationSize_));
+        }
         drawInstantTooltip(painter, rect(), button.rect, tooltip);
         break;
       }

--- a/editor.hpp
+++ b/editor.hpp
@@ -91,6 +91,7 @@ private:
                                            const QPointF &second) const;
   [[nodiscard]] QRectF colorPaletteRect() const;
   [[nodiscard]] QRectF customColorPanelRect() const;
+  [[nodiscard]] QRectF spotlightShapePanelRect() const;
   [[nodiscard]] QRectF textSizePanelRect() const;
   [[nodiscard]] QVector<QRectF> cropHandleRects() const;
   [[nodiscard]] int cropHandleAt(const QPointF &point) const;
@@ -144,6 +145,7 @@ private:
   bool busy_ = false;
   bool colorPaletteOpen_ = false;
   bool customColorPickerOpen_ = false;
+  bool spotlightShapePanelOpen_ = false;
   bool usingCustomColor_ = false;
   int hoveredWindow_ = -1;
   int colorIndex_ = 0;
@@ -152,6 +154,7 @@ private:
   int nextMarker_ = 1;
   qreal annotationSize_ = 4.0;
   qreal spotlightMagnification_ = 2.0;
+  SpotlightShape spotlightShape_ = SpotlightShape::Ellipse;
   int textSizeIndex_ = 1;
   QVector<Annotation> annotations_;
   int selectedAnnotation_ = -1;

--- a/editor.hpp
+++ b/editor.hpp
@@ -39,6 +39,7 @@ public:
     Line,
     Freehand,
     Highlighter,
+    Spotlight,
     Marker,
     Rectangle,
     Text,
@@ -150,6 +151,7 @@ private:
   qreal customHue_ = 0.98;
   int nextMarker_ = 1;
   qreal annotationSize_ = 4.0;
+  qreal spotlightMagnification_ = 2.0;
   int textSizeIndex_ = 1;
   QVector<Annotation> annotations_;
   int selectedAnnotation_ = -1;

--- a/icons.cpp
+++ b/icons.cpp
@@ -46,6 +46,12 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     painter.setPen(
         QPen(color, 5.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
     painter.drawLine(QPointF(5, 16), QPointF(19, 8));
+  } else if (action == QStringLiteral("tool-spotlight")) {
+    painter.drawEllipse(QRectF(4, 4, 13, 13));
+    painter.drawLine(QPointF(15.5, 15.5), QPointF(20, 20));
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(color);
+    painter.drawEllipse(QPointF(10.5, 10.5), 2.3, 2.3);
   } else if (action == QStringLiteral("tool-marker")) {
     painter.drawEllipse(QPointF(12, 12), 8, 8);
     QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);

--- a/icons.cpp
+++ b/icons.cpp
@@ -52,6 +52,12 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     painter.setPen(Qt::NoPen);
     painter.setBrush(color);
     painter.drawEllipse(QPointF(10.5, 10.5), 2.3, 2.3);
+  } else if (action == QStringLiteral("spotlight-shape-ellipse")) {
+    painter.drawEllipse(QRectF(3, 6, 18, 12));
+  } else if (action == QStringLiteral("spotlight-shape-rectangle")) {
+    painter.drawRect(QRectF(3, 6, 18, 12));
+  } else if (action == QStringLiteral("spotlight-shape-rounded")) {
+    painter.drawRoundedRect(QRectF(3, 6, 18, 12), 3, 3);
   } else if (action == QStringLiteral("tool-marker")) {
     painter.drawEllipse(QPointF(12, 12), 8, 8);
     QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);


### PR DESCRIPTION
## Summary

- add a separate Spotlight/Loupe annotation tool while keeping the existing highlighter
- support ellipse, rectangle, and rounded-rectangle lenses through a shape popover
- magnify lens contents from 1× to 4× with the mouse wheel
- support selection, moving, resizing, recoloring, undo/redo, and native-resolution export
- keep the annotation toolbar usable on narrow overlays

## Why

Spotlight annotations make a screenshot's focal area easier to inspect by dimming the surrounding image and magnifying the selected region. The separate tool preserves the existing translucent highlighter workflow.

## Validation

- `cmake --build build --parallel`
- `PATH=/usr/bin:/bin QT_QPA_PLATFORM=offscreen ./build/omasnap-smoke /tmp/omasnap-codex-review`
- Codex review against `upstream/main`: no accepted/actionable findings
- manual native-Wayland overlay test with LayerShellQt
