### PR TITLE
Add quick copy and save capture modes

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -39,6 +39,14 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: ./build/omasnap-smoke /tmp/omasnap-smoke
 
+      - name: Run focused smokes
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          for smoke in ./build/omasnap-*-smoke; do
+            "$smoke"
+          done
+
       - name: Stage installation
         run: cmake --install build --prefix "$PWD/stage/usr"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,22 @@ qt_add_executable(omasnap-smoke
   editor.cpp
   editor.hpp
 )
+
+qt_add_executable(omasnap-quick-output-smoke
+  quick-output-smoke.cpp
+  capture.cpp
+  capture.hpp
+  surface-capture.cpp
+  ${PROTOCOL_SOURCES}
+)
+target_include_directories(omasnap-quick-output-smoke PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+target_compile_features(omasnap-quick-output-smoke PRIVATE cxx_std_23)
+target_compile_options(omasnap-quick-output-smoke PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(omasnap-quick-output-smoke PRIVATE
+  Qt6::Core
+  Qt6::Gui
+  PkgConfig::WaylandClient
+)
 qt_add_resources(omasnap-smoke "capture-fonts-smoke"
   PREFIX "/fonts"
   BASE "${CMAKE_CURRENT_SOURCE_DIR}/assets"

--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ omasnap smart       # maps to region selection
 These options choose what is initially selected; the editor still controls whether the
 result is copied, saved, or both.
 
+Quick output skips the annotation editor. Add `--copy` to copy only, `--save` to save
+only, or both flags to copy and save. Region and window captures output after selection;
+fullscreen captures output immediately. Quick output cannot be combined with `--file` or
+`--pin`.
+
 ### Edit an existing image
 
 Point omasnap at any readable image and it opens straight into the annotation editor

--- a/capture.cpp
+++ b/capture.cpp
@@ -15,6 +15,7 @@
 #include <QPainterPath>
 #include <QProcess>
 #include <QRandomGenerator>
+#include <QSaveFile>
 #include <QStandardPaths>
 #include <QTemporaryFile>
 
@@ -649,28 +650,23 @@ bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
     return false;
   }
 
-  // Reuse the current file (snapshotPath_ is stable) but never follow a
-  // pre-created symlink.
-  const QByteArray encodedPath = QFile::encodeName(path);
-  const int fd = ::open(encodedPath.constData(),
-                        O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC,
-                        S_IRUSR | S_IWUSR);
-  if (fd < 0 || ::fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
-    if (fd >= 0)
-      ::close(fd);
-    error = QStringLiteral("Could not open secure snapshot file: %1").arg(path);
-    return false;
-  }
-
-  QFile file;
-  if (!file.open(fd, QIODevice::WriteOnly, QFileDevice::AutoCloseHandle)) {
-    ::close(fd);
-    error = QStringLiteral("Could not open snapshot file handle: %1").arg(path);
+  QSaveFile file(path);
+  file.setDirectWriteFallback(false);
+  if (!file.open(QIODevice::WriteOnly) ||
+      !file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner)) {
+    error = QStringLiteral("Could not open secure snapshot file: %1")
+                .arg(file.errorString());
     return false;
   }
 
   if (!image.save(&file, "PNG")) {
+    file.cancelWriting();
     error = QStringLiteral("Could not save temporary snapshot: %1").arg(path);
+    return false;
+  }
+  if (!file.commit()) {
+    error = QStringLiteral("Could not replace temporary snapshot: %1")
+                .arg(file.errorString());
     return false;
   }
   return true;

--- a/capture.cpp
+++ b/capture.cpp
@@ -589,6 +589,37 @@ bool copyPngFileToClipboard(const QString &path, QString &error) {
   return copyToWaylandClipboard(QStringLiteral("image/png"), png, error);
 }
 
+bool quickOutput(const QImage &image, QuickOutputMode mode, QString &error) {
+  if (image.isNull() || mode == QuickOutputMode::None) {
+    error = QStringLiteral("Could not prepare screenshot snapshot");
+    return false;
+  }
+  const QString path = temporarySnapshotPath();
+  if (path.isEmpty() || !saveTemporarySnapshot(image, path, error))
+    return false;
+
+  if (mode == QuickOutputMode::Copy || mode == QuickOutputMode::Both) {
+    if (!copyPngFileToClipboard(path, error)) {
+      QFile::remove(path);
+      return false;
+    }
+  }
+  if (mode == QuickOutputMode::Save || mode == QuickOutputMode::Both) {
+    const QString saved = moveSnapshotToScreenshots(path, error);
+    if (saved.isEmpty())
+      return false;
+    if (mode == QuickOutputMode::Save)
+      sendCaptureNotification(QStringLiteral("Screenshot saved"), saved);
+    else
+      sendCaptureNotification(QStringLiteral("Screenshot saved and copied"),
+                              saved);
+  } else {
+    QFile::remove(path);
+    sendCaptureNotification(QStringLiteral("Screenshot copied to clipboard"));
+  }
+  return true;
+}
+
 QString moveSnapshotToScreenshots(const QString &sourcePath, QString &error) {
   const QString targetPath = screenshotTargetPath(error);
   if (targetPath.isEmpty())

--- a/capture.hpp
+++ b/capture.hpp
@@ -36,6 +36,9 @@ struct CaptureData {
 
 enum class BackgroundStyle { None, Aurora, Sunset, Lagoon, Violet };
 
+/** Selects whether a quick capture is copied, saved, or both. */
+enum class QuickOutputMode { None, Copy, Save, Both };
+
 struct Annotation {
   enum class Kind {
     Arrow,
@@ -70,6 +73,9 @@ struct Annotation {
                                    const QVector<Annotation> &annotations,
                                    BackgroundStyle backgroundStyle);
 [[nodiscard]] bool copyPngFileToClipboard(const QString &path, QString &error);
+/** Writes a rendered capture to the requested quick-output destination. */
+[[nodiscard]] bool quickOutput(const QImage &image, QuickOutputMode mode,
+                               QString &error);
 [[nodiscard]] bool copyTextToClipboard(const QString &text, QString &error);
 void paintAnnotation(QPainter &painter, const Annotation &annotation);
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -15,8 +15,12 @@
 #include <QtTest/QTest>
 
 #include <algorithm>
+#include <array>
+#include <cerrno>
 #include <csignal>
+#include <sys/inotify.h>
 #include <sys/resource.h>
+#include <unistd.h>
 
 namespace {
 /** Guards the working-snapshot lifecycle: create and overwrite in place. */
@@ -190,6 +194,29 @@ bool runHighlighterRenderingCheck(QString &error) {
   }
   return true;
 }
+
+/** Counts atomic commits to the working snapshot after a quick capture. */
+int snapshotCommitCount(int fd, const QString &snapshotPath) {
+  const QByteArray target = QFileInfo(snapshotPath).fileName().toUtf8();
+  std::array<char, 4096> buffer{};
+  int count = 0;
+  for (;;) {
+    const ssize_t length = ::read(fd, buffer.data(), buffer.size());
+    if (length < 0 && errno == EINTR)
+      continue;
+    if (length <= 0)
+      break;
+    for (ssize_t offset = 0; offset < length;) {
+      const auto *event = reinterpret_cast<const inotify_event *>(
+          buffer.data() + offset);
+      if ((event->mask & (IN_CREATE | IN_MOVED_TO)) != 0 && event->len > 0 &&
+          QByteArray(event->name) == target)
+        ++count;
+      offset += sizeof(inotify_event) + event->len;
+    }
+  }
+  return count;
+}
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
 int main(int argc, char **argv) {
@@ -253,6 +280,44 @@ int main(int argc, char **argv) {
   capture.windows = {
       {{80, 80, 300, 220}, QStringLiteral("1"), QStringLiteral("first")},
       {{420, 120, 300, 320}, QStringLiteral("2"), QStringLiteral("second")}};
+
+  {
+    CaptureEditor quickEditor(capture, CaptureEditor::CaptureMode::Region,
+                              QuickOutputMode::Save);
+    quickEditor.resize(800, 600);
+    quickEditor.show();
+    application.processEvents();
+    QTest::mousePress(&quickEditor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(100, 100));
+    QTest::mouseMove(&quickEditor, QPoint(650, 470), 20);
+    const int snapshotWatch = ::inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+    const int watch = snapshotWatch >= 0
+                          ? ::inotify_add_watch(
+                                snapshotWatch,
+                                QFile::encodeName(secureRuntimeDirectory())
+                                    .constData(),
+                                IN_CREATE | IN_MOVED_TO)
+                          : -1;
+    if (watch < 0) {
+      if (snapshotWatch >= 0)
+        ::close(snapshotWatch);
+      return 75;
+    }
+    QTest::mouseRelease(&quickEditor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(650, 470));
+    application.processEvents();
+    const int snapshotCommits = snapshotCommitCount(snapshotWatch, snapshotPath);
+    ::inotify_rm_watch(snapshotWatch, watch);
+    ::close(snapshotWatch);
+    const QStringList files =
+        QDir(savedRoot).entryList({QStringLiteral("*.png")}, QDir::Files);
+    if (quickEditor.isVisible() || files.size() != 1 ||
+        QImage(QDir(savedRoot).filePath(files.constFirst())).isNull())
+      return 73;
+    if (snapshotCommits != 1)
+      return 76;
+  }
+  QDir(savedRoot).removeRecursively();
 
   CaptureEditor editor(capture);
   editor.resize(800, 600);

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -15,6 +15,8 @@
 #include <QtTest/QTest>
 
 #include <algorithm>
+#include <csignal>
+#include <sys/resource.h>
 
 namespace {
 /** Guards the working-snapshot lifecycle: create and overwrite in place. */
@@ -40,6 +42,55 @@ bool runTemporarySnapshotChecks(QString &error) {
     return false; // O_EXCL used to fail on the second call.
   if (reload(path) != secondImage) {
     error = QStringLiteral("Overwritten snapshot did not replace the first");
+    return false;
+  }
+
+  QFile baselineFile(path);
+  if (!baselineFile.open(QIODevice::ReadOnly)) {
+    error = QStringLiteral("Could not read the valid snapshot baseline");
+    return false;
+  }
+  const QByteArray baseline = baselineFile.readAll();
+  baselineFile.close();
+
+  QImage largeImage(512, 512, QImage::Format_ARGB32_Premultiplied);
+  quint32 noise = 0x12345678U;
+  for (int y = 0; y < largeImage.height(); ++y) {
+    for (int x = 0; x < largeImage.width(); ++x) {
+      noise ^= noise << 13;
+      noise ^= noise >> 17;
+      noise ^= noise << 5;
+      largeImage.setPixel(x, y, 0xff000000U | (noise & 0x00ffffffU));
+    }
+  }
+
+  struct rlimit originalLimit{};
+  struct sigaction originalSignal{};
+  struct sigaction ignoredSignal{};
+  ignoredSignal.sa_handler = SIG_IGN;
+  sigemptyset(&ignoredSignal.sa_mask);
+  if (::getrlimit(RLIMIT_FSIZE, &originalLimit) != 0 ||
+      ::sigaction(SIGXFSZ, &ignoredSignal, &originalSignal) != 0) {
+    error = QStringLiteral("Could not prepare the interrupted-write check");
+    return false;
+  }
+  struct rlimit limited = originalLimit;
+  limited.rlim_cur = std::min<rlim_t>(originalLimit.rlim_cur, 1024);
+  const bool limitSet = ::setrlimit(RLIMIT_FSIZE, &limited) == 0;
+  QString writeError;
+  const bool interruptedSave =
+      limitSet && saveTemporarySnapshot(largeImage, path, writeError);
+  const bool limitRestored = ::setrlimit(RLIMIT_FSIZE, &originalLimit) == 0;
+  const bool signalRestored =
+      ::sigaction(SIGXFSZ, &originalSignal, nullptr) == 0;
+
+  QFile preservedFile(path);
+  const bool preservedOpened = preservedFile.open(QIODevice::ReadOnly);
+  const QByteArray preserved = preservedFile.readAll();
+  if (!limitSet || interruptedSave || !limitRestored || !signalRestored ||
+      !preservedOpened || preserved != baseline) {
+    error = QStringLiteral(
+        "A failed snapshot write did not preserve the previous PNG");
     return false;
   }
 

--- a/editor.cpp
+++ b/editor.cpp
@@ -171,8 +171,9 @@ QString backgroundName(BackgroundStyle style) {
 } // namespace
 
 CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
-                             QWidget *parent)
-    : QWidget(parent), capture_(std::move(capture)) {
+                             QuickOutputMode quickOutput, QWidget *parent)
+    : QWidget(parent), capture_(std::move(capture)),
+      quickOutputMode_(quickOutput) {
   setWindowTitle(QStringLiteral("Omasnap"));
   setWindowFlags(Qt::Window | Qt::FramelessWindowHint |
                  Qt::WindowStaysOnTopHint);
@@ -762,6 +763,15 @@ void CaptureEditor::enterEdit(QString status) {
   redoStack_.clear();
   setStatus(std::move(status));
   updatePointerCursor();
+  if (quickOutputMode_ != QuickOutputMode::None) {
+    const OutputMode output =
+        quickOutputMode_ == QuickOutputMode::Copy
+            ? OutputMode::Copy
+            : quickOutputMode_ == QuickOutputMode::Save ? OutputMode::Save
+                                                        : OutputMode::Both;
+    finish(output);
+    return;
+  }
   persistSnapshot();
 }
 

--- a/editor.hpp
+++ b/editor.hpp
@@ -19,6 +19,7 @@ public:
 
   explicit CaptureEditor(CaptureData capture,
                          CaptureMode mode = CaptureMode::Region,
+                         QuickOutputMode quickOutput = QuickOutputMode::None,
                          QWidget *parent = nullptr);
   ~CaptureEditor() override;
 
@@ -161,6 +162,7 @@ private:
   bool dragStartStateValid_ = false;
   bool dragChanged_ = false;
   QString snapshotPath_;
+  QuickOutputMode quickOutputMode_ = QuickOutputMode::None;
   int pinCount_ = 0;
   QString status_ =
       QStringLiteral("Drag to select an area · Space selects a window");

--- a/main.cpp
+++ b/main.cpp
@@ -111,6 +111,14 @@ int main(int argc, char **argv) {
   parser.addOption(fullscreenOption);
   parser.addOption(windowOption);
   parser.addOption(regionOption);
+  const QCommandLineOption copyOption(
+      QStringLiteral("copy"),
+      QStringLiteral("Copy the capture directly without opening the editor."));
+  const QCommandLineOption saveOption(
+      QStringLiteral("save"),
+      QStringLiteral("Save the capture directly without opening the editor."));
+  parser.addOption(copyOption);
+  parser.addOption(saveOption);
   const QCommandLineOption fileOption(
       QStringLiteral("file"),
       QStringLiteral("Open an existing image file in the annotation editor "
@@ -129,6 +137,14 @@ int main(int argc, char **argv) {
       QStringLiteral("[target]"));
   parser.process(application);
 
+  QuickOutputMode quickOutputMode = QuickOutputMode::None;
+  if (parser.isSet(copyOption) && parser.isSet(saveOption))
+    quickOutputMode = QuickOutputMode::Both;
+  else if (parser.isSet(copyOption))
+    quickOutputMode = QuickOutputMode::Copy;
+  else if (parser.isSet(saveOption))
+    quickOutputMode = QuickOutputMode::Save;
+
   QString filePath = parser.value(fileOption);
 
   CaptureEditor::CaptureMode captureMode = CaptureEditor::CaptureMode::Region;
@@ -141,7 +157,8 @@ int main(int argc, char **argv) {
 
   const QStringList positional = parser.positionalArguments();
   if (parser.isSet(pinOption)) {
-    if (!filePath.isEmpty() || requestedModes > 0 || !positional.isEmpty()) {
+    if (!filePath.isEmpty() || requestedModes > 0 || !positional.isEmpty() ||
+        quickOutputMode != QuickOutputMode::None) {
       qCritical()
           << "Pinned mode cannot be combined with capture or edit targets";
       return 2;
@@ -183,6 +200,10 @@ int main(int argc, char **argv) {
   }
   if (!filePath.isEmpty() && requestedModes > 0) {
     qCritical() << "An image file cannot be combined with a capture mode";
+    return 2;
+  }
+  if (!filePath.isEmpty() && quickOutputMode != QuickOutputMode::None) {
+    qCritical() << "Quick output options cannot be combined with an image file";
     return 2;
   }
   if (!loadCaptureFonts())
@@ -236,6 +257,19 @@ int main(int argc, char **argv) {
                              .arg(capture.monitor.workspaceId)
                              .arg(capture.windows.size());
 
+  if (filePath.isEmpty() && captureMode == CaptureEditor::CaptureMode::Fullscreen &&
+      quickOutputMode != QuickOutputMode::None) {
+    QString outputError;
+    if (!quickOutput(renderCapture(capture,
+                                   QRectF(QPointF(), capture.preview.size()),
+                                   {}, BackgroundStyle::None),
+                     quickOutputMode, outputError)) {
+      qCritical().noquote() << outputError;
+      return 1;
+    }
+    return 0;
+  }
+
   QScreen *targetScreen = QGuiApplication::primaryScreen();
   for (QScreen *screen : QGuiApplication::screens()) {
     if (screen->name() == capture.monitor.name) {
@@ -244,7 +278,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  CaptureEditor editor(std::move(capture), captureMode);
+  CaptureEditor editor(std::move(capture), captureMode, quickOutputMode);
   editor.setScreen(targetScreen);
   editor.setGeometry(targetScreen->geometry());
   editor.winId();

--- a/quick-output-smoke.cpp
+++ b/quick-output-smoke.cpp
@@ -1,0 +1,39 @@
+/** @fileoverview Verifies direct copy/save output for quick capture mode. */
+#include "capture.hpp"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QImage>
+#include <QTemporaryDir>
+
+#include <cstdio>
+
+int main(int argc, char **argv) {
+  QCoreApplication application(argc, argv);
+  QTemporaryDir output;
+  if (!output.isValid())
+    return 1;
+
+  qputenv("OMASNAP_SCREENSHOT_DIR",
+          QDir(output.path()).filePath(QStringLiteral("saved")).toUtf8());
+  QImage image(32, 24, QImage::Format_ARGB32_Premultiplied);
+  image.fill(QColor(QStringLiteral("#123456")));
+  QString error;
+  if (!quickOutput(image, QuickOutputMode::Save, error)) {
+    std::fprintf(stderr, "%s\n", qPrintable(error));
+    return 2;
+  }
+
+  const QStringList saved =
+      QDir(QDir(output.path()).filePath(QStringLiteral("saved")))
+          .entryList({QStringLiteral("*.png")}, QDir::Files);
+  if (saved.size() != 1)
+    return 3;
+  const QImage savedImage(QDir(output.path()).filePath(
+      QStringLiteral("saved/%1").arg(saved.constFirst())));
+  if (savedImage.isNull() ||
+      savedImage.convertToFormat(image.format()) != image)
+    return 3;
+  return 0;
+}


### PR DESCRIPTION
## Summary

  - Add `--copy` and `--save` command-line options.
  - Allow both options together to copy and save.
  - Output region and window captures immediately after selection.
  - Output fullscreen captures immediately.
  - Skip the annotation editor in quick-output mode.
  - Reject quick-output options with `--file` and `--pin`.
  - Encode region and window screenshots only once.

  ## Testing

  - Added focused quick-output tests.
  - Added a regression test that confirms one snapshot write per capture.
  - Added focused smoke programs to Linux CI.
  - Full headless smoke suite passes.
  - `git diff --check` passes.

  ## Dependency

  This branch is based on PR #24 for atomic snapshot writes. Please merge PR #24 first, then rebase this branch onto `main`.