### PR TITLE
fix: support positional file URLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ endforeach()
 
 qt_add_executable(omasnap
   main.cpp
+  cli-path.cpp
+  cli-path.hpp
   icons.cpp
   icons.hpp
   pin.cpp
@@ -69,6 +71,8 @@ qt_add_executable(omasnap-smoke
   icons.hpp
   transform-smoke.cpp
   transform-smoke.hpp
+  cli-path.cpp
+  cli-path.hpp
   capture.cpp
   capture.hpp
   surface-capture.cpp

--- a/cli-path.cpp
+++ b/cli-path.cpp
@@ -1,0 +1,24 @@
+/** @fileoverview Resolves local image targets accepted by the command line. */
+#include "cli-path.hpp"
+
+#include <QFileInfo>
+#include <QUrl>
+
+QString resolveLocalImagePath(const QString &target) {
+  if (target.isEmpty())
+    return {};
+
+  const QUrl url(target);
+  QString path;
+  if (url.isLocalFile())
+    path = url.toLocalFile();
+  else if (!url.scheme().isEmpty() &&
+           target.startsWith(url.scheme() + QStringLiteral("://"),
+                             Qt::CaseInsensitive))
+    return {};
+  else
+    path = target;
+
+  const QFileInfo file(path);
+  return file.isFile() ? file.absoluteFilePath() : QString{};
+}

--- a/cli-path.hpp
+++ b/cli-path.hpp
@@ -1,0 +1,7 @@
+/** @fileoverview Resolves local image targets accepted by the command line. */
+#pragma once
+
+#include <QString>
+
+/** Returns an existing local path for a raw path or local file URL. */
+QString resolveLocalImagePath(const QString &target);

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -1,6 +1,7 @@
 /** @fileoverview Exercises capture editor behavior without a live compositor.
  */
 #include "capture.hpp"
+#include "cli-path.hpp"
 #include "editor.hpp"
 #include "transform-smoke.hpp"
 
@@ -11,12 +12,55 @@
 #include <QFileInfo>
 #include <QPainter>
 #include <QTemporaryDir>
+#include <QUrl>
 #include <QWheelEvent>
 #include <QtTest/QTest>
 
 #include <algorithm>
 
 namespace {
+/** Checks that positional local image targets are recognized. */
+bool runPositionalImageTargetCheck(QString &error) {
+  QTemporaryDir directory;
+  if (!directory.isValid()) {
+    error = QStringLiteral("Could not create positional target directory");
+    return false;
+  }
+  const QString path = QDir(directory.path())
+                           .filePath(QStringLiteral("image with # marker.png"));
+  QImage image(8, 8, QImage::Format_ARGB32_Premultiplied);
+  image.fill(Qt::white);
+  const QString url = QUrl::fromLocalFile(path).toString();
+  const QString previousDirectory = QDir::currentPath();
+  const QString colonName = QStringLiteral("image:one.png");
+  const QString colonPath = QDir(directory.path()).filePath(colonName);
+  const QString remoteLookalikeName =
+      QStringLiteral("https:/example.com/image.png");
+  const bool savedColonImage = image.save(colonPath, "PNG");
+  const bool changedDirectory = QDir::setCurrent(directory.path());
+  const QString resolvedColonPath = resolveLocalImagePath(colonName);
+  const bool createdRemoteLookalike =
+      changedDirectory && QDir().mkpath(QStringLiteral("https:/example.com")) &&
+      image.save(remoteLookalikeName, "PNG");
+  const QString resolvedRemoteUrl = createdRemoteLookalike
+                                        ? resolveLocalImagePath(QStringLiteral(
+                                              "https://example.com/image.png"))
+                                        : QStringLiteral("setup failed");
+  QDir::setCurrent(previousDirectory);
+  if (!image.save(path, "PNG") || resolveLocalImagePath(path) != path ||
+      resolveLocalImagePath(url) != path || !changedDirectory ||
+      resolvedColonPath != colonPath || !savedColonImage ||
+      !createdRemoteLookalike || !resolvedRemoteUrl.isEmpty() ||
+      !resolveLocalImagePath(
+           QDir(directory.path()).filePath(QStringLiteral("missing.png")))
+           .isEmpty()) {
+    error =
+        QStringLiteral("Local file URL was not recognized as an image target");
+    return false;
+  }
+  return true;
+}
+
 /** Guards the working-snapshot lifecycle: create and overwrite in place. */
 bool runTemporarySnapshotChecks(QString &error) {
   const QString path = temporarySnapshotPath();
@@ -146,6 +190,10 @@ int main(int argc, char **argv) {
   if (!loadCaptureFonts())
     return 17;
   QString snapshotError;
+  if (!runPositionalImageTargetCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 70;
+  }
   if (!runTemporarySnapshotChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 68;

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
 #include "capture.hpp"
+#include "cli-path.hpp"
 #include "editor.hpp"
 #include "pin.hpp"
 
@@ -8,7 +9,6 @@
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QDir>
-#include <QFileInfo>
 #include <QGuiApplication>
 #include <QLockFile>
 #include <QScreen>
@@ -156,9 +156,9 @@ int main(int argc, char **argv) {
     return 2;
   }
   if (!positional.isEmpty()) {
-    const QFileInfo target(positional.first());
-    if (filePath.isEmpty() && target.isFile()) {
-      filePath = positional.first();
+    const QString localTarget = resolveLocalImagePath(positional.first());
+    if (filePath.isEmpty() && !localTarget.isEmpty()) {
+      filePath = localTarget;
     } else {
       ++requestedModes;
       const QString mode = positional.first();


### PR DESCRIPTION
## Summary

  - Open local `file://` URLs passed as positional arguments.
  - Continue supporting normal local file paths.
  - Reject remote URLs, even when a similar local path exists.
  - Cover paths containing spaces, `#`, and `:`.

  This fixes notification actions that pass the saved screenshot
  as a `file://` URL.

  ## Testing

  - Added regression coverage for local paths, file URLs,
  missing files, and remote URL lookalikes.
  - Confirmed the new test fails against the old behavior and
  passes after the fix.
  - Full headless smoke tests passed with GCC and Clang.
  - AddressSanitizer and UndefinedBehaviorSanitizer passed.
  - Formatting and `git diff --check` passed.

  Branch: fix/file-url-targets
  Commit: 9161ac1