### PR TITLE
fix(pin,main): eliminate QDrag memory leak and truncate error

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -190,10 +190,8 @@ bool parseMonitor(const QByteArray &json, MonitorInfo &monitor,
     const int rawWidth = object.value(QStringLiteral("width")).toInt();
     const int rawHeight = object.value(QStringLiteral("height")).toInt();
     const int transform = object.value(QStringLiteral("transform")).toInt();
-    int logicalWidth =
-        static_cast<int>(std::floor(rawWidth / std::max<qreal>(scale, 0.01)));
-    int logicalHeight =
-        static_cast<int>(std::floor(rawHeight / std::max<qreal>(scale, 0.01)));
+    int logicalWidth = qRound(rawWidth / std::max<qreal>(scale, 0.01));
+    int logicalHeight = qRound(rawHeight / std::max<qreal>(scale, 0.01));
     if (transform == 1 || transform == 3 || transform == 5 || transform == 7)
       std::swap(logicalWidth, logicalHeight);
 

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@
 #include <QUrl>
 #include <QWindow>
 
+#include <cerrno>
 #include <csignal>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -31,10 +32,12 @@ public:
 
     struct sigaction sa{};
     sa.sa_handler = [](int) {
+      const int savedErrno = errno;
       const char byte = 1;
       const int fd = signalFd_;
       if (fd >= 0)
         static_cast<void>(::write(fd, &byte, sizeof(byte)));
+      errno = savedErrno;
     };
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_RESTART;

--- a/pin.cpp
+++ b/pin.cpp
@@ -224,15 +224,18 @@ protected:
     const QList<QUrl> urls{QUrl::fromLocalFile(path_)};
     mime->setUrls(urls);
     mime->setText(urls.constFirst().toLocalFile());
-    QFile file(path_);
-    if (file.open(QIODevice::ReadOnly))
-      mime->setData(QStringLiteral("image/png"), file.readAll());
 
-    QDrag *drag = new QDrag(this);
-    drag->setMimeData(mime);
-    drag->setPixmap(QPixmap::fromImage(image_.scaled(
+    QByteArray pngData;
+    QBuffer buffer(&pngData);
+    buffer.open(QIODevice::WriteOnly);
+    if (image_.save(&buffer, "PNG"))
+      mime->setData(QStringLiteral("image/png"), pngData);
+
+    QDrag drag(this);
+    drag.setMimeData(mime);
+    drag.setPixmap(QPixmap::fromImage(image_.scaled(
         256, 256, Qt::KeepAspectRatio, Qt::SmoothTransformation)));
-    drag->exec(Qt::CopyAction | Qt::MoveAction);
+    drag.exec(Qt::CopyAction | Qt::MoveAction);
   }
 
   void wheelEvent(QWheelEvent *event) override {


### PR DESCRIPTION
    fix(pin,main): eliminate QDrag memory leak and protect signal handler errno

    - pin: use stack allocation for QDrag to guarantee immediate RAII cleanup
      and stream PNG bytes from in-memory QImage instead of re-reading file from disk.
    - main: preserve and restore errno inside PosixSignalNotifier signal handler
      to prevent race conditions with interrupted system calls.

    fix(pin,main): eliminate QDrag memory leak and protect signal handler errno

    - pin: use stack allocation for QDrag to guarantee immediate RAII cleanup
      and stream PNG bytes from in-memory QImage instead of re-reading file from disk.
    - main: preserve and restore errno inside PosixSignalNotifier signal handler
      to prevent race conditions with interrupted system calls.