### PR TITLE
fix(editor): add zero preview dimension guard to sourceRect

### DIFF
--- a/editor.cpp
+++ b/editor.cpp
@@ -511,7 +511,8 @@ QPointF CaptureEditor::toAnnotationPoint(const QPointF &position) const {
 }
 
 QRectF CaptureEditor::sourceRect(const QRectF &logicalRect) const {
-  if (capture_.preview.isNull() || capture_.source.isNull())
+  if (capture_.preview.isNull() || capture_.source.isNull() ||
+      capture_.preview.width() <= 0 || capture_.preview.height() <= 0)
     return {};
   const qreal scaleX =
       capture_.source.width() / static_cast<qreal>(capture_.preview.width());


### PR DESCRIPTION
Fixes a potential division-by-zero (Inf/NaN) in `CaptureEditor::sourceRect`.