### PR TITLE
Fix active pin snapshot lifecycle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ qt_add_executable(omasnap
   icons.hpp
   pin.cpp
   pin.hpp
+  pin-file.cpp
+  pin-file.hpp
   capture.cpp
   capture.hpp
   surface-capture.cpp
@@ -65,6 +67,12 @@ target_link_libraries(omasnap PRIVATE
 
 qt_add_executable(omasnap-smoke
   editor-smoke.cpp
+  pin-lifecycle-smoke.cpp
+  pin-lifecycle-smoke.hpp
+  pin-file.cpp
+  pin-file.hpp
+  pin.cpp
+  pin.hpp
   icons.cpp
   icons.hpp
   transform-smoke.cpp
@@ -90,6 +98,7 @@ target_link_libraries(omasnap-smoke PRIVATE
   Qt6::Gui
   Qt6::Test
   Qt6::Widgets
+  LayerShellQt::Interface
   PkgConfig::WaylandClient
 )
 

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ Install the corresponding Tesseract language data before adding a language to
 
 ### Pinned captures
 
-`P` renders the current capture, writes it to a `pin-<pid>-<n>.png` under the runtime
-snapshot directory, and launches the same `omasnap` executable in detached pin mode.
+`P` renders the current capture, writes it to a `pin-<pid>-<n>-<random>.png` under the
+runtime snapshot directory, and launches the same `omasnap` executable in detached pin mode.
 The layer-shell surface is anchored 14 logical pixels from the bottom-right corner and
 stays visible on every workspace without compositor window rules. It preserves the image
 aspect ratio, with a maximum width of one third of the screen and a maximum height of one

--- a/capture.cpp
+++ b/capture.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <fcntl.h>
 #include <limits>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -612,11 +613,15 @@ QString temporarySnapshotPath() {
 }
 
 QString pinnedSnapshotPath(int index) {
-  return runtimePath(QStringLiteral("pin-%1-%2.png")
-                         .arg(QCoreApplication::applicationPid())
-                         .arg(index));
+  // A fresh nonce prevents collisions when the editor PID is recycled.
+  return runtimePath(
+      QStringLiteral("pin-%1-%2-%3.png")
+          .arg(QCoreApplication::applicationPid())
+          .arg(index)
+          .arg(QRandomGenerator::system()->generate64(), 16, 16, QChar('0')));
 }
 
+/** Removes stale pin files that no running pin still holds. */
 void prunePinnedSnapshots() {
   const QString runtime = secureRuntimeDirectory();
   if (runtime.isEmpty())
@@ -625,8 +630,18 @@ void prunePinnedSnapshots() {
   const QFileInfoList stale =
       QDir(runtime).entryInfoList({QStringLiteral("pin-*.png")}, QDir::Files);
   for (const QFileInfo &entry : stale) {
-    if (entry.lastModified() < cutoff)
-      QFile::remove(entry.absoluteFilePath());
+    if (entry.lastModified() >= cutoff)
+      continue;
+    const QByteArray encodedPath = QFile::encodeName(entry.absoluteFilePath());
+    const int fd = ::open(encodedPath.constData(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0 || ::flock(fd, LOCK_EX | LOCK_NB) != 0) {
+      if (fd >= 0)
+        ::close(fd);
+      continue;
+    }
+    QFile::remove(entry.absoluteFilePath());
+    ::flock(fd, LOCK_UN);
+    ::close(fd);
   }
 }
 

--- a/capture.hpp
+++ b/capture.hpp
@@ -82,6 +82,7 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
                                                 QString &error);
 [[nodiscard]] QString temporarySnapshotPath();
 [[nodiscard]] QString pinnedSnapshotPath(int index);
+/** Removes abandoned pin files without touching active pins. */
 void prunePinnedSnapshots();
 [[nodiscard]] bool saveTemporarySnapshot(const QImage &image, QString path,
                                          QString &error);

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -2,6 +2,7 @@
  */
 #include "capture.hpp"
 #include "editor.hpp"
+#include "pin-lifecycle-smoke.hpp"
 #include "transform-smoke.hpp"
 
 #include <QApplication>
@@ -149,6 +150,10 @@ int main(int argc, char **argv) {
   if (!runTemporarySnapshotChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 68;
+  }
+  if (!runPinLifecycleSmoke(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 71;
   }
   if (!runHighlighterRenderingCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/pin-file.cpp
+++ b/pin-file.cpp
@@ -1,0 +1,43 @@
+/** @fileoverview Implements pinned snapshot file locking. */
+#include "pin-file.hpp"
+
+#include "capture.hpp"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
+PinSnapshotFile::PinSnapshotFile(QString path)
+    : path_(QFileInfo(path).absoluteFilePath()) {
+  fd_ = ::open(QFile::encodeName(path_).constData(),
+               O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+  if (fd_ < 0 || ::flock(fd_, LOCK_SH | LOCK_NB) != 0) {
+    if (fd_ >= 0)
+      ::close(fd_);
+    fd_ = -1;
+  }
+}
+
+PinSnapshotFile::~PinSnapshotFile() {
+  const bool locked = fd_ >= 0;
+  if (fd_ >= 0) {
+    ::flock(fd_, LOCK_UN);
+    ::close(fd_);
+  }
+  static const QRegularExpression internalName(
+      QStringLiteral("^pin-[1-9][0-9]*-[1-9][0-9]*-[0-9a-f]{16}\\.png$"));
+  const QFileInfo fileInfo(path_);
+  const QString runtime = secureRuntimeDirectory();
+  if (locked && !preserve_ && !runtime.isEmpty() &&
+      fileInfo.absolutePath() == runtime &&
+      internalName.match(fileInfo.fileName()).hasMatch())
+    QFile::remove(path_);
+}
+
+bool PinSnapshotFile::isLocked() const { return fd_ >= 0; }
+
+void PinSnapshotFile::preserveForEditor() { preserve_ = true; }

--- a/pin-file.hpp
+++ b/pin-file.hpp
@@ -1,0 +1,26 @@
+/** @fileoverview Owns a lock for a pinned snapshot file. */
+#pragma once
+
+#include <QString>
+
+/** Tracks a pinned snapshot while its window is open. */
+class PinSnapshotFile {
+public:
+  /** Opens and locks the supplied snapshot path. */
+  explicit PinSnapshotFile(QString path);
+  /** Releases the lock and removes an owned internal snapshot. */
+  ~PinSnapshotFile();
+
+  PinSnapshotFile(const PinSnapshotFile &) = delete;
+  PinSnapshotFile &operator=(const PinSnapshotFile &) = delete;
+
+  /** Returns whether the snapshot lock is held. */
+  [[nodiscard]] bool isLocked() const;
+  /** Keeps the snapshot for reopening in the editor. */
+  void preserveForEditor();
+
+private:
+  QString path_;
+  int fd_ = -1;
+  bool preserve_ = false;
+};

--- a/pin-lifecycle-smoke.cpp
+++ b/pin-lifecycle-smoke.cpp
@@ -1,0 +1,159 @@
+/** @fileoverview Tests the lifetime rules for pinned screenshot files. */
+#include "pin-lifecycle-smoke.hpp"
+
+#include "capture.hpp"
+#include "pin-file.hpp"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QImage>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
+/** Verifies pin names, ownership, cleanup, preservation, and pruning. */
+bool runPinLifecycleSmoke(QString &error) {
+  const QString firstPath = pinnedSnapshotPath(987654);
+  const QString secondPath = pinnedSnapshotPath(987654);
+  if (firstPath.isEmpty() || secondPath.isEmpty() || firstPath == secondPath) {
+    error = QStringLiteral("Pinned snapshot paths are not unique");
+    return false;
+  }
+
+  QImage image(8, 8, QImage::Format_ARGB32_Premultiplied);
+  image.fill(Qt::white);
+  const QString closePath = pinnedSnapshotPath(987656);
+  if (!saveTemporarySnapshot(image, closePath, error))
+    return false;
+  {
+    PinSnapshotFile file(closePath);
+    if (!file.isLocked()) {
+      error = QStringLiteral("Normal pin snapshot was not locked");
+      QFile::remove(closePath);
+      return false;
+    }
+  }
+  if (QFileInfo::exists(closePath)) {
+    error = QStringLiteral("Normal pin close did not remove its snapshot");
+    QFile::remove(closePath);
+    return false;
+  }
+
+  const QString lockedPath = pinnedSnapshotPath(987658);
+  if (!saveTemporarySnapshot(image, lockedPath, error))
+    return false;
+  const int lockedFd =
+      ::open(QFile::encodeName(lockedPath).constData(), O_RDONLY | O_CLOEXEC);
+  if (lockedFd < 0 || ::flock(lockedFd, LOCK_EX | LOCK_NB) != 0) {
+    error = QStringLiteral("Could not hold exclusive pin snapshot lock");
+    if (lockedFd >= 0)
+      ::close(lockedFd);
+    QFile::remove(lockedPath);
+    return false;
+  }
+  {
+    PinSnapshotFile file(lockedPath);
+    if (file.isLocked()) {
+      error = QStringLiteral("Contended pin snapshot unexpectedly locked");
+      ::flock(lockedFd, LOCK_UN);
+      ::close(lockedFd);
+      QFile::remove(lockedPath);
+      return false;
+    }
+  }
+  ::flock(lockedFd, LOCK_UN);
+  ::close(lockedFd);
+  if (!QFileInfo::exists(lockedPath)) {
+    error = QStringLiteral("Unowned pin snapshot was removed");
+    return false;
+  }
+  QFile::remove(lockedPath);
+
+  const QString reopenPath = pinnedSnapshotPath(987657);
+  if (!saveTemporarySnapshot(image, reopenPath, error))
+    return false;
+  {
+    PinSnapshotFile file(reopenPath);
+    if (!file.isLocked()) {
+      error = QStringLiteral("Reopened pin snapshot was not locked");
+      QFile::remove(reopenPath);
+      return false;
+    }
+    file.preserveForEditor();
+  }
+  if (!QFileInfo::exists(reopenPath)) {
+    error = QStringLiteral("Reopened pin snapshot was not preserved");
+    return false;
+  }
+  QFile::remove(reopenPath);
+
+  const QString unrelatedPath =
+      QDir(secureRuntimeDirectory()).filePath(QStringLiteral("manual.png"));
+  if (!saveTemporarySnapshot(image, unrelatedPath, error))
+    return false;
+  {
+    PinSnapshotFile file(unrelatedPath);
+    if (!file.isLocked()) {
+      error = QStringLiteral("Unrelated runtime file was not locked");
+      QFile::remove(unrelatedPath);
+      return false;
+    }
+  }
+  if (!QFileInfo::exists(unrelatedPath)) {
+    error = QStringLiteral("Unrelated runtime file was removed");
+    return false;
+  }
+  QFile::remove(unrelatedPath);
+
+  const QString path = pinnedSnapshotPath(987654);
+  if (!saveTemporarySnapshot(image, path, error))
+    return false;
+  QFile agedFile(path);
+  if (!agedFile.open(QIODevice::ReadOnly) ||
+      !agedFile.setFileTime(QDateTime::currentDateTime().addDays(-2),
+                            QFileDevice::FileModificationTime)) {
+    error = QStringLiteral("Could not age pin snapshot");
+    QFile::remove(path);
+    return false;
+  }
+  agedFile.close();
+
+  bool survived = false;
+  {
+    PinSnapshotFile file(path);
+    if (!file.isLocked()) {
+      error = QStringLiteral("Could not hold pin snapshot lock");
+      QFile::remove(path);
+      return false;
+    }
+    prunePinnedSnapshots();
+    survived = QFileInfo::exists(path);
+  }
+  if (!survived) {
+    error = QStringLiteral("Active pin snapshot was pruned");
+    return false;
+  }
+
+  const QString abandonedPath = pinnedSnapshotPath(987655);
+  if (!saveTemporarySnapshot(image, abandonedPath, error))
+    return false;
+  QFile abandonedFile(abandonedPath);
+  if (!abandonedFile.open(QIODevice::ReadOnly) ||
+      !abandonedFile.setFileTime(QDateTime::currentDateTime().addDays(-2),
+                                 QFileDevice::FileModificationTime)) {
+    error = QStringLiteral("Could not age abandoned pin snapshot");
+    QFile::remove(abandonedPath);
+    return false;
+  }
+  abandonedFile.close();
+  prunePinnedSnapshots();
+  if (QFileInfo::exists(abandonedPath)) {
+    error = QStringLiteral("Abandoned pin snapshot was not pruned");
+    QFile::remove(abandonedPath);
+    return false;
+  }
+  return true;
+}

--- a/pin-lifecycle-smoke.hpp
+++ b/pin-lifecycle-smoke.hpp
@@ -1,0 +1,7 @@
+/** @fileoverview Declares pin file lifecycle smoke checks. */
+#pragma once
+
+class QString;
+
+/** Verifies pin naming, ownership, cleanup, and stale-file pruning. */
+[[nodiscard]] bool runPinLifecycleSmoke(QString &error);

--- a/pin.cpp
+++ b/pin.cpp
@@ -1,5 +1,7 @@
+/** @fileoverview Displays and manages pinned screenshot layers. */
 #include "pin.hpp"
 #include "icons.hpp"
+#include "pin-file.hpp"
 
 #include <LayerShellQt/Window>
 #include <QApplication>
@@ -74,7 +76,8 @@ bool copyPngToClipboard(const QImage &image, QString &error) {
   return true;
 }
 
-bool copyTextToClipboard(const QString &text, QString &error) {
+/** Copies pin text through the persistent Wayland clipboard. */
+bool copyPinTextToClipboard(const QString &text, QString &error) {
   QProcess copy;
   copy.start(
       QStringLiteral("wl-copy"),
@@ -96,13 +99,17 @@ bool copyTextToClipboard(const QString &text, QString &error) {
 
 class PinWindow final : public QWidget {
 public:
+  /** Creates a pin and holds its backing file open. */
   explicit PinWindow(QImage image, QString path)
-      : image_(std::move(image)), path_(std::move(path)) {
+      : image_(std::move(image)), path_(std::move(path)), snapshotFile_(path_) {
     setWindowTitle(QStringLiteral("omasnap-pin"));
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
     setMouseTracking(true);
     resize(initialSize());
   }
+
+  /** Returns whether this process owns the pin's shared file lock. */
+  [[nodiscard]] bool hasPinLock() const { return snapshotFile_.isLocked(); }
 
 protected:
   void paintEvent(QPaintEvent *) override {
@@ -183,7 +190,7 @@ protected:
       }
       if (pathButtonRect().contains(position)) {
         QString error;
-        showToast(copyTextToClipboard(path_, error)
+        showToast(copyPinTextToClipboard(path_, error)
                       ? QStringLiteral("Copied path")
                       : error);
         return;
@@ -195,13 +202,15 @@ protected:
     }
   }
 
-  // Send the pinned image back to the omasnap editor, replacing the pin.
+  /** Reopens the file without deleting it during process handoff. */
   void reopenInEditor() {
     if (!QProcess::startDetached(QCoreApplication::applicationFilePath(),
                                  {path_}))
       showToast(QStringLiteral("Could not start omasnap"));
-    else
+    else {
+      snapshotFile_.preserveForEditor();
       close();
+    }
   }
 
   void mouseMoveEvent(QMouseEvent *event) override {
@@ -380,6 +389,7 @@ private:
   QString hoverTip_;
   bool hovered_ = false;
   int hoveredControl_ = -1;
+  PinSnapshotFile snapshotFile_;
 };
 
 } // namespace
@@ -392,6 +402,10 @@ int runPinnedCapture(const QString &path) {
   }
 
   PinWindow window(std::move(image), path);
+  if (!window.hasPinLock()) {
+    qWarning("omasnap: could not lock pinned image %s", qUtf8Printable(path));
+    return 1;
+  }
   static_cast<void>(window.winId());
   QWindow *handle = window.windowHandle();
   LayerShellQt::Window *layer =

--- a/pin.hpp
+++ b/pin.hpp
@@ -1,6 +1,7 @@
+/** @fileoverview Declares the pinned screenshot window. */
 #pragma once
 
 #include <QString>
 
-/** Runs a detached pinned-image layer using the current Omasnap process. */
+/** Displays a pinned screenshot until its window closes. */
 [[nodiscard]] int runPinnedCapture(const QString &path);


### PR DESCRIPTION
## Summary

  - Keep each active pin snapshot locked so stale-file cleanup cannot remove it.
  - Give every pin filename a random value to prevent filename reuse.
  - Remove internal pin snapshots when their pin closes normally.
  - Preserve snapshots when reopening them in the editor.
  - Avoid deleting unrelated runtime files or files that Omasnap could not lock.
  - Compile pin handling into the smoke target and add lifecycle coverage.
  - Update the documented pin filename format.

  ## Testing

  - Covered unique filenames, normal close, editor preservation, lock failure, unrelated files, active-pin pruning, and abandoned-
  pin cleanup.
  - Full smoke suite passed with GCC and Clang.
  - AddressSanitizer and UndefinedBehaviorSanitizer passed.
  - Formatting and `git diff --check` passed.

  Branch: fix/active-pin-lifecycle
  Commit: f7a313b