### PR TITLE
Add KDE Plasma support

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check installer scripts
-        run: bash -n install-omarchy
+        run: |
+          bash -n install-omarchy
+          bash -n install-kde
 
       - name: Configure release build
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
@@ -38,6 +40,14 @@ jobs:
         env:
           QT_QPA_PLATFORM: offscreen
         run: ./build/omasnap-smoke /tmp/omasnap-smoke
+
+      - name: Compile and smoke the KDE backend
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          cmake -S . -B build-kde -G Ninja -DCMAKE_BUILD_TYPE=Release -DOMASNAP_KDE=ON
+          cmake --build build-kde --parallel
+          ./build-kde/omasnap-smoke /tmp/omasnap-smoke-kde
 
       - name: Stage installation
         run: cmake --install build --prefix "$PWD/stage/usr"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
+build-kde/
 stage/
 *.tar.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # Omasnap — Agent Guide
 
 Omasnap is a super fast, native Wayland screenshot and annotation overlay,
-built primarily for [Omarchy](https://omarchy.org) on Hyprland. It captures
+built primarily for [Omarchy](https://omarchy.org) on Hyprland, with KDE
+Plasma 6 as a second supported desktop. It captures
 region, window, or full monitor, then opens an annotation editor with vector
 layers (arrows, lines, freehand, highlighter, rectangles, numbered markers,
 text, OCR). Finished captures go to clipboard, `~/Pictures/Screenshots`, or a
@@ -12,7 +13,9 @@ pinned always-on-top layer surface.
 - **Speed first.** The tool must feel instant: capture, annotate, copy. No
   startup bloat, no settings UI, no wizards.
 - **Wayland only.** Requires Wayland + Hyprland (monitor/window discovery via
-  `hyprctl`). No X11, no macOS/Windows ports, no generic-compositor support.
+  `hyprctl`) or Wayland + KDE Plasma 6 (KWin `ScreenShot2` DBus and scripting,
+  see `kwin.cpp`). No X11, no macOS/Windows ports, no generic-compositor
+  support.
 - **No backwards compatibility.** Break keybindings, CLI flags, file formats,
   or internals whenever it keeps the code simpler or the tool faster. Do not
   add compatibility shims, deprecation aliases, or migration code.
@@ -29,12 +32,14 @@ pinned always-on-top layer surface.
 |---|---|
 | `main.cpp` | CLI parsing, single-instance lock, mode dispatch (capture / edit file / pin) |
 | `capture.cpp/.hpp` | Capture selection overlay, snapshot lifecycle under `/run/user/<UID>/omasnap/` |
+| `kwin.cpp/.hpp` | KDE Plasma backend: KWin `ScreenShot2` DBus capture and scripted window discovery; compiled only with `-DOMASNAP_KDE=ON` (`kwin.hpp` stubs it out otherwise) |
 | `editor.cpp/.hpp` | Annotation editor: tools, layers, undo/redo, rendering, export |
 | `pin.cpp/.hpp` | Pinned-capture layer-shell surfaces (bottom-right, all workspaces) |
 | `surface-capture.cpp` | Clean window capture via `ext-image-copy-capture` Wayland protocol |
 | `icons.cpp/.hpp` | Vector icon renderer for toolbar and pin controls |
 | `editor-smoke.cpp`, `transform-smoke.cpp` | Headless smoke tests (Qt Test, offscreen platform) |
 | `install-omarchy` | Omarchy installer (deps via `omarchy-pkg-add`, installs to `~/.local`) |
+| `install-kde` | KDE Plasma installer (installs to `~/.local`, refreshes the KDE service cache) |
 | `CMakeLists.txt` | Build definition; **the version lives here** (`project(omasnap VERSION ...)`) |
 
 ## Build and verify

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,23 @@ cmake_minimum_required(VERSION 3.24)
 project(omasnap VERSION 1.12.0 LANGUAGES C CXX)
 include(GNUInstallDirs)
 
+option(OMASNAP_KDE "Build the KDE Plasma (KWin) backend" OFF)
+
 find_package(PkgConfig REQUIRED)
 find_package(Qt6 6.8 REQUIRED COMPONENTS Concurrent Core Gui Test Widgets)
+if(OMASNAP_KDE)
+  find_package(Qt6 6.8 REQUIRED COMPONENTS DBus)
+endif()
 find_package(LayerShellQt REQUIRED)
 pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
 find_program(WAYLAND_SCANNER wayland-scanner REQUIRED)
 
+set(WAYLAND_PROTOCOLS_DIR "/usr/share/wayland-protocols" CACHE PATH
+  "Root of the wayland-protocols XML tree")
 set(PROTOCOL_XMLS
-  /usr/share/wayland-protocols/staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml
-  /usr/share/wayland-protocols/staging/ext-image-capture-source/ext-image-capture-source-v1.xml
-  /usr/share/wayland-protocols/staging/ext-image-copy-capture/ext-image-copy-capture-v1.xml
+  ${WAYLAND_PROTOCOLS_DIR}/staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml
+  ${WAYLAND_PROTOCOLS_DIR}/staging/ext-image-capture-source/ext-image-capture-source-v1.xml
+  ${WAYLAND_PROTOCOLS_DIR}/staging/ext-image-copy-capture/ext-image-copy-capture-v1.xml
 )
 set(PROTOCOL_SOURCES)
 foreach(PROTOCOL_XML IN LISTS PROTOCOL_XMLS)
@@ -42,6 +49,7 @@ qt_add_executable(omasnap
   pin-layout.hpp
   capture.cpp
   capture.hpp
+  kwin.hpp
   eyedropper.cpp
   eyedropper.hpp
   surface-capture.cpp
@@ -81,6 +89,8 @@ qt_add_executable(omasnap-smoke
   cli-path.hpp
   capture.cpp
   capture.hpp
+  kwin.hpp
+  kwin-smoke.hpp
   surface-capture-smoke.cpp
   surface-capture-smoke.hpp
   ${PROTOCOL_SOURCES}
@@ -114,6 +124,17 @@ target_link_libraries(omasnap-smoke PRIVATE
   PkgConfig::WaylandClient
 )
 
+if(OMASNAP_KDE)
+  # kwin.cpp declares a moc'd QObject for its DBus window-list sink.
+  foreach(KDE_TARGET omasnap omasnap-smoke)
+    target_sources(${KDE_TARGET} PRIVATE kwin.cpp)
+    target_compile_definitions(${KDE_TARGET} PRIVATE OMASNAP_KDE)
+    target_link_libraries(${KDE_TARGET} PRIVATE Qt6::DBus)
+    set_target_properties(${KDE_TARGET} PROPERTIES AUTOMOC ON)
+  endforeach()
+  target_sources(omasnap-smoke PRIVATE kwin-smoke.cpp)
+endif()
+
 install(TARGETS omasnap
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 )
@@ -121,6 +142,16 @@ install(FILES assets/OFL.txt
   DESTINATION "${CMAKE_INSTALL_DATADIR}/licenses/omasnap"
   RENAME Neucha-OFL.txt
 )
-install(FILES omasnap.desktop
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/applications"
-)
+if(OMASNAP_KDE)
+  # KWin authorizes the ScreenShot2 DBus interface by resolving a desktop
+  # entry whose Exec matches the calling binary, so Exec must be absolute.
+  configure_file(omasnap-kde.desktop.in
+    "${CMAKE_CURRENT_BINARY_DIR}/omasnap.desktop" @ONLY)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/omasnap.desktop"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/applications"
+  )
+else()
+  install(FILES omasnap.desktop
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/applications"
+  )
+endif()

--- a/README.md
+++ b/README.md
@@ -31,22 +31,36 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 
 ## Platform scope
 
-The supported target is **Wayland + Hyprland**, with Omarchy as the primary integration.
-The renderer, layer surface, clipboard, and clean-window capture use Wayland protocols;
-monitor/window discovery currently calls `hyprctl`. `grim` captures the monitor before
-the layer maps. Selection displays that captured frame, while the annotation editor uses
-a translucent layer scrim over the live desktop and draws only the selected capture.
-Another Wayland compositor could support the application after supplying equivalent
-monitor and window discovery; generic Wayland support is not claimed by 1.0.
+The supported targets are **Wayland + Hyprland** (with Omarchy as the primary
+integration) and **Wayland + KDE Plasma 6**. The renderer, layer surface, and clipboard
+use Wayland protocols on both. Selection displays the captured frame, while the
+annotation editor uses a translucent layer scrim over the live desktop and draws only
+the selected capture. Another Wayland compositor could support the application after
+supplying equivalent monitor and window discovery; generic Wayland support is not
+claimed.
+
+On Hyprland, monitor/window discovery calls `hyprctl`, `grim` captures the monitor
+before the layer maps, and clean window capture uses the `ext-image-copy-capture`
+Wayland protocol.
+
+On KDE Plasma (opt-in at build time with `-DOMASNAP_KDE=ON`, which `install-kde`
+passes), KWin does not expose those capture protocols to ordinary clients, so
+Omasnap uses the interfaces Plasma sanctions for screenshot tools instead: the
+`org.kde.KWin.ScreenShot2` DBus service for monitor and clean window pixels, and a
+transient KWin script for stacking-ordered window discovery. KWin authorizes
+`ScreenShot2` callers by matching the installed desktop entry's absolute `Exec` path
+against the calling binary, which is why the desktop entry declares
+`X-KDE-DBUS-Restricted-Interfaces=org.kde.KWin.ScreenShot2` and why running an
+uninstalled binary is denied.
 
 Runtime commands used by the application:
 
-- `hyprctl`
-- `grim`
+- `hyprctl` and `grim` (Hyprland only)
 - `wl-copy` and `wl-paste`
 - `tesseract`
 - `omarchy-notification-send` when available; saved captures include a thumbnail and
-  reopen in Omasnap when clicked. Notification failure does not invalidate output.
+  reopen in Omasnap when clicked. Falls back to `notify-send` on other desktops.
+  Notification failure does not invalidate output.
 
 ## Install on Omarchy
 
@@ -96,6 +110,33 @@ extensions; they do not install native executables or system packages.
 
 Set `OMASNAP_PREFIX` before running `install-omarchy` to use a prefix other than
 `~/.local`.
+
+## Install on KDE Plasma
+
+Install the dependencies (Arch package names shown; `layer-shell-qt` ships with
+Plasma):
+
+```bash
+sudo pacman -S --needed \
+  base-devel cmake ninja pkgconf qt6-base layer-shell-qt \
+  wayland wayland-protocols wl-clipboard \
+  tesseract tesseract-data-eng
+```
+
+Then clone the repository and run the KDE installer:
+
+```bash
+git clone https://github.com/tobi/omasnap.git
+cd omasnap
+./install-kde
+```
+
+The installer builds with `-DOMASNAP_KDE=ON` in `~/.cache/omasnap`, installs under
+`~/.local` (override with `OMASNAP_PREFIX`), and refreshes the KDE service cache so
+KWin authorizes the screenshot interface. Builds without the option contain no KDE
+code and ship the plain desktop entry, so Omarchy installs are unaffected. Bind a global shortcut to `~/.local/bin/omasnap` in System
+Settings under Keyboard, Shortcuts. The binary must be launched from its installed
+path; KWin denies screenshot access to binaries without a matching desktop entry.
 
 ### Manual Arch Linux build
 

--- a/capture.cpp
+++ b/capture.cpp
@@ -1,6 +1,8 @@
 /** @fileoverview Captures, renders, saves, and shares screenshots. */
 #include "capture.hpp"
 
+#include "kwin.hpp"
+
 #include <QBuffer>
 #include <QCoreApplication>
 #include <QDateTime>
@@ -663,6 +665,9 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
 }
 
 bool captureFocusedMonitor(CaptureData &capture, QString &error) {
+  if (kwinSession())
+    return kwinCaptureFocusedMonitor(capture, error);
+
   const ProcessResult monitors =
       runProcess(QStringLiteral("hyprctl"),
                  {QStringLiteral("monitors"), QStringLiteral("-j")});
@@ -994,7 +999,42 @@ QString recognizeText(const QImage &image, QString &error) {
   return text;
 }
 
+namespace {
+/** Sends a plain notify-send notification on desktops without Omarchy. */
+void sendFreedesktopNotification(const QString &message,
+                                 const QString &imagePath) {
+  if (QStandardPaths::findExecutable(QStringLiteral("notify-send")).isEmpty())
+    return;
+  if (imagePath.isEmpty()) {
+    QProcess::startDetached(QStringLiteral("notify-send"),
+                            {QStringLiteral("-a"), QStringLiteral("omasnap"),
+                             QStringLiteral("-t"), QStringLiteral("4500"),
+                             message});
+    return;
+  }
+  QString omasnap = QDir(QCoreApplication::applicationDirPath())
+                        .filePath(QStringLiteral("omasnap"));
+  if (!QFileInfo::exists(omasnap))
+    omasnap = QStringLiteral("omasnap");
+  // notify-send -A blocks until the notification closes and prints the
+  // chosen action, so a detached shell waits for the click on our behalf.
+  const QString command =
+      QStringLiteral("action=$(notify-send -a omasnap -t 4500 -i %1 -A "
+                     "default=Edit %2 'Click to edit'); "
+                     "[ \"$action\" = default ] && exec %3 %1")
+          .arg(shellQuote(imagePath), shellQuote(message), shellQuote(omasnap));
+  QProcess::startDetached(QStringLiteral("bash"),
+                          {QStringLiteral("-c"), command});
+}
+} // namespace
+
 void sendCaptureNotification(const QString &message, const QString &imagePath) {
+  if (QStandardPaths::findExecutable(
+          QStringLiteral("omarchy-notification-send"))
+          .isEmpty()) {
+    sendFreedesktopNotification(message, imagePath);
+    return;
+  }
   QStringList arguments{QStringLiteral("-g"), QStringLiteral(""),
                         QStringLiteral("--app-name"), QStringLiteral("omasnap"),
                         message};

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -3,6 +3,7 @@
 #include "capture.hpp"
 #include "cli-path.hpp"
 #include "editor.hpp"
+#include "kwin-smoke.hpp"
 #include "pin-layout-smoke.hpp"
 #include "pin-lifecycle-smoke.hpp"
 #include "transform-smoke.hpp"
@@ -710,6 +711,21 @@ int main(int argc, char **argv) {
   QApplication application(argc, argv);
   if (!loadCaptureFonts())
     return 17;
+  // Stub the notifiers so save checks cannot spam the host desktop.
+  QTemporaryDir notifierStubs;
+  if (notifierStubs.isValid()) {
+    const QByteArray stub = QByteArrayLiteral("#!/usr/bin/env bash\nexit 0\n");
+    for (const QString &name :
+         {QStringLiteral("omarchy-notification-send"),
+          QStringLiteral("notify-send")}) {
+      QFile file(QDir(notifierStubs.path()).filePath(name));
+      if (file.open(QIODevice::WriteOnly) && file.write(stub) == stub.size())
+        file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner |
+                            QFileDevice::ExeOwner);
+    }
+    qputenv("PATH",
+            notifierStubs.path().toUtf8() + ':' + qgetenv("PATH"));
+  }
   QString snapshotError;
   if (!runPositionalImageTargetCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
@@ -750,6 +766,10 @@ int main(int argc, char **argv) {
   if (!runContinuousAnnotationToolsSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 80;
+  }
+  if (!runKWinParseSmoke(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 81;
   }
   const QString outputRoot =
       argc > 1 ? QString::fromLocal8Bit(argv[1])

--- a/install-kde
+++ b/install-kde
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+prefix="${OMASNAP_PREFIX:-$HOME/.local}"
+build_dir="${XDG_CACHE_HOME:-$HOME/.cache}/omasnap/build"
+
+missing=()
+for tool in cmake ninja pkg-config wayland-scanner; do
+  command -v "$tool" >/dev/null || missing+=("$tool")
+done
+if ((${#missing[@]})); then
+  printf 'install-kde: missing build tools: %s\n' "${missing[*]}" >&2
+  printf 'On Arch: sudo pacman -S --needed base-devel cmake ninja pkgconf qt6-base layer-shell-qt wayland wayland-protocols wl-clipboard tesseract tesseract-data-eng\n' >&2
+  exit 1
+fi
+
+cmake -S "$repo_dir" -B "$build_dir" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$prefix" \
+  -DOMASNAP_KDE=ON
+cmake --build "$build_dir" --parallel
+cmake --install "$build_dir"
+
+# KWin authorizes ScreenShot2 by matching the desktop entry's absolute Exec
+# path against the calling binary; refresh the service cache so the freshly
+# installed entry is seen without waiting for kded.
+command -v kbuildsycoca6 >/dev/null && kbuildsycoca6 --noincremental >/dev/null 2>&1 || true
+
+for tool in wl-copy wl-paste tesseract; do
+  command -v "$tool" >/dev/null || printf 'install-kde: %s is not installed; install it before capturing\n' "$tool" >&2
+done
+
+"$prefix/bin/omasnap" --version
+printf 'Bind a global shortcut to %s/bin/omasnap in System Settings > Keyboard > Shortcuts.\n' "$prefix"

--- a/kwin-smoke.cpp
+++ b/kwin-smoke.cpp
@@ -1,0 +1,51 @@
+/** @fileoverview Tests KWin window-list JSON mapping without a compositor. */
+#include "kwin-smoke.hpp"
+
+#include "kwin.hpp"
+
+bool runKWinParseSmoke(QString &error) {
+  MonitorInfo monitor;
+  monitor.name = QStringLiteral("DP-1");
+  monitor.geometry = {2560, 100, 2560, 1440};
+  monitor.pixelSize = {3840, 2160};
+  monitor.scale = 1.5;
+
+  // Windows arrive in KWin stacking order (bottom to top) with global
+  // logical coordinates: one fully inside, one straddling the monitor edge,
+  // one on another monitor, and one untitled.
+  const QByteArray json = QByteArrayLiteral(
+      "[{\"title\":\"editor\",\"id\":\"{aa}\",\"x\":2660,\"y\":200,"
+      "\"width\":800,\"height\":600},"
+      "{\"title\":\"straddler\",\"id\":\"{bb}\",\"x\":2360,\"y\":150,"
+      "\"width\":400,\"height\":300},"
+      "{\"title\":\"elsewhere\",\"id\":\"{cc}\",\"x\":0,\"y\":0,"
+      "\"width\":640,\"height\":480},"
+      "{\"title\":\"\",\"id\":\"{dd}\",\"x\":2560,\"y\":100,"
+      "\"width\":2560,\"height\":1440}]");
+  const QVector<WindowTarget> windows = kwinParseWindows(json, monitor);
+  if (windows.size() != 3) {
+    error = QStringLiteral("KWin window parsing kept %1 of 3 windows")
+                .arg(windows.size());
+    return false;
+  }
+  if (windows.at(0).rect != QRect(100, 100, 800, 600) ||
+      windows.at(0).stableId != QStringLiteral("{aa}") ||
+      windows.at(0).title != QStringLiteral("editor")) {
+    error = QStringLiteral("KWin window parsing mangled an inside window");
+    return false;
+  }
+  if (windows.at(1).rect != QRect(0, 50, 200, 300)) {
+    error = QStringLiteral("KWin window parsing did not clip to the monitor");
+    return false;
+  }
+  if (windows.at(2).rect != QRect(0, 0, 2560, 1440) ||
+      windows.at(2).title != QStringLiteral("window")) {
+    error = QStringLiteral("KWin window parsing lost the untitled fallback");
+    return false;
+  }
+  if (kwinParseWindows(QByteArrayLiteral("not json"), monitor).size() != 0) {
+    error = QStringLiteral("KWin window parsing accepted invalid JSON");
+    return false;
+  }
+  return true;
+}

--- a/kwin-smoke.hpp
+++ b/kwin-smoke.hpp
@@ -1,0 +1,10 @@
+/** @fileoverview Declares the KWin window-list parsing smoke test. */
+#pragma once
+
+#include <QString>
+
+#ifdef OMASNAP_KDE
+[[nodiscard]] bool runKWinParseSmoke(QString &error);
+#else
+[[nodiscard]] inline bool runKWinParseSmoke(QString &) { return true; }
+#endif

--- a/kwin.cpp
+++ b/kwin.cpp
@@ -1,0 +1,317 @@
+/** @fileoverview Captures monitors and windows on KDE Plasma through KWin.
+ *
+ * KWin does not expose the wlr or ext capture protocols to ordinary clients,
+ * so this backend uses the interfaces Plasma sanctions for screenshot tools:
+ * the org.kde.KWin.ScreenShot2 DBus service for pixels (authorized through
+ * the installed desktop entry's X-KDE-DBUS-Restricted-Interfaces key) and a
+ * transient KWin script for window discovery.
+ */
+#include "kwin.hpp"
+
+#include <QCoreApplication>
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+#include <QDBusReply>
+#include <QDBusUnixFileDescriptor>
+#include <QDir>
+#include <QEventLoop>
+#include <QFile>
+#include <QGuiApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QScreen>
+#include <QTimer>
+
+#include <algorithm>
+#include <fcntl.h>
+#include <poll.h>
+#include <unistd.h>
+
+namespace {
+constexpr int kDBusTimeoutMs = 3000;
+constexpr int kCaptureTimeoutMs = 10000;
+
+const QString kKWinService = QStringLiteral("org.kde.KWin");
+
+/** Receives the window list a transient KWin script reports back over DBus. */
+class KWinWindowSink final : public QObject {
+  Q_OBJECT
+  Q_CLASSINFO("D-Bus Interface", "org.omasnap.WindowSink")
+public:
+  QByteArray payload;
+  bool received = false;
+  QEventLoop *loop = nullptr;
+
+public Q_SLOTS:
+  Q_SCRIPTABLE void windows(const QString &json) {
+    payload = json.toUtf8();
+    received = true;
+    if (loop)
+      loop->quit();
+  }
+};
+
+QString activeOutputName(QString &error) {
+  QDBusMessage message = QDBusMessage::createMethodCall(
+      kKWinService, QStringLiteral("/KWin"), QStringLiteral("org.kde.KWin"),
+      QStringLiteral("activeOutputName"));
+  const QDBusReply<QString> reply =
+      QDBusConnection::sessionBus().call(message, QDBus::Block, kDBusTimeoutMs);
+  if (!reply.isValid() || reply.value().isEmpty()) {
+    error = QStringLiteral("KWin did not report a focused monitor: %1")
+                .arg(reply.error().message());
+    return {};
+  }
+  return reply.value();
+}
+
+/** Runs one ScreenShot2 method and reads the raw image from a pipe. */
+bool screenshot2Capture(const QString &method, const QString &target,
+                        QVariantMap options, QImage &image, qreal &scale,
+                        QString &error) {
+  int fds[2];
+  if (::pipe2(fds, O_CLOEXEC) != 0) {
+    error = QStringLiteral("Could not create screenshot pipe");
+    return false;
+  }
+
+  options.insert(QStringLiteral("native-resolution"), true);
+  QDBusMessage message = QDBusMessage::createMethodCall(
+      kKWinService, QStringLiteral("/org/kde/KWin/ScreenShot2"),
+      QStringLiteral("org.kde.KWin.ScreenShot2"), method);
+  message << target << options
+          << QVariant::fromValue(QDBusUnixFileDescriptor(fds[1]));
+  QDBusPendingCallWatcher watcher(
+      QDBusConnection::sessionBus().asyncCall(message, kCaptureTimeoutMs));
+  ::close(fds[1]);
+
+  QEventLoop loop;
+  QObject::connect(&watcher, &QDBusPendingCallWatcher::finished, &loop,
+                   &QEventLoop::quit);
+  QTimer::singleShot(kCaptureTimeoutMs, &loop, &QEventLoop::quit);
+  loop.exec();
+  if (!watcher.isFinished()) {
+    ::close(fds[0]);
+    error = QStringLiteral("KWin did not answer the screenshot request");
+    return false;
+  }
+  const QDBusPendingReply<QVariantMap> reply = watcher;
+  if (reply.isError()) {
+    ::close(fds[0]);
+    if (reply.error().name() ==
+        QStringLiteral("org.kde.KWin.ScreenShot2.Error.NoAuthorized"))
+      error = QStringLiteral(
+          "KWin denied screenshot access; run install-kde so the omasnap "
+          "desktop entry authorizes org.kde.KWin.ScreenShot2");
+    else
+      error = reply.error().message();
+    return false;
+  }
+
+  const QVariantMap attributes = reply.value();
+  const int width = attributes.value(QStringLiteral("width")).toInt();
+  const int height = attributes.value(QStringLiteral("height")).toInt();
+  const int stride = attributes.value(QStringLiteral("stride")).toInt();
+  const auto format = static_cast<QImage::Format>(
+      attributes.value(QStringLiteral("format")).toUInt());
+  scale = attributes.value(QStringLiteral("scale")).toReal();
+  if (scale <= 0.0)
+    scale = 1.0;
+  const qint64 total = static_cast<qint64>(stride) * height;
+  if (width <= 0 || height <= 0 || stride <= 0 ||
+      total > qint64(1) << 29 || format <= QImage::Format_Invalid ||
+      format >= QImage::NImageFormats) {
+    ::close(fds[0]);
+    error = QStringLiteral("KWin returned an unusable screenshot format");
+    return false;
+  }
+
+  QByteArray bytes;
+  bytes.resize(total);
+  qsizetype received = 0;
+  while (received < bytes.size()) {
+    struct pollfd poller{fds[0], POLLIN, 0};
+    if (::poll(&poller, 1, kCaptureTimeoutMs) <= 0)
+      break;
+    const ssize_t count = ::read(fds[0], bytes.data() + received,
+                                 static_cast<size_t>(bytes.size() - received));
+    if (count <= 0)
+      break;
+    received += count;
+  }
+  ::close(fds[0]);
+  if (received < bytes.size()) {
+    error = QStringLiteral("KWin closed the screenshot stream early");
+    return false;
+  }
+
+  image = QImage(reinterpret_cast<const uchar *>(bytes.constData()), width,
+                 height, stride, format)
+              .copy();
+  return !image.isNull();
+}
+
+/** Asks a transient KWin script for the stacking-ordered window list. */
+QByteArray listWindowsJson() {
+  const QString runtime = secureRuntimeDirectory();
+  if (runtime.isEmpty())
+    return {};
+
+  QDBusConnection bus = QDBusConnection::sessionBus();
+  KWinWindowSink sink;
+  const QString sinkPath = QStringLiteral("/windows");
+  if (!bus.registerObject(sinkPath, &sink,
+                          QDBusConnection::ExportScriptableSlots))
+    return {};
+
+  const QString scriptPath = QDir(runtime).filePath(
+      QStringLiteral("omasnap-windows-%1.js")
+          .arg(QCoreApplication::applicationPid()));
+  const QString script =
+      QStringLiteral(
+          "const current = workspace.currentDesktop;\n"
+          "const list = [];\n"
+          "for (const w of workspace.stackingOrder) {\n"
+          "  if (!w.normalWindow || w.minimized) continue;\n"
+          "  if (!w.onAllDesktops && !w.desktops.includes(current)) continue;\n"
+          "  list.push({title: w.caption, id: String(w.internalId),\n"
+          "    x: Math.round(w.frameGeometry.x),\n"
+          "    y: Math.round(w.frameGeometry.y),\n"
+          "    width: Math.round(w.frameGeometry.width),\n"
+          "    height: Math.round(w.frameGeometry.height)});\n"
+          "}\n"
+          "callDBus(\"%1\", \"%2\", \"org.omasnap.WindowSink\", \"windows\",\n"
+          "  JSON.stringify(list));\n")
+          .arg(bus.baseService(), sinkPath);
+  QFile scriptFile(scriptPath);
+  const bool written =
+      scriptFile.open(QIODevice::WriteOnly | QIODevice::Truncate) &&
+      scriptFile.write(script.toUtf8()) >= 0;
+  scriptFile.close();
+  if (!written) {
+    bus.unregisterObject(sinkPath);
+    return {};
+  }
+
+  const QString pluginName = QStringLiteral("omasnap-windows-%1")
+                                 .arg(QCoreApplication::applicationPid());
+  const QString scriptingPath = QStringLiteral("/Scripting");
+  const QString scriptingInterface = QStringLiteral("org.kde.kwin.Scripting");
+  QDBusMessage load = QDBusMessage::createMethodCall(
+      kKWinService, scriptingPath, scriptingInterface,
+      QStringLiteral("loadScript"));
+  load << scriptPath << pluginName;
+  const QDBusReply<int> loaded = bus.call(load, QDBus::Block, kDBusTimeoutMs);
+  if (loaded.isValid() && loaded.value() >= 0) {
+    QEventLoop loop;
+    sink.loop = &loop;
+    bus.call(QDBusMessage::createMethodCall(kKWinService, scriptingPath,
+                                            scriptingInterface,
+                                            QStringLiteral("start")),
+             QDBus::Block, kDBusTimeoutMs);
+    if (!sink.received) {
+      QTimer::singleShot(kDBusTimeoutMs, &loop, &QEventLoop::quit);
+      loop.exec();
+    }
+    sink.loop = nullptr;
+  }
+  QDBusMessage unload = QDBusMessage::createMethodCall(
+      kKWinService, scriptingPath, scriptingInterface,
+      QStringLiteral("unloadScript"));
+  unload << pluginName;
+  bus.call(unload, QDBus::Block, kDBusTimeoutMs);
+  QFile::remove(scriptPath);
+  bus.unregisterObject(sinkPath);
+  return sink.payload;
+}
+} // namespace
+
+bool kwinSession() {
+  if (!qEnvironmentVariableIsEmpty("HYPRLAND_INSTANCE_SIGNATURE"))
+    return false;
+  const QStringList desktops = qEnvironmentVariable("XDG_CURRENT_DESKTOP")
+                                   .split(QLatin1Char(':'), Qt::SkipEmptyParts);
+  return std::any_of(desktops.begin(), desktops.end(), [](const QString &entry) {
+    return entry.compare(QStringLiteral("KDE"), Qt::CaseInsensitive) == 0;
+  });
+}
+
+QVector<WindowTarget> kwinParseWindows(const QByteArray &json,
+                                       const MonitorInfo &monitor) {
+  QVector<WindowTarget> result;
+  const QJsonDocument document = QJsonDocument::fromJson(json);
+  if (!document.isArray())
+    return result;
+
+  for (const QJsonValue value : document.array()) {
+    const QJsonObject object = value.toObject();
+    QRect rect(object.value(QStringLiteral("x")).toInt() -
+                   monitor.geometry.x(),
+               object.value(QStringLiteral("y")).toInt() -
+                   monitor.geometry.y(),
+               object.value(QStringLiteral("width")).toInt(),
+               object.value(QStringLiteral("height")).toInt());
+    rect = rect.intersected(QRect(QPoint(), monitor.geometry.size()));
+    if (rect.isEmpty())
+      continue;
+
+    QString title = object.value(QStringLiteral("title")).toString();
+    if (title.isEmpty())
+      title = QStringLiteral("window");
+    result.push_back({rect, object.value(QStringLiteral("id")).toString(),
+                      std::move(title)});
+  }
+  return result;
+}
+
+bool kwinCaptureFocusedMonitor(CaptureData &capture, QString &error) {
+  const QString outputName = activeOutputName(error);
+  if (outputName.isEmpty())
+    return false;
+
+  QScreen *screen = nullptr;
+  for (QScreen *candidate : QGuiApplication::screens()) {
+    if (candidate->name() == outputName) {
+      screen = candidate;
+      break;
+    }
+  }
+  if (!screen) {
+    error = QStringLiteral("KWin reported unknown monitor %1").arg(outputName);
+    return false;
+  }
+
+  capture.monitor.name = outputName;
+  capture.monitor.geometry = screen->geometry();
+  capture.monitor.workspaceId = 0;
+  if (!screenshot2Capture(QStringLiteral("CaptureScreen"), outputName, {},
+                          capture.source, capture.monitor.scale, error))
+    return false;
+  capture.monitor.pixelSize = capture.source.size();
+
+  capture.preview =
+      capture.source.scaled(capture.monitor.geometry.size(),
+                            Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+  if (capture.preview.isNull()) {
+    error = QStringLiteral("Could not prepare screenshot preview");
+    return false;
+  }
+
+  capture.windows = kwinParseWindows(listWindowsJson(), capture.monitor);
+  return true;
+}
+
+bool kwinCaptureWindowSurface(const WindowTarget &window, QImage &image,
+                              QString &error) {
+  qreal scale = 1.0;
+  return screenshot2Capture(
+      QStringLiteral("CaptureWindow"), window.stableId,
+      {{QStringLiteral("include-decoration"), true},
+       {QStringLiteral("include-shadow"), false}},
+      image, scale, error);
+}
+
+#include "kwin.moc"

--- a/kwin.hpp
+++ b/kwin.hpp
@@ -1,0 +1,33 @@
+/** @fileoverview Declares KDE Plasma (KWin) discovery and capture support.
+ *
+ * The backend is compiled only when CMake is configured with
+ * -DOMASNAP_KDE=ON; otherwise the inline stubs below keep call sites free
+ * of preprocessor branching and the compiler drops the dead paths.
+ */
+#pragma once
+
+#include "capture.hpp"
+
+#ifdef OMASNAP_KDE
+/** Returns true when running inside a KDE Plasma Wayland session. */
+[[nodiscard]] bool kwinSession();
+[[nodiscard]] bool kwinCaptureFocusedMonitor(CaptureData &capture,
+                                             QString &error);
+[[nodiscard]] bool kwinCaptureWindowSurface(const WindowTarget &window,
+                                            QImage &image, QString &error);
+/** Maps KWin script window JSON into monitor-relative window targets. */
+[[nodiscard]] QVector<WindowTarget> kwinParseWindows(const QByteArray &json,
+                                                     const MonitorInfo &monitor);
+#else
+[[nodiscard]] inline bool kwinSession() { return false; }
+[[nodiscard]] inline bool kwinCaptureFocusedMonitor(CaptureData &,
+                                                    QString &error) {
+  error = QStringLiteral("KDE support is not compiled in");
+  return false;
+}
+[[nodiscard]] inline bool kwinCaptureWindowSurface(const WindowTarget &,
+                                                   QImage &, QString &error) {
+  error = QStringLiteral("KDE support is not compiled in");
+  return false;
+}
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
   QCommandLineParser parser;
   parser.setApplicationDescription(
       QStringLiteral("Native Wayland screenshot and annotation overlay for "
-                     "Hyprland and Omarchy."));
+                     "Hyprland, KDE Plasma, and Omarchy."));
   parser.addHelpOption();
   parser.addVersionOption();
   const QCommandLineOption fullscreenOption(

--- a/omasnap-kde.desktop.in
+++ b/omasnap-kde.desktop.in
@@ -1,0 +1,24 @@
+[Desktop Entry]
+Type=Application
+Name=Omasnap
+Comment=Capture and annotate a screenshot
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/omasnap
+Icon=camera-photo
+Terminal=false
+NoDisplay=true
+Categories=Graphics;
+StartupNotify=false
+X-KDE-DBUS-Restricted-Interfaces=org.kde.KWin.ScreenShot2
+Actions=region;windows;fullscreen;
+
+[Desktop Action region]
+Name=Capture Region
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/omasnap region
+
+[Desktop Action windows]
+Name=Capture Window
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/omasnap windows
+
+[Desktop Action fullscreen]
+Name=Capture Monitor
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/omasnap fullscreen

--- a/surface-capture.cpp
+++ b/surface-capture.cpp
@@ -1,6 +1,8 @@
 /** @fileoverview Captures native window surfaces through Wayland protocols. */
 #include "capture.hpp"
 
+#include "kwin.hpp"
+
 #include "ext-foreign-toplevel-list-v1-client-protocol.h"
 #include "ext-image-capture-source-v1-client-protocol.h"
 #include "ext-image-copy-capture-v1-client-protocol.h"
@@ -372,9 +374,11 @@ bool captureWindowSurface(const WindowTarget &window, QImage &image,
                           QString &error) {
   if (window.stableId.isEmpty()) {
     error =
-        QStringLiteral("Hyprland did not provide a stable window identifier");
+        QStringLiteral("Compositor did not provide a stable window identifier");
     return false;
   }
+  if (kwinSession())
+    return kwinCaptureWindowSurface(window, image, error);
 
   CaptureState state;
   state.display = wl_display_connect(nullptr);

--- a/transform-smoke.cpp
+++ b/transform-smoke.cpp
@@ -81,6 +81,9 @@ bool runTransformSmoke(QString &error) {
   }
 
   const QByteArray originalPath = qgetenv("PATH");
+  const QByteArray originalSignature = qgetenv("HYPRLAND_INSTANCE_SIGNATURE");
+  // Force the hyprctl code path even when the smoke test runs inside KDE.
+  qputenv("HYPRLAND_INSTANCE_SIGNATURE", "omasnap-smoke");
   qputenv("PATH", fakeCommands.path().toUtf8() + ':' + originalPath);
   qputenv("OMASNAP_TEST_PPM", ppmPath.toUtf8());
   for (const int transform : {1, 3, 5, 7}) {
@@ -91,12 +94,14 @@ bool runTransformSmoke(QString &error) {
         rotatedCapture.preview.size() != QSize(200, 300)) {
       if (error.isEmpty())
         error = QStringLiteral("Quarter-turn monitor geometry was not swapped");
+      qputenv("HYPRLAND_INSTANCE_SIGNATURE", originalSignature);
       qputenv("PATH", originalPath);
       qunsetenv("OMASNAP_TEST_PPM");
       qunsetenv("OMASNAP_TEST_TRANSFORM");
       return false;
     }
   }
+  qputenv("HYPRLAND_INSTANCE_SIGNATURE", originalSignature);
   qputenv("PATH", originalPath);
   qunsetenv("OMASNAP_TEST_PPM");
   qunsetenv("OMASNAP_TEST_TRANSFORM");


### PR DESCRIPTION
This adds KDE Plasma 6 as a second supported desktop next to Hyprland/Omarchy. The README says another Wayland compositor could support the application after supplying equivalent monitor and window discovery, so it sounded like the project was open to this. The agent guide listed Hyprland-only under project principles, so I updated that section and the README platform scope to match. I just wanted to open with this in case you'd rather keep KDE support out of tree I'll happily close the PR :slightly_smiling_face: 

The backend is opt-in at build time: everything KDE-specific sits behind `-DOMASNAP_KDE=ON` (which `install-kde` passes), so a default build compiles no KDE code, links no `Qt6::DBus`, and installs the exact same `omasnap.desktop` as before. `kwin.hpp` provides inline stubs when the option is off so the call sites stay free of preprocessor branching.

KWin doesn't expose `wlr-screencopy` or the `ext-image-copy-capture`/`ext-foreign-toplevel-list` globals to ordinary clients, so neither `grim` nor the existing clean window capture path can work there. The new `kwin.cpp` backend uses the interfaces Plasma sanctions for screenshot tools instead: the `org.kde.KWin.ScreenShot2` DBus service for monitor and clean window pixels, and a transient KWin script that reports `workspace.stackingOrder` back over DBus for window discovery (bottom to top, so the picker's topmost-wins behaviour is preserved). Backend selection is by environment: `HYPRLAND_INSTANCE_SIGNATURE` keeps the `hyprctl` path, otherwise `XDG_CURRENT_DESKTOP` containing KDE selects KWin. Nothing changes on Hyprland.

KWin only grants `ScreenShot2` to callers whose installed desktop entry has an absolute `Exec` resolving to the calling binary plus `X-KDE-DBUS-Restricted-Interfaces=org.kde.KWin.ScreenShot2` (see [`serviceutils.h`](https://invent.kde.org/plasma/kwin/-/blob/v6.7.4/src/utils/serviceutils.h) and the [interface XML](https://invent.kde.org/plasma/kwin/-/blob/master/src/plugins/screenshot/org.kde.KWin.ScreenShot2.xml)). KDE builds therefore install a desktop entry configured from `omasnap-kde.desktop.in` with the absolute install path, plus `region`/`windows`/`fullscreen` desktop actions so KDE global shortcuts can target a mode; the checked-in `omasnap.desktop` is untouched and still installed by default builds. A new `install-kde` script mirrors `install-omarchy` and refreshes the KDE service cache. Running an uninstalled binary is denied by KWin; the error message says to run `install-kde`.

Smaller changes riding along: notifications fall back to `notify-send` (with a click-to-edit action) when `omarchy-notification-send` is missing, the wayland-protocols XML root is a `WAYLAND_PROTOCOLS_DIR` cache variable, and the smoke stubs both notifiers so save checks can't spam the host desktop.

Verified on Plasma 6.7.4 with a 3840x2160 monitor at 1.5 fractional scale: fullscreen save produced the full native-resolution capture, window discovery returned the stacking-ordered list, `CaptureWindow` returned a decorated native-resolution window surface, the selection overlay maps through KWin's layer-shell, and `--copy` passed the existing `wl-copy`/`wl-paste` verification roundtrip. I also checked the default build is unaffected: no `libQt6DBus` in its `NEEDED` entries and the staged `omasnap.desktop` is byte-identical to the current one. Both configurations pass the offscreen smoke (the KDE one adds a window-list parsing check), and CI now builds and smokes both.

<img width="1196" height="298" alt="image" src="https://github.com/user-attachments/assets/3122cb96-d20f-48a3-a54b-a9167a868eed" />

