### PR TITLE
Stack pinned captures and support drag positioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ qt_add_executable(omasnap
   icons.hpp
   pin.cpp
   pin.hpp
+  pin-layout.cpp
+  pin-layout.hpp
   pin-file.cpp
   pin-file.hpp
   capture.cpp
@@ -69,6 +71,10 @@ qt_add_executable(omasnap-smoke
   editor-smoke.cpp
   pin-lifecycle-smoke.cpp
   pin-lifecycle-smoke.hpp
+  pin-layout-smoke.cpp
+  pin-layout-smoke.hpp
+  pin-layout.cpp
+  pin-layout.hpp
   pin-file.cpp
   pin-file.hpp
   pin.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ qt_add_executable(omasnap
   icons.hpp
   pin.cpp
   pin.hpp
+  pin-file.cpp
+  pin-file.hpp
   capture.cpp
   capture.hpp
   surface-capture.cpp
@@ -65,6 +67,12 @@ target_link_libraries(omasnap PRIVATE
 
 qt_add_executable(omasnap-smoke
   editor-smoke.cpp
+  pin-lifecycle-smoke.cpp
+  pin-lifecycle-smoke.hpp
+  pin-file.cpp
+  pin-file.hpp
+  pin.cpp
+  pin.hpp
   icons.cpp
   icons.hpp
   transform-smoke.cpp
@@ -90,6 +98,7 @@ target_link_libraries(omasnap-smoke PRIVATE
   Qt6::Gui
   Qt6::Test
   Qt6::Widgets
+  LayerShellQt::Interface
   PkgConfig::WaylandClient
 )
 

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ Install the corresponding Tesseract language data before adding a language to
 
 ### Pinned captures
 
-`P` renders the current capture, writes it to a `pin-<pid>-<n>.png` under the runtime
-snapshot directory, and launches the same `omasnap` executable in detached pin mode.
+`P` renders the current capture, writes it to a `pin-<pid>-<n>-<random>.png` under the
+runtime snapshot directory, and launches the same `omasnap` executable in detached pin mode.
 The layer-shell surface is anchored 14 logical pixels from the bottom-right corner and
 stays visible on every workspace without compositor window rules. It preserves the image
 aspect ratio, with a maximum width of one third of the screen and a maximum height of one

--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ Install the corresponding Tesseract language data before adding a language to
 
 `P` renders the current capture, writes it to a `pin-<pid>-<n>-<random>.png` under the
 runtime snapshot directory, and launches the same `omasnap` executable in detached pin mode.
-The layer-shell surface is anchored 14 logical pixels from the bottom-right corner and
-stays visible on every workspace without compositor window rules. It preserves the image
+The layer-shell surface starts 14 logical pixels from the bottom-right corner, stacking
+active pins upward and wrapping into another column when needed. It stays visible on every
+workspace without compositor window rules. It preserves the image
 aspect ratio, with a maximum width of one third of the screen and a maximum height of one
 half.
 
@@ -247,6 +248,7 @@ Hover the pin to reveal its controls:
 | Link button | Copy the source file path |
 | Copy button, `Ctrl+C` | Copy the full-resolution PNG |
 | Double-wide top-left drag handle | Drag the PNG into a file-capable drop target |
+| Image background drag | Move the pin; it stays fully inside the screen |
 | Wheel | Resize within the screen caps, preserving aspect ratio |
 | Close button, `Esc`, middle-click | Close |
 

--- a/capture.cpp
+++ b/capture.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <fcntl.h>
 #include <limits>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -612,11 +613,15 @@ QString temporarySnapshotPath() {
 }
 
 QString pinnedSnapshotPath(int index) {
-  return runtimePath(QStringLiteral("pin-%1-%2.png")
-                         .arg(QCoreApplication::applicationPid())
-                         .arg(index));
+  // A fresh nonce prevents collisions when the editor PID is recycled.
+  return runtimePath(
+      QStringLiteral("pin-%1-%2-%3.png")
+          .arg(QCoreApplication::applicationPid())
+          .arg(index)
+          .arg(QRandomGenerator::system()->generate64(), 16, 16, QChar('0')));
 }
 
+/** Removes stale pin files that no running pin still holds. */
 void prunePinnedSnapshots() {
   const QString runtime = secureRuntimeDirectory();
   if (runtime.isEmpty())
@@ -625,8 +630,18 @@ void prunePinnedSnapshots() {
   const QFileInfoList stale =
       QDir(runtime).entryInfoList({QStringLiteral("pin-*.png")}, QDir::Files);
   for (const QFileInfo &entry : stale) {
-    if (entry.lastModified() < cutoff)
-      QFile::remove(entry.absoluteFilePath());
+    if (entry.lastModified() >= cutoff)
+      continue;
+    const QByteArray encodedPath = QFile::encodeName(entry.absoluteFilePath());
+    const int fd = ::open(encodedPath.constData(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0 || ::flock(fd, LOCK_EX | LOCK_NB) != 0) {
+      if (fd >= 0)
+        ::close(fd);
+      continue;
+    }
+    QFile::remove(entry.absoluteFilePath());
+    ::flock(fd, LOCK_UN);
+    ::close(fd);
   }
 }
 

--- a/capture.hpp
+++ b/capture.hpp
@@ -82,6 +82,7 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
                                                 QString &error);
 [[nodiscard]] QString temporarySnapshotPath();
 [[nodiscard]] QString pinnedSnapshotPath(int index);
+/** Removes abandoned pin files without touching active pins. */
 void prunePinnedSnapshots();
 [[nodiscard]] bool saveTemporarySnapshot(const QImage &image, QString path,
                                          QString &error);

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -3,6 +3,7 @@
 #include "capture.hpp"
 #include "editor.hpp"
 #include "pin-lifecycle-smoke.hpp"
+#include "pin-layout-smoke.hpp"
 #include "transform-smoke.hpp"
 
 #include <QApplication>
@@ -154,6 +155,10 @@ int main(int argc, char **argv) {
   if (!runPinLifecycleSmoke(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 71;
+  }
+  if (!runPinLayoutSmoke(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 72;
   }
   if (!runHighlighterRenderingCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -2,6 +2,7 @@
  */
 #include "capture.hpp"
 #include "editor.hpp"
+#include "pin-lifecycle-smoke.hpp"
 #include "transform-smoke.hpp"
 
 #include <QApplication>
@@ -149,6 +150,10 @@ int main(int argc, char **argv) {
   if (!runTemporarySnapshotChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 68;
+  }
+  if (!runPinLifecycleSmoke(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 71;
   }
   if (!runHighlighterRenderingCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/pin-file.cpp
+++ b/pin-file.cpp
@@ -3,12 +3,14 @@
 
 #include "capture.hpp"
 
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QRegularExpression>
 
 #include <fcntl.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 PinSnapshotFile::PinSnapshotFile(QString path)
@@ -41,3 +43,36 @@ PinSnapshotFile::~PinSnapshotFile() {
 bool PinSnapshotFile::isLocked() const { return fd_ >= 0; }
 
 void PinSnapshotFile::preserveForEditor() { preserve_ = true; }
+
+PinSlotLock::PinSlotLock() {
+  const QString runtime = secureRuntimeDirectory();
+  if (runtime.isEmpty())
+    return;
+  for (int candidate = 0; candidate < 1024; ++candidate) {
+    const QString path = QDir(runtime).filePath(
+        QStringLiteral(".pin-slot-%1.lock").arg(candidate));
+    const int fd = ::open(QFile::encodeName(path).constData(),
+                          O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+                          S_IRUSR | S_IWUSR);
+    if (fd < 0)
+      continue;
+    if (::fchmod(fd, S_IRUSR | S_IWUSR) == 0 &&
+        ::flock(fd, LOCK_EX | LOCK_NB) == 0) {
+      fd_ = fd;
+      index_ = candidate;
+      return;
+    }
+    ::close(fd);
+  }
+}
+
+PinSlotLock::~PinSlotLock() {
+  if (fd_ < 0)
+    return;
+  ::flock(fd_, LOCK_UN);
+  ::close(fd_);
+}
+
+bool PinSlotLock::isLocked() const { return fd_ >= 0; }
+
+int PinSlotLock::index() const { return index_; }

--- a/pin-file.cpp
+++ b/pin-file.cpp
@@ -1,0 +1,43 @@
+/** @fileoverview Implements pinned snapshot file locking. */
+#include "pin-file.hpp"
+
+#include "capture.hpp"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
+PinSnapshotFile::PinSnapshotFile(QString path)
+    : path_(QFileInfo(path).absoluteFilePath()) {
+  fd_ = ::open(QFile::encodeName(path_).constData(),
+               O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+  if (fd_ < 0 || ::flock(fd_, LOCK_SH | LOCK_NB) != 0) {
+    if (fd_ >= 0)
+      ::close(fd_);
+    fd_ = -1;
+  }
+}
+
+PinSnapshotFile::~PinSnapshotFile() {
+  const bool locked = fd_ >= 0;
+  if (fd_ >= 0) {
+    ::flock(fd_, LOCK_UN);
+    ::close(fd_);
+  }
+  static const QRegularExpression internalName(
+      QStringLiteral("^pin-[1-9][0-9]*-[1-9][0-9]*-[0-9a-f]{16}\\.png$"));
+  const QFileInfo fileInfo(path_);
+  const QString runtime = secureRuntimeDirectory();
+  if (locked && !preserve_ && !runtime.isEmpty() &&
+      fileInfo.absolutePath() == runtime &&
+      internalName.match(fileInfo.fileName()).hasMatch())
+    QFile::remove(path_);
+}
+
+bool PinSnapshotFile::isLocked() const { return fd_ >= 0; }
+
+void PinSnapshotFile::preserveForEditor() { preserve_ = true; }

--- a/pin-file.hpp
+++ b/pin-file.hpp
@@ -1,0 +1,26 @@
+/** @fileoverview Owns a lock for a pinned snapshot file. */
+#pragma once
+
+#include <QString>
+
+/** Tracks a pinned snapshot while its window is open. */
+class PinSnapshotFile {
+public:
+  /** Opens and locks the supplied snapshot path. */
+  explicit PinSnapshotFile(QString path);
+  /** Releases the lock and removes an owned internal snapshot. */
+  ~PinSnapshotFile();
+
+  PinSnapshotFile(const PinSnapshotFile &) = delete;
+  PinSnapshotFile &operator=(const PinSnapshotFile &) = delete;
+
+  /** Returns whether the snapshot lock is held. */
+  [[nodiscard]] bool isLocked() const;
+  /** Keeps the snapshot for reopening in the editor. */
+  void preserveForEditor();
+
+private:
+  QString path_;
+  int fd_ = -1;
+  bool preserve_ = false;
+};

--- a/pin-file.hpp
+++ b/pin-file.hpp
@@ -24,3 +24,24 @@ private:
   int fd_ = -1;
   bool preserve_ = false;
 };
+
+/** Holds the first free layout slot while a pin is active. */
+class PinSlotLock {
+public:
+  /** Claims the first available layout slot. */
+  PinSlotLock();
+  /** Releases the claimed layout slot. */
+  ~PinSlotLock();
+
+  PinSlotLock(const PinSlotLock &) = delete;
+  PinSlotLock &operator=(const PinSlotLock &) = delete;
+
+  /** Returns whether a slot was claimed. */
+  [[nodiscard]] bool isLocked() const;
+  /** Returns the claimed zero-based slot. */
+  [[nodiscard]] int index() const;
+
+private:
+  int fd_ = -1;
+  int index_ = -1;
+};

--- a/pin-layout-smoke.cpp
+++ b/pin-layout-smoke.cpp
@@ -1,0 +1,51 @@
+/** @fileoverview Tests pure pinned-window stacking and clamping helpers. */
+#include "pin-layout-smoke.hpp"
+
+#include "pin-layout.hpp"
+
+/** Verifies stacked slots wrap into columns and geometry stays on-screen. */
+bool runPinLayoutSmoke(QString &error) {
+  const QPoint firstDrag = pinPositionFromGlobalPointer(
+      QPoint(446, 306), QPoint(100, 50), QPoint(50, 40));
+  const QPoint secondDrag = pinPositionFromGlobalPointer(
+      QPoint(456, 316), QPoint(100, 50), QPoint(50, 40));
+  if (firstDrag != QPoint(296, 216) || secondDrag != QPoint(306, 226)) {
+    error = QStringLiteral("Pin drag did not follow the global pointer");
+    return false;
+  }
+
+  const QSize screen(400, 300);
+  const QSize pin(100, 80);
+  const QPoint first = pinSlotPosition(screen, pin, pin, 0, 10, 14);
+  const QPoint second = pinSlotPosition(screen, pin, pin, 1, 10, 14);
+  const QPoint third = pinSlotPosition(screen, pin, pin, 2, 10, 14);
+  const QPoint wrapped = pinSlotPosition(screen, pin, pin, 3, 10, 14);
+  if (first != QPoint(286, 206) || second != QPoint(286, 116) ||
+      third != QPoint(286, 26) || wrapped != QPoint(176, 206)) {
+    error = QStringLiteral("Pinned slots did not stack and wrap correctly");
+    return false;
+  }
+
+  const QSize cell(120, 90);
+  const QRect large(pinSlotPosition(screen, QSize(120, 90), cell, 0, 10, 14),
+                    QSize(120, 90));
+  const QRect small(pinSlotPosition(screen, QSize(60, 40), cell, 1, 10, 14),
+                    QSize(60, 40));
+  if (large.intersects(small)) {
+    error = QStringLiteral("Different pin sizes overlapped their layout slots");
+    return false;
+  }
+
+  const QRect bounds(QPoint(10, 20), QSize(400, 300));
+  if (clampPinGeometry(QRect(380, 290, 100, 80), bounds) !=
+      QRect(310, 240, 100, 80)) {
+    error = QStringLiteral("Pinned geometry was not clamped to the screen");
+    return false;
+  }
+  if (clampPinGeometry(QRect(-20, 0, 100, 80), bounds) !=
+      QRect(10, 20, 100, 80)) {
+    error = QStringLiteral("Pinned geometry did not clamp at top-left");
+    return false;
+  }
+  return true;
+}

--- a/pin-layout-smoke.hpp
+++ b/pin-layout-smoke.hpp
@@ -1,0 +1,7 @@
+/** @fileoverview Declares pure pinned-window layout smoke checks. */
+#pragma once
+
+#include <QString>
+
+/** Runs pinned-window stacking and clamping checks. */
+bool runPinLayoutSmoke(QString &error);

--- a/pin-layout.cpp
+++ b/pin-layout.cpp
@@ -1,0 +1,34 @@
+/** @fileoverview Implements pinned-window stacking and clamping helpers. */
+#include "pin-layout.hpp"
+
+#include <algorithm>
+
+QPoint pinPositionFromGlobalPointer(const QPoint &globalPointer,
+                                    const QPoint &screenOrigin,
+                                    const QPoint &pressOffset) {
+  return globalPointer - screenOrigin - pressOffset;
+}
+
+QPoint pinSlotPosition(const QSize &screenSize, const QSize &pinSize,
+                       const QSize &slotSize, int index, int gap, int margin) {
+  const int verticalSpace = std::max(1, screenSize.height() - 2 * margin);
+  const int rowHeight = std::max(1, slotSize.height() + gap);
+  const int rows = std::max(1, (verticalSpace + gap) / rowHeight);
+  const int row = std::max(0, index) % rows;
+  const int column = std::max(0, index) / rows;
+  const int x = screenSize.width() - margin - pinSize.width() -
+                column * (std::max(1, slotSize.width()) + gap);
+  const int y = screenSize.height() - margin - pinSize.height() -
+                row * rowHeight;
+  return {x, y};
+}
+
+QRect clampPinGeometry(const QRect &pin, const QRect &bounds) {
+  if (bounds.isEmpty())
+    return pin;
+  const int x = std::clamp(pin.x(), bounds.left(),
+                          std::max(bounds.left(), bounds.right() - pin.width() + 1));
+  const int y = std::clamp(pin.y(), bounds.top(),
+                          std::max(bounds.top(), bounds.bottom() - pin.height() + 1));
+  return {x, y, pin.width(), pin.height()};
+}

--- a/pin-layout.hpp
+++ b/pin-layout.hpp
@@ -1,0 +1,18 @@
+/** @fileoverview Provides pure pinned-window layout helpers. */
+#pragma once
+
+#include <QPoint>
+#include <QRect>
+#include <QSize>
+
+/** Maps a global pointer position to the pin's screen-local top-left. */
+[[nodiscard]] QPoint pinPositionFromGlobalPointer(
+    const QPoint &globalPointer, const QPoint &screenOrigin,
+    const QPoint &pressOffset);
+/** Returns the bottom-right slot for an active pin index. */
+[[nodiscard]] QPoint pinSlotPosition(const QSize &screenSize,
+                                     const QSize &pinSize,
+                                     const QSize &slotSize, int index, int gap,
+                                     int margin);
+/** Keeps a pin rectangle fully inside screen bounds where possible. */
+[[nodiscard]] QRect clampPinGeometry(const QRect &pin, const QRect &bounds);

--- a/pin-lifecycle-smoke.cpp
+++ b/pin-lifecycle-smoke.cpp
@@ -1,0 +1,159 @@
+/** @fileoverview Tests the lifetime rules for pinned screenshot files. */
+#include "pin-lifecycle-smoke.hpp"
+
+#include "capture.hpp"
+#include "pin-file.hpp"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QImage>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
+/** Verifies pin names, ownership, cleanup, preservation, and pruning. */
+bool runPinLifecycleSmoke(QString &error) {
+  const QString firstPath = pinnedSnapshotPath(987654);
+  const QString secondPath = pinnedSnapshotPath(987654);
+  if (firstPath.isEmpty() || secondPath.isEmpty() || firstPath == secondPath) {
+    error = QStringLiteral("Pinned snapshot paths are not unique");
+    return false;
+  }
+
+  QImage image(8, 8, QImage::Format_ARGB32_Premultiplied);
+  image.fill(Qt::white);
+  const QString closePath = pinnedSnapshotPath(987656);
+  if (!saveTemporarySnapshot(image, closePath, error))
+    return false;
+  {
+    PinSnapshotFile file(closePath);
+    if (!file.isLocked()) {
+      error = QStringLiteral("Normal pin snapshot was not locked");
+      QFile::remove(closePath);
+      return false;
+    }
+  }
+  if (QFileInfo::exists(closePath)) {
+    error = QStringLiteral("Normal pin close did not remove its snapshot");
+    QFile::remove(closePath);
+    return false;
+  }
+
+  const QString lockedPath = pinnedSnapshotPath(987658);
+  if (!saveTemporarySnapshot(image, lockedPath, error))
+    return false;
+  const int lockedFd =
+      ::open(QFile::encodeName(lockedPath).constData(), O_RDONLY | O_CLOEXEC);
+  if (lockedFd < 0 || ::flock(lockedFd, LOCK_EX | LOCK_NB) != 0) {
+    error = QStringLiteral("Could not hold exclusive pin snapshot lock");
+    if (lockedFd >= 0)
+      ::close(lockedFd);
+    QFile::remove(lockedPath);
+    return false;
+  }
+  {
+    PinSnapshotFile file(lockedPath);
+    if (file.isLocked()) {
+      error = QStringLiteral("Contended pin snapshot unexpectedly locked");
+      ::flock(lockedFd, LOCK_UN);
+      ::close(lockedFd);
+      QFile::remove(lockedPath);
+      return false;
+    }
+  }
+  ::flock(lockedFd, LOCK_UN);
+  ::close(lockedFd);
+  if (!QFileInfo::exists(lockedPath)) {
+    error = QStringLiteral("Unowned pin snapshot was removed");
+    return false;
+  }
+  QFile::remove(lockedPath);
+
+  const QString reopenPath = pinnedSnapshotPath(987657);
+  if (!saveTemporarySnapshot(image, reopenPath, error))
+    return false;
+  {
+    PinSnapshotFile file(reopenPath);
+    if (!file.isLocked()) {
+      error = QStringLiteral("Reopened pin snapshot was not locked");
+      QFile::remove(reopenPath);
+      return false;
+    }
+    file.preserveForEditor();
+  }
+  if (!QFileInfo::exists(reopenPath)) {
+    error = QStringLiteral("Reopened pin snapshot was not preserved");
+    return false;
+  }
+  QFile::remove(reopenPath);
+
+  const QString unrelatedPath =
+      QDir(secureRuntimeDirectory()).filePath(QStringLiteral("manual.png"));
+  if (!saveTemporarySnapshot(image, unrelatedPath, error))
+    return false;
+  {
+    PinSnapshotFile file(unrelatedPath);
+    if (!file.isLocked()) {
+      error = QStringLiteral("Unrelated runtime file was not locked");
+      QFile::remove(unrelatedPath);
+      return false;
+    }
+  }
+  if (!QFileInfo::exists(unrelatedPath)) {
+    error = QStringLiteral("Unrelated runtime file was removed");
+    return false;
+  }
+  QFile::remove(unrelatedPath);
+
+  const QString path = pinnedSnapshotPath(987654);
+  if (!saveTemporarySnapshot(image, path, error))
+    return false;
+  QFile agedFile(path);
+  if (!agedFile.open(QIODevice::ReadOnly) ||
+      !agedFile.setFileTime(QDateTime::currentDateTime().addDays(-2),
+                            QFileDevice::FileModificationTime)) {
+    error = QStringLiteral("Could not age pin snapshot");
+    QFile::remove(path);
+    return false;
+  }
+  agedFile.close();
+
+  bool survived = false;
+  {
+    PinSnapshotFile file(path);
+    if (!file.isLocked()) {
+      error = QStringLiteral("Could not hold pin snapshot lock");
+      QFile::remove(path);
+      return false;
+    }
+    prunePinnedSnapshots();
+    survived = QFileInfo::exists(path);
+  }
+  if (!survived) {
+    error = QStringLiteral("Active pin snapshot was pruned");
+    return false;
+  }
+
+  const QString abandonedPath = pinnedSnapshotPath(987655);
+  if (!saveTemporarySnapshot(image, abandonedPath, error))
+    return false;
+  QFile abandonedFile(abandonedPath);
+  if (!abandonedFile.open(QIODevice::ReadOnly) ||
+      !abandonedFile.setFileTime(QDateTime::currentDateTime().addDays(-2),
+                                 QFileDevice::FileModificationTime)) {
+    error = QStringLiteral("Could not age abandoned pin snapshot");
+    QFile::remove(abandonedPath);
+    return false;
+  }
+  abandonedFile.close();
+  prunePinnedSnapshots();
+  if (QFileInfo::exists(abandonedPath)) {
+    error = QStringLiteral("Abandoned pin snapshot was not pruned");
+    QFile::remove(abandonedPath);
+    return false;
+  }
+  return true;
+}

--- a/pin-lifecycle-smoke.cpp
+++ b/pin-lifecycle-smoke.cpp
@@ -10,12 +10,32 @@
 #include <QFileInfo>
 #include <QImage>
 
+#include <algorithm>
 #include <fcntl.h>
 #include <sys/file.h>
 #include <unistd.h>
 
 /** Verifies pin names, ownership, cleanup, preservation, and pruning. */
 bool runPinLifecycleSmoke(QString &error) {
+  int expectedReusedSlot = -1;
+  {
+    PinSlotLock first;
+    PinSlotLock second;
+    if (!first.isLocked() || !second.isLocked() ||
+        first.index() == second.index()) {
+      error = QStringLiteral("Active pins did not claim distinct slots");
+      return false;
+    }
+    expectedReusedSlot = std::min(first.index(), second.index());
+  }
+  {
+    PinSlotLock reused;
+    if (!reused.isLocked() || reused.index() != expectedReusedSlot) {
+      error = QStringLiteral("Released pin slot was not reused");
+      return false;
+    }
+  }
+
   const QString firstPath = pinnedSnapshotPath(987654);
   const QString secondPath = pinnedSnapshotPath(987654);
   if (firstPath.isEmpty() || secondPath.isEmpty() || firstPath == secondPath) {

--- a/pin-lifecycle-smoke.hpp
+++ b/pin-lifecycle-smoke.hpp
@@ -1,0 +1,7 @@
+/** @fileoverview Declares pin file lifecycle smoke checks. */
+#pragma once
+
+class QString;
+
+/** Verifies pin naming, ownership, cleanup, and stale-file pruning. */
+[[nodiscard]] bool runPinLifecycleSmoke(QString &error);

--- a/pin.cpp
+++ b/pin.cpp
@@ -1,5 +1,7 @@
+/** @fileoverview Displays and manages pinned screenshot layers. */
 #include "pin.hpp"
 #include "icons.hpp"
+#include "pin-file.hpp"
 
 #include <LayerShellQt/Window>
 #include <QApplication>
@@ -74,7 +76,8 @@ bool copyPngToClipboard(const QImage &image, QString &error) {
   return true;
 }
 
-bool copyTextToClipboard(const QString &text, QString &error) {
+/** Copies pin text through the persistent Wayland clipboard. */
+bool copyPinTextToClipboard(const QString &text, QString &error) {
   QProcess copy;
   copy.start(
       QStringLiteral("wl-copy"),
@@ -96,13 +99,17 @@ bool copyTextToClipboard(const QString &text, QString &error) {
 
 class PinWindow final : public QWidget {
 public:
+  /** Creates a pin and holds its backing file open. */
   explicit PinWindow(QImage image, QString path)
-      : image_(std::move(image)), path_(std::move(path)) {
+      : image_(std::move(image)), path_(std::move(path)), snapshotFile_(path_) {
     setWindowTitle(QStringLiteral("omasnap-pin"));
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
     setMouseTracking(true);
     resize(initialSize());
   }
+
+  /** Returns whether this process owns the pin's shared file lock. */
+  [[nodiscard]] bool hasPinLock() const { return snapshotFile_.isLocked(); }
 
 protected:
   void paintEvent(QPaintEvent *) override {
@@ -183,7 +190,7 @@ protected:
       }
       if (pathButtonRect().contains(position)) {
         QString error;
-        showToast(copyTextToClipboard(path_, error)
+        showToast(copyPinTextToClipboard(path_, error)
                       ? QStringLiteral("Copied path")
                       : error);
         return;
@@ -195,13 +202,15 @@ protected:
     }
   }
 
-  // Send the pinned image back to the omasnap editor, replacing the pin.
+  /** Reopens the file without deleting it during process handoff. */
   void reopenInEditor() {
     if (!QProcess::startDetached(QCoreApplication::applicationFilePath(),
                                  {path_}))
       showToast(QStringLiteral("Could not start omasnap"));
-    else
+    else {
+      snapshotFile_.preserveForEditor();
       close();
+    }
   }
 
   void mouseMoveEvent(QMouseEvent *event) override {
@@ -380,6 +389,7 @@ private:
   QString hoverTip_;
   bool hovered_ = false;
   int hoveredControl_ = -1;
+  PinSnapshotFile snapshotFile_;
 };
 
 } // namespace
@@ -392,6 +402,10 @@ int runPinnedCapture(const QString &path) {
   }
 
   PinWindow window(std::move(image), path);
+  if (!window.hasPinLock()) {
+    qWarning("omasnap: could not lock pinned image %s", qUtf8Printable(path));
+    return 1;
+  }
   static_cast<void>(window.winId());
   QWindow *handle = window.windowHandle();
   LayerShellQt::Window *layer =

--- a/pin.cpp
+++ b/pin.cpp
@@ -2,6 +2,7 @@
 #include "pin.hpp"
 #include "icons.hpp"
 #include "pin-file.hpp"
+#include "pin-layout.hpp"
 
 #include <LayerShellQt/Window>
 #include <QApplication>
@@ -46,6 +47,7 @@ constexpr qreal kMaxWidthShare = 1.0 / 3.0;
 constexpr qreal kMaxHeightShare = 0.5;
 constexpr qreal kWheelStep = 0.1;
 constexpr int kToastMs = 1200;
+constexpr int kPinGap = 10;
 
 // wl-copy backgrounds itself and keeps serving the selection after this process
 // exits, which QClipboard cannot do on Wayland.
@@ -109,7 +111,15 @@ public:
   }
 
   /** Returns whether this process owns the pin's shared file lock. */
-  [[nodiscard]] bool hasPinLock() const { return snapshotFile_.isLocked(); }
+  [[nodiscard]] bool hasPinLock() const {
+    return snapshotFile_.isLocked() && slotLock_.isLocked();
+  }
+
+  /** Returns the layout slot held by this pin. */
+  [[nodiscard]] int slotIndex() const { return slotLock_.index(); }
+
+  /** Sets the initial screen-local position before showing the layer. */
+  void setInitialPosition(QPoint position) { position_ = position; }
 
 protected:
   void paintEvent(QPaintEvent *) override {
@@ -199,6 +209,10 @@ protected:
         reopenInEditor();
         return;
       }
+      dragging_ = true;
+      dragOffset_ = position.toPoint();
+      event->accept();
+      return;
     }
   }
 
@@ -218,12 +232,30 @@ protected:
     setCursor(controlRectAt(position) >= 0 ? Qt::PointingHandCursor
                                            : Qt::ArrowCursor);
 
+    if (dragging_) {
+      const QScreen *target = screen() ? screen() : QGuiApplication::primaryScreen();
+      const QPoint origin = target ? target->availableGeometry().topLeft() : QPoint();
+      const QRect bounds(QPoint(), target ? target->availableGeometry().size()
+                                          : availableSize());
+      const QPoint requested = pinPositionFromGlobalPointer(
+          event->globalPosition().toPoint(), origin, dragOffset_);
+      applyPosition(clampPinGeometry(QRect(requested, size()), bounds).topLeft());
+      event->accept();
+      return;
+    }
+
     const int control = controlRectAt(position);
     if (control != hoveredControl_) {
       hoveredControl_ = control;
       hoverTip_ = control >= 0 ? controlTip(control) : QString();
       update();
     }
+  }
+
+  void mouseReleaseEvent(QMouseEvent *event) override {
+    if (event->button() == Qt::LeftButton)
+      dragging_ = false;
+    QWidget::mouseReleaseEvent(event);
   }
 
   // A layer surface can still initiate a Wayland uri-list drag just like a
@@ -255,6 +287,9 @@ protected:
       if (LayerShellQt::Window *layer = LayerShellQt::Window::get(handle))
         layer->setDesiredSize(nextSize);
     }
+    applyPosition(clampPinGeometry(QRect(position_, nextSize),
+                                   QRect(QPoint(), availableSize()))
+                      .topLeft());
     event->accept();
   }
 
@@ -309,6 +344,17 @@ private:
     const QScreen *target =
         screen() ? screen() : QGuiApplication::primaryScreen();
     return target ? target->availableGeometry().size() : QSize(1920, 1080);
+  }
+
+  void applyPosition(QPoint position) {
+    position_ = position;
+    if (QWindow *handle = windowHandle()) {
+      if (LayerShellQt::Window *layer = LayerShellQt::Window::get(handle)) {
+        const QSize available = availableSize();
+        layer->setMargins(QMargins(0, 0, available.width() - position.x() - width(),
+                                   available.height() - position.y() - height()));
+      }
+    }
   }
 
   // The rendered capture is in device pixels, so a scaled output would
@@ -389,7 +435,11 @@ private:
   QString hoverTip_;
   bool hovered_ = false;
   int hoveredControl_ = -1;
+  QPoint position_;
+  QPoint dragOffset_;
+  bool dragging_ = false;
   PinSnapshotFile snapshotFile_;
+  PinSlotLock slotLock_;
 };
 
 } // namespace
@@ -420,7 +470,19 @@ int runPinnedCapture(const QString &path) {
   anchors.setFlag(LayerShellQt::Window::AnchorBottom);
   anchors.setFlag(LayerShellQt::Window::AnchorRight);
   layer->setAnchors(anchors);
-  layer->setMargins(QMargins(0, 0, kCornerMargin, kCornerMargin));
+  const QScreen *target = QGuiApplication::primaryScreen();
+  const QSize available = target ? target->availableGeometry().size()
+                                 : QSize(1920, 1080);
+  const QSize slotSize(std::max(1, qRound(available.width() * kInitialScreenShare)),
+                       std::max(1, qRound(available.height() * kInitialScreenShare)));
+  const QPoint rawSlot = pinSlotPosition(available, window.size(), slotSize,
+                                         window.slotIndex(), kPinGap,
+                                         kCornerMargin);
+  const QPoint slot = clampPinGeometry(QRect(rawSlot, window.size()),
+                                       QRect(QPoint(), available)).topLeft();
+  window.setInitialPosition(slot);
+  layer->setMargins(QMargins(0, 0, available.width() - slot.x() - window.width(),
+                             available.height() - slot.y() - window.height()));
   layer->setExclusiveZone(0);
   layer->setDesiredSize(window.size());
   layer->setKeyboardInteractivity(

--- a/pin.hpp
+++ b/pin.hpp
@@ -1,6 +1,7 @@
+/** @fileoverview Declares the pinned screenshot window. */
 #pragma once
 
 #include <QString>
 
-/** Runs a detached pinned-image layer using the current Omasnap process. */
+/** Displays a pinned screenshot until its window closes. */
 [[nodiscard]] int runPinnedCapture(const QString &path);


### PR DESCRIPTION
## Summary

  - Place active pins into separate bottom-right slots.
  - Stack pins upward and wrap into another column when needed.
  - Safely reuse slots after pins close.
  - Allow dragging a pin by its image background.
  - Keep toolbar controls and the file-drag handle unchanged.
  - Keep moved and resized pins inside the available screen.
  - Use global mouse coordinates to prevent shaking while moving a pin.

  ## Testing

  - Added tests for stacking, column wrapping, clamping, slot reuse, and different pin sizes.
  - Added regression coverage for consecutive drag movements and non-zero screen origins.
  - Full headless smoke suite passes.
  - `git diff --check` passes.

  ## Dependency

  This branch is based on PR #25 for active pin lifecycle handling. Please merge PR #25 first, then rebase this branch onto `main`.