### PR TITLE
Add a color eyedropper to the annotation editor

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -39,6 +39,14 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: ./build/omasnap-smoke /tmp/omasnap-smoke
 
+      - name: Run focused smokes
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          for smoke in ./build/omasnap-*-smoke; do
+            "$smoke"
+          done
+
       - name: Stage installation
         run: cmake --install build --prefix "$PWD/stage/usr"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ qt_add_executable(omasnap
   ${PROTOCOL_SOURCES}
   editor.cpp
   editor.hpp
+  eyedropper.cpp
+  eyedropper.hpp
 )
 qt_add_resources(omasnap "capture-fonts"
   PREFIX "/fonts"
@@ -75,6 +77,8 @@ qt_add_executable(omasnap-smoke
   ${PROTOCOL_SOURCES}
   editor.cpp
   editor.hpp
+  eyedropper.cpp
+  eyedropper.hpp
 )
 qt_add_resources(omasnap-smoke "capture-fonts-smoke"
   PREFIX "/fonts"
@@ -92,6 +96,15 @@ target_link_libraries(omasnap-smoke PRIVATE
   Qt6::Widgets
   PkgConfig::WaylandClient
 )
+
+qt_add_executable(omasnap-eyedropper-smoke
+  eyedropper-smoke.cpp
+  eyedropper.cpp
+  eyedropper.hpp
+)
+target_compile_features(omasnap-eyedropper-smoke PRIVATE cxx_std_23)
+target_compile_options(omasnap-eyedropper-smoke PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(omasnap-eyedropper-smoke PRIVATE Qt6::Core Qt6::Gui)
 
 install(TARGETS omasnap
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Install the corresponding Tesseract language data before adding a language to
 | `R` | Rectangle |
 | `T` | Neucha text |
 | `O` | Drag an OCR region and copy recognized text |
+| `I` | Sample the original image color, set it as the custom color, and copy `#RRGGBB` |
 | `B` | Cycle backdrop |
 | `1`–`6` | Set annotation color |
 | Wheel | Scale selected layer or change active tool size |

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -305,6 +305,18 @@ int main(int argc, char **argv) {
       return 44;
   }
 
+  QTest::keyClick(&editor, Qt::Key_I);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier,
+                    QPoint(400, 300));
+  application.processEvents();
+  if (editor.cursor().shape() != Qt::ArrowCursor ||
+      QImage(snapshotPath) == lineSnapshot)
+    return 73;
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (QImage(snapshotPath) != lineSnapshot)
+    return 74;
+
   const QImage beforeSelectorZoom =
       editor.grab().toImage().copy(QRect(100, 150, 600, 350));
   QWheelEvent selectorZoom(QPointF(520, 265), QPointF(520, 265), {}, {0, 120},

--- a/editor.cpp
+++ b/editor.cpp
@@ -2,6 +2,7 @@
  */
 #include "editor.hpp"
 #include "icons.hpp"
+#include "eyedropper.hpp"
 
 #include <QtConcurrent/QtConcurrentRun>
 
@@ -35,7 +36,7 @@ constexpr std::array<const char *, 6> kColorNames{
     "#ff375f", "#ff9f0a", "#ffd60a", "#30d158", "#0a84ff", "#bf5af2"};
 constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
-constexpr qreal kToolbarWidth = 680;
+constexpr qreal kToolbarWidth = 760;
 
 bool hasEndpointHandles(Annotation::Kind kind) {
   return kind == Annotation::Kind::Arrow || kind == Annotation::Kind::Line ||
@@ -77,6 +78,8 @@ QString toolAction(CaptureEditor::Tool tool) {
     return QStringLiteral("tool-text");
   case CaptureEditor::Tool::Ocr:
     return QStringLiteral("tool-ocr");
+  case CaptureEditor::Tool::Eyedropper:
+    return QStringLiteral("tool-eyedropper");
   }
   return {};
 }
@@ -609,6 +612,8 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
       annotationColor());
   add(36, QStringLiteral("tool-ocr"), {},
       QStringLiteral("Draw around text to copy · O"));
+  add(36, QStringLiteral("tool-eyedropper"), {},
+      QStringLiteral("Sample source color · I"));
   add(36, QStringLiteral("background"), {},
       QStringLiteral("Cycle backdrop · B"));
   add(36, QStringLiteral("undo"), {}, QStringLiteral("Undo · Ctrl+Z"));
@@ -997,6 +1002,8 @@ void CaptureEditor::handleToolbar(const QString &action) {
     tool_ = Tool::Text;
   else if (action == QStringLiteral("tool-ocr"))
     tool_ = Tool::Ocr;
+  else if (action == QStringLiteral("tool-eyedropper"))
+    tool_ = Tool::Eyedropper;
   else if (action == QStringLiteral("palette"))
     colorPaletteOpen_ = true;
   else if (action.startsWith(QStringLiteral("color-"))) {
@@ -1128,6 +1135,8 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Text;
   } else if (event->key() == Qt::Key_O) {
     tool_ = Tool::Ocr;
+  } else if (event->key() == Qt::Key_I) {
+    tool_ = Tool::Eyedropper;
   } else if (event->key() == Qt::Key_P) {
     pinSnapshot();
     return;
@@ -1369,6 +1378,29 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
   }
   if (!editImageRect().contains(cursor_))
     return;
+
+  if (tool_ == Tool::Eyedropper) {
+    customColor_ = sampleSourceColor(capture_.source, capture_.preview.size(),
+                                     selection_, editImageRect(), cursor_);
+    usingCustomColor_ = true;
+    if (customColor_.hsvHueF() >= 0)
+      customHue_ = customColor_.hsvHueF();
+    if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size()) {
+      recordEdit();
+      annotations_[selectedAnnotation_].color = customColor_;
+      persistSnapshot();
+    }
+    const QString hex = customColor_.name(QColor::HexRgb).toUpper();
+    QString clipboardError;
+    if (copyTextToClipboard(hex, clipboardError))
+      setStatus(QStringLiteral("%1 copied · Select tool").arg(hex));
+    else
+      setStatus(QStringLiteral("%1 · %2").arg(hex, clipboardError));
+    tool_ = Tool::Select;
+    updatePointerCursor();
+    update();
+    return;
+  }
 
   const QPointF point = toAnnotationPoint(cursor_);
   if (tool_ == Tool::Select) {
@@ -1892,7 +1924,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
        {QStringLiteral("Double click"), QStringLiteral("Edit text layer")},
        {QStringLiteral("1–6"), QStringLiteral("Color")},
        {QStringLiteral("Wheel"), QStringLiteral("Zoom selected / tool size")},
-       {QStringLiteral("O"), QStringLiteral("Select OCR text")},
+       {QStringLiteral("O / I"), QStringLiteral("OCR / sample color")},
        {QStringLiteral("B / P"), QStringLiteral("Backdrop / Pin on screen")},
        {QStringLiteral("Ctrl+Z"), QStringLiteral("Undo")},
        {QStringLiteral("Ctrl+Shift+Z"), QStringLiteral("Redo")},

--- a/editor.hpp
+++ b/editor.hpp
@@ -42,7 +42,8 @@ public:
     Marker,
     Rectangle,
     Text,
-    Ocr
+    Ocr,
+    Eyedropper
   };
 
 private:

--- a/eyedropper-smoke.cpp
+++ b/eyedropper-smoke.cpp
@@ -1,0 +1,44 @@
+/** @fileoverview Focused tests for original-source eyedropper coordinate mapping. */
+#include "eyedropper.hpp"
+
+#include <QCoreApplication>
+#include <QImage>
+
+#include <iostream>
+
+namespace {
+bool expectColor(const char *name, const QColor &actual, const QColor &expected) {
+  if (actual == expected)
+    return true;
+  std::cerr << name << ": expected " << expected.name().toStdString()
+            << ", got " << actual.name().toStdString() << '\n';
+  return false;
+}
+}
+
+int main(int argc, char **argv) {
+  QCoreApplication app(argc, argv);
+  QImage source(16, 8, QImage::Format_RGB32);
+  for (int y = 0; y < source.height(); ++y)
+    for (int x = 0; x < source.width(); ++x)
+      source.setPixelColor(x, y, QColor(x * 10, y * 20, 100));
+
+  bool ok = true;
+  ok &= expectColor("cropped mapping",
+                    sampleSourceColor(source, QSizeF(8, 4), QRectF(2, 1, 4, 2),
+                                      QRectF(10, 20, 80, 40), QPointF(50, 40)),
+                    QColor(80, 80, 100));
+  ok &= expectColor("high dpi mapping",
+                    sampleSourceColor(source, QSizeF(8, 4), QRectF(0, 0, 8, 4),
+                                      QRectF(0, 0, 160, 80), QPointF(95, 45)),
+                    QColor(90, 80, 100));
+  ok &= expectColor("bottom edge clamping",
+                    sampleSourceColor(source, QSizeF(8, 4), QRectF(2, 1, 4, 2),
+                                      QRectF(10, 20, 80, 40), QPointF(-100, 100)),
+                    QColor(40, 100, 100));
+  ok &= expectColor("right edge clamping",
+                    sampleSourceColor(source, QSizeF(8, 4), QRectF(2, 1, 4, 2),
+                                      QRectF(10, 20, 80, 40), QPointF(100, 40)),
+                    QColor(110, 80, 100));
+  return ok ? 0 : 1;
+}

--- a/eyedropper.cpp
+++ b/eyedropper.cpp
@@ -1,0 +1,38 @@
+/** @fileoverview Maps displayed editor coordinates to source pixels. */
+#include "eyedropper.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+QColor sampleSourceColor(const QImage &source, const QSizeF &previewSize,
+                         const QRectF &selection, const QRectF &displayRect,
+                         const QPointF &displayPoint) {
+  if (source.isNull() || previewSize.width() <= 0 || previewSize.height() <= 0 ||
+      selection.isEmpty() || displayRect.isEmpty())
+    return {};
+  const QRectF boundedSelection = selection.normalized().intersected(
+      QRectF(QPointF(), previewSize));
+  if (boundedSelection.isEmpty())
+    return {};
+  const qreal u = std::clamp((displayPoint.x() - displayRect.left()) /
+                                 displayRect.width(), 0.0, 1.0);
+  const qreal v = std::clamp((displayPoint.y() - displayRect.top()) /
+                                 displayRect.height(), 0.0, 1.0);
+  const auto sourcePixel = [](qreal start, qreal end, qreal position,
+                              int sourceExtent, qreal previewExtent) {
+    const int first = std::clamp(
+        static_cast<int>(std::floor(start * sourceExtent / previewExtent)), 0,
+        sourceExtent - 1);
+    const int pastLast = std::clamp(
+        static_cast<int>(std::ceil(end * sourceExtent / previewExtent)),
+        first + 1, sourceExtent);
+    return std::clamp(
+        first + static_cast<int>(std::floor(position * (pastLast - first))),
+        first, pastLast - 1);
+  };
+  const int x = sourcePixel(boundedSelection.left(), boundedSelection.right(),
+                            u, source.width(), previewSize.width());
+  const int y = sourcePixel(boundedSelection.top(), boundedSelection.bottom(),
+                            v, source.height(), previewSize.height());
+  return source.pixelColor(x, y);
+}

--- a/eyedropper.hpp
+++ b/eyedropper.hpp
@@ -1,0 +1,15 @@
+/** @fileoverview Pure source-pixel sampling helper for the editor eyedropper. */
+#pragma once
+
+#include <QColor>
+#include <QImage>
+#include <QPointF>
+#include <QRectF>
+#include <QSizeF>
+
+/** Samples the original source image at a point in the displayed selection. */
+[[nodiscard]] QColor sampleSourceColor(const QImage &source,
+                                       const QSizeF &previewSize,
+                                       const QRectF &selection,
+                                       const QRectF &displayRect,
+                                       const QPointF &displayPoint);

--- a/icons.cpp
+++ b/icons.cpp
@@ -81,6 +81,11 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     path.moveTo(8, 17);
     path.lineTo(13, 17);
     painter.drawPath(path);
+  } else if (action == QStringLiteral("tool-eyedropper")) {
+    painter.drawEllipse(QPointF(8, 8), 4, 4);
+    painter.drawLine(QPointF(11, 11), QPointF(19, 19));
+    painter.drawLine(QPointF(16, 16), QPointF(20, 12));
+    painter.drawLine(QPointF(4, 20), QPointF(8, 16));
   } else if (action == QStringLiteral("custom-color")) {
     QConicalGradient gradient(QPointF(12, 12), 90);
     gradient.setColorAt(0.0, QColor(QStringLiteral("#ff375f")));


### PR DESCRIPTION
## Summary

  - Add an Eyedropper toolbar tool with the `I` shortcut.
  - Sample colors from the original full-resolution screenshot.
  - Correctly map cropped and high-DPI captures.
  - Keep right and bottom edge samples inside the selected crop.
  - Set the sampled color as the current custom annotation color.
  - Recolor a selected annotation with normal undo support.
  - Copy the uppercase `#RRGGBB` value to the clipboard.
  - Preserve the selected color if clipboard copying fails.
  - Return to Select after sampling.

  ## Testing

  - Added focused tests for cropped, high-DPI, right-edge, bottom-edge, and clamped sampling.
  - Added editor interaction and undo coverage.
  - Added focused smoke programs to Linux CI.
  - Full headless smoke suite passes.
  - `git diff --check` passes.