### PR TITLE
Fix snapshot corruption when writes fail

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -15,6 +15,7 @@
 #include <QPainterPath>
 #include <QProcess>
 #include <QRandomGenerator>
+#include <QSaveFile>
 #include <QStandardPaths>
 #include <QTemporaryFile>
 
@@ -649,28 +650,23 @@ bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
     return false;
   }
 
-  // Reuse the current file (snapshotPath_ is stable) but never follow a
-  // pre-created symlink.
-  const QByteArray encodedPath = QFile::encodeName(path);
-  const int fd = ::open(encodedPath.constData(),
-                        O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC,
-                        S_IRUSR | S_IWUSR);
-  if (fd < 0 || ::fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
-    if (fd >= 0)
-      ::close(fd);
-    error = QStringLiteral("Could not open secure snapshot file: %1").arg(path);
-    return false;
-  }
-
-  QFile file;
-  if (!file.open(fd, QIODevice::WriteOnly, QFileDevice::AutoCloseHandle)) {
-    ::close(fd);
-    error = QStringLiteral("Could not open snapshot file handle: %1").arg(path);
+  QSaveFile file(path);
+  file.setDirectWriteFallback(false);
+  if (!file.open(QIODevice::WriteOnly) ||
+      !file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner)) {
+    error = QStringLiteral("Could not open secure snapshot file: %1")
+                .arg(file.errorString());
     return false;
   }
 
   if (!image.save(&file, "PNG")) {
+    file.cancelWriting();
     error = QStringLiteral("Could not save temporary snapshot: %1").arg(path);
+    return false;
+  }
+  if (!file.commit()) {
+    error = QStringLiteral("Could not replace temporary snapshot: %1")
+                .arg(file.errorString());
     return false;
   }
   return true;

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -15,6 +15,8 @@
 #include <QtTest/QTest>
 
 #include <algorithm>
+#include <csignal>
+#include <sys/resource.h>
 
 namespace {
 /** Guards the working-snapshot lifecycle: create and overwrite in place. */
@@ -40,6 +42,55 @@ bool runTemporarySnapshotChecks(QString &error) {
     return false; // O_EXCL used to fail on the second call.
   if (reload(path) != secondImage) {
     error = QStringLiteral("Overwritten snapshot did not replace the first");
+    return false;
+  }
+
+  QFile baselineFile(path);
+  if (!baselineFile.open(QIODevice::ReadOnly)) {
+    error = QStringLiteral("Could not read the valid snapshot baseline");
+    return false;
+  }
+  const QByteArray baseline = baselineFile.readAll();
+  baselineFile.close();
+
+  QImage largeImage(512, 512, QImage::Format_ARGB32_Premultiplied);
+  quint32 noise = 0x12345678U;
+  for (int y = 0; y < largeImage.height(); ++y) {
+    for (int x = 0; x < largeImage.width(); ++x) {
+      noise ^= noise << 13;
+      noise ^= noise >> 17;
+      noise ^= noise << 5;
+      largeImage.setPixel(x, y, 0xff000000U | (noise & 0x00ffffffU));
+    }
+  }
+
+  struct rlimit originalLimit{};
+  struct sigaction originalSignal{};
+  struct sigaction ignoredSignal{};
+  ignoredSignal.sa_handler = SIG_IGN;
+  sigemptyset(&ignoredSignal.sa_mask);
+  if (::getrlimit(RLIMIT_FSIZE, &originalLimit) != 0 ||
+      ::sigaction(SIGXFSZ, &ignoredSignal, &originalSignal) != 0) {
+    error = QStringLiteral("Could not prepare the interrupted-write check");
+    return false;
+  }
+  struct rlimit limited = originalLimit;
+  limited.rlim_cur = std::min<rlim_t>(originalLimit.rlim_cur, 1024);
+  const bool limitSet = ::setrlimit(RLIMIT_FSIZE, &limited) == 0;
+  QString writeError;
+  const bool interruptedSave =
+      limitSet && saveTemporarySnapshot(largeImage, path, writeError);
+  const bool limitRestored = ::setrlimit(RLIMIT_FSIZE, &originalLimit) == 0;
+  const bool signalRestored =
+      ::sigaction(SIGXFSZ, &originalSignal, nullptr) == 0;
+
+  QFile preservedFile(path);
+  const bool preservedOpened = preservedFile.open(QIODevice::ReadOnly);
+  const QByteArray preserved = preservedFile.readAll();
+  if (!limitSet || interruptedSave || !limitRestored || !signalRestored ||
+      !preservedOpened || preserved != baseline) {
+    error = QStringLiteral(
+        "A failed snapshot write did not preserve the previous PNG");
     return false;
   }
 


### PR DESCRIPTION
## Summary

  - Write snapshots to a temporary file before replacing the existing PNG.
  - Preserve the previous valid snapshot if encoding or writing fails.
  - Keep snapshot permissions restricted to the current user.
  - Add a smoke test that forces a failed write and confirms the previous PNG remains unchanged.

  ## Testing

  - Full smoke suite passed with GCC and Clang.
  - AddressSanitizer and UndefinedBehaviorSanitizer passed.
  - `git diff --check` passed.

  Branch: fix/atomic-snapshot-writes
  Commit: 60601ae