### PR TITLE
perf: stream grim via stdout and overlap window discovery

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -5,6 +5,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
+#include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
 #include <QFontDatabase>
@@ -18,7 +19,6 @@
 #include <QRandomGenerator>
 #include <QSaveFile>
 #include <QStandardPaths>
-#include <QTemporaryFile>
 
 #include <QUrl>
 #include <algorithm>
@@ -110,6 +110,51 @@ ProcessResult runProcess(const QString &program, const QStringList &arguments,
   if (!finished)
     process.kill();
   return {process.readAllStandardOutput(), process.readAllStandardError(),
+          finished ? process.exitCode() : -1, finished};
+}
+
+/**
+ * Runs a process whose stdout carries a large payload, draining the pipe as it
+ * arrives into one buffer sized up front. Letting QProcess buffer the whole
+ * payload first costs an extra copy of the full frame.
+ */
+ProcessResult runStreamingProcess(const QString &program,
+                                  const QStringList &arguments,
+                                  qsizetype expectedBytes, int timeoutMs) {
+  QProcess process;
+  process.setProcessChannelMode(QProcess::SeparateChannels);
+  process.start(program, arguments, QIODevice::ReadOnly);
+  if (!process.waitForStarted(2000))
+    return {{}, process.errorString().toUtf8(), -1, false};
+
+  QByteArray output;
+  output.reserve(std::max<qsizetype>(expectedBytes, 0));
+  const auto drain = [&process, &output] {
+    const qint64 available = process.bytesAvailable();
+    if (available <= 0)
+      return;
+    const qsizetype offset = output.size();
+    output.resize(offset + available);
+    const qint64 read = process.read(output.data() + offset, available);
+    output.resize(offset + std::max<qint64>(read, 0));
+  };
+
+  QElapsedTimer clock;
+  clock.start();
+  const auto remainingMs = [&clock, timeoutMs] {
+    return std::max<qint64>(0, timeoutMs - clock.elapsed());
+  };
+  while (remainingMs() > 0 &&
+         process.waitForReadyRead(static_cast<int>(remainingMs())))
+    drain();
+
+  const bool finished =
+      process.state() == QProcess::NotRunning ||
+      process.waitForFinished(static_cast<int>(remainingMs()));
+  if (!finished)
+    process.kill();
+  drain();
+  return {std::move(output), process.readAllStandardError(),
           finished ? process.exitCode() : -1, finished};
 }
 
@@ -675,40 +720,56 @@ bool probeFocusedMonitor(MonitorInfo &monitor, QString &error) {
 }
 
 bool captureMonitorPixels(const MonitorInfo &monitor, CaptureData &capture,
-                          QString &error) {
+                          bool includeWindows, QString &error) {
   capture.monitor = monitor;
-  const QString sourceTemplate =
-      runtimePath(QStringLiteral("omasnap-capture-XXXXXX.ppm"));
-  if (sourceTemplate.isEmpty()) {
-    error = QStringLiteral("Could not create private runtime directory");
-    return false;
-  }
-  QTemporaryFile sourceFile(sourceTemplate);
-  sourceFile.setAutoRemove(true);
-  if (!sourceFile.open()) {
-    error = sourceFile.errorString();
-    return false;
-  }
-  const QString sourcePath = sourceFile.fileName();
-  sourceFile.close();
-
   const QRect geometry = capture.monitor.geometry;
+  if (geometry.size().isEmpty()) {
+    error = QStringLiteral("Focused monitor reported an empty geometry");
+    return false;
+  }
+
+  // Window discovery is independent of the screen grab, so let the hyprctl
+  // round trip overlap grim instead of running after it.
+  QProcess clients;
+  if (includeWindows) {
+    clients.setProcessChannelMode(QProcess::SeparateChannels);
+    clients.start(QStringLiteral("hyprctl"),
+                  {QStringLiteral("clients"), QStringLiteral("-j")});
+    clients.closeWriteChannel();
+  }
+
   const QString grimGeometry = QStringLiteral("%1,%2 %3x%4")
                                    .arg(geometry.x())
                                    .arg(geometry.y())
                                    .arg(geometry.width())
                                    .arg(geometry.height());
-  const ProcessResult grim = runProcess(
+  // A PPM frame is three bytes per pixel plus a short header.
+  const qsizetype expectedBytes =
+      static_cast<qsizetype>(capture.monitor.pixelSize.width()) *
+          capture.monitor.pixelSize.height() * 3 +
+      64;
+  const ProcessResult grim = runStreamingProcess(
       QStringLiteral("grim"),
       {QStringLiteral("-t"), QStringLiteral("ppm"), QStringLiteral("-s"),
        QString::number(capture.monitor.scale, 'g', 8), QStringLiteral("-g"),
-       grimGeometry, sourcePath},
-      {}, 10000);
+       grimGeometry, QStringLiteral("-")},
+      expectedBytes, 10000);
 
-  if (!grim.finished || grim.exitCode != 0 ||
-      !capture.source.load(sourcePath)) {
-    error = QStringLiteral("Screen capture failed: %1")
-                .arg(QString::fromUtf8(grim.error).trimmed());
+  if (!grim.finished || grim.exitCode != 0) {
+    QString detail = QString::fromUtf8(grim.error).trimmed();
+    if (detail.isEmpty()) {
+      detail = grim.finished ? QStringLiteral("grim exited with code %1")
+                                   .arg(grim.exitCode)
+                             : QStringLiteral("grim did not finish in time");
+    }
+    error = QStringLiteral("Screen capture failed: %1").arg(detail);
+    return false;
+  }
+  if (!capture.source.loadFromData(grim.output, "PPM")) {
+    error = QStringLiteral(
+                "Screen capture failed: could not decode %1 bytes of PPM data "
+                "from grim")
+                .arg(grim.output.size());
     return false;
   }
 
@@ -719,18 +780,21 @@ bool captureMonitorPixels(const MonitorInfo &monitor, CaptureData &capture,
     return false;
   }
 
-  const ProcessResult clients =
-      runProcess(QStringLiteral("hyprctl"),
-                 {QStringLiteral("clients"), QStringLiteral("-j")});
-  if (clients.finished && clients.exitCode == 0)
-    capture.windows = parseWindows(clients.output, capture.monitor);
+  if (includeWindows) {
+    if (!clients.waitForFinished(10000))
+      clients.kill();
+    else if (clients.exitCode() == 0)
+      capture.windows =
+          parseWindows(clients.readAllStandardOutput(), capture.monitor);
+  }
   return true;
 }
 
-bool captureFocusedMonitor(CaptureData &capture, QString &error) {
+bool captureFocusedMonitor(CaptureData &capture, bool includeWindows,
+                           QString &error) {
   if (!probeFocusedMonitor(capture.monitor, error))
     return false;
-  return captureMonitorPixels(capture.monitor, capture, error);
+  return captureMonitorPixels(capture.monitor, capture, includeWindows, error);
 }
 
 QImage renderCapture(const CaptureData &capture, const QRectF &selection,

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -79,13 +79,17 @@ struct Annotation {
  */
 [[nodiscard]] bool probeFocusedMonitor(MonitorInfo &monitor, QString &error);
 /**
- * Captures the focused monitor's pixels and window list onto the given
- * monitor. Pure I/O and image work (no GUI objects): safe on any thread.
+ * Captures the focused monitor's pixels onto the given monitor, and its window
+ * list when `includeWindows` is set. Window discovery runs alongside the screen
+ * grab, so callers that never show the overlay should skip it. Pure I/O and
+ * image work (no GUI objects): safe on any thread.
  */
 [[nodiscard]] bool captureMonitorPixels(const MonitorInfo &monitor,
-                                        CaptureData &capture, QString &error);
+                                        CaptureData &capture,
+                                        bool includeWindows, QString &error);
 /** Convenience: probes the focused monitor, then captures its pixels. */
-[[nodiscard]] bool captureFocusedMonitor(CaptureData &capture, QString &error);
+[[nodiscard]] bool captureFocusedMonitor(CaptureData &capture,
+                                         bool includeWindows, QString &error);
 [[nodiscard]] bool captureWindowSurface(const WindowTarget &window,
                                         QImage &image, QString &error);
 /** Returns an upright image for captured Wayland buffer contents. */

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1047,17 +1047,18 @@ void CaptureEditor::pinSnapshot() {
       }));
 }
 
-void CaptureEditor::startCapture(CaptureMode mode) {
+void CaptureEditor::startCapture(CaptureMode mode, bool includeWindows) {
   if (captureStarted_ || !capture_.source.isNull())
     return;
   captureStarted_ = true;
   capturePending_ = true;
   pendingMode_ = mode;
   const MonitorInfo monitor = capture_.monitor;
-  captureWatcher_.setFuture(QtConcurrent::run([monitor] {
+  captureWatcher_.setFuture(QtConcurrent::run([monitor, includeWindows] {
     CaptureJob job;
     job.capture.monitor = monitor;
-    job.ok = captureMonitorPixels(monitor, job.capture, job.error);
+    job.ok =
+        captureMonitorPixels(monitor, job.capture, includeWindows, job.error);
     return job;
   }));
 }

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -32,9 +32,11 @@ public:
   /**
    * Kicks off the monitor pixel capture in the background. The overlay stays
    * interactive (showing a "Capturing…" state) until it lands, then emits
-   * captureReady. Safe to call once, before entering the event loop.
+   * captureReady. Safe to call once, before entering the event loop. Window
+   * discovery runs alongside the grab and is skipped when `includeWindows` is
+   * false, for callers that never show the overlay.
    */
-  void startCapture(CaptureMode mode);
+  void startCapture(CaptureMode mode, bool includeWindows);
   /**
    * Blocks until the in-flight snapshot persistence has drained, letting the
    * event loop run meanwhile. Returns whether the last write succeeded.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -331,8 +331,11 @@ int main(int argc, char **argv) {
     editor.setFocus(Qt::ActiveWindowFocusReason);
   }
 
-  if (filePath.isEmpty())
-    editor.startCapture(captureMode);
+  if (filePath.isEmpty()) {
+    // The quick fullscreen path never shows the overlay, so it never needs the
+    // window list that only window-mode hover consumes.
+    editor.startCapture(captureMode, !instantFullscreenOutput);
+  }
 
   return application.exec();
 }

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -747,10 +747,11 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
                         "else\n"
                         "  printf '[]\\n'\n"
                         "fi\n");
+  // grim streams the capture on stdout.
   const QByteArray grimScript =
       QByteArrayLiteral("#!/usr/bin/env bash\n"
                         "set -euo pipefail\n"
-                        "cp -- \"$OMASNAP_TEST_PPM\" \"${@: -1}\"\n");
+                        "cat -- \"$OMASNAP_TEST_PPM\"\n");
   if (!writeExecutable(fakeHyprctl, hyprctlScript) ||
       !writeExecutable(fakeGrim, grimScript)) {
     error = QStringLiteral("Could not create async capture commands");
@@ -787,7 +788,7 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
                      ready = ok;
                      captureError = message;
                    });
-  editor.startCapture(CaptureEditor::CaptureMode::Region);
+  editor.startCapture(CaptureEditor::CaptureMode::Region, true);
 
   QElapsedTimer timer;
   timer.start();

--- a/tests/transform-smoke.cpp
+++ b/tests/transform-smoke.cpp
@@ -60,12 +60,19 @@ bool runTransformSmoke(QString &error) {
       "\"x\":0,\"y\":0,\"activeWorkspace\":{\"id\":7}}]\\n' "
       "\"$OMASNAP_TEST_TRANSFORM\"\n"
       "else\n"
-      "  printf '[]\\n'\n"
+      "  printf '[{\"workspace\":{\"id\":7},\"at\":[0,0],\"size\":[100,100],"
+      "\"title\":\"Test window\",\"stableId\":\"w1\"}]\\n'\n"
       "fi\n");
-  const QByteArray grimScript =
-      QByteArrayLiteral("#!/usr/bin/env bash\n"
-                        "set -euo pipefail\n"
-                        "cp -- \"$OMASNAP_TEST_PPM\" \"${@: -1}\"\n");
+  // grim streams the capture on stdout; the garbage mode exits cleanly with
+  // undecodable bytes so the decode failure path can be checked.
+  const QByteArray grimScript = QByteArrayLiteral(
+      "#!/usr/bin/env bash\n"
+      "set -euo pipefail\n"
+      "if [[ -n \"${OMASNAP_TEST_GRIM_GARBAGE:-}\" ]]; then\n"
+      "  printf 'not-a-ppm'\n"
+      "  exit 0\n"
+      "fi\n"
+      "cat -- \"$OMASNAP_TEST_PPM\"\n");
   if (!writeExecutable(fakeHyprctl, hyprctlScript) ||
       !writeExecutable(fakeGrim, grimScript)) {
     error = QStringLiteral("Could not create transform-test commands");
@@ -83,23 +90,53 @@ bool runTransformSmoke(QString &error) {
   const QByteArray originalPath = qgetenv("PATH");
   qputenv("PATH", fakeCommands.path().toUtf8() + ':' + originalPath);
   qputenv("OMASNAP_TEST_PPM", ppmPath.toUtf8());
+  const auto restoreEnvironment = [&originalPath] {
+    qputenv("PATH", originalPath);
+    qunsetenv("OMASNAP_TEST_PPM");
+    qunsetenv("OMASNAP_TEST_TRANSFORM");
+    qunsetenv("OMASNAP_TEST_GRIM_GARBAGE");
+  };
   for (const int transform : {1, 3, 5, 7}) {
     qputenv("OMASNAP_TEST_TRANSFORM", QByteArray::number(transform));
     CaptureData rotatedCapture;
-    if (!captureFocusedMonitor(rotatedCapture, error) ||
+    if (!captureFocusedMonitor(rotatedCapture, true, error) ||
         rotatedCapture.monitor.geometry.size() != QSize(200, 300) ||
-        rotatedCapture.preview.size() != QSize(200, 300)) {
+        rotatedCapture.preview.size() != QSize(200, 300) ||
+        rotatedCapture.windows.size() != 1) {
       if (error.isEmpty())
         error = QStringLiteral("Quarter-turn monitor geometry was not swapped");
-      qputenv("PATH", originalPath);
-      qunsetenv("OMASNAP_TEST_PPM");
-      qunsetenv("OMASNAP_TEST_TRANSFORM");
+      restoreEnvironment();
       return false;
     }
   }
-  qputenv("PATH", originalPath);
-  qunsetenv("OMASNAP_TEST_PPM");
-  qunsetenv("OMASNAP_TEST_TRANSFORM");
+
+  // Callers that never show the overlay skip window discovery entirely.
+  qputenv("OMASNAP_TEST_TRANSFORM", QByteArrayLiteral("0"));
+  CaptureData withoutWindows;
+  if (!captureFocusedMonitor(withoutWindows, false, error) ||
+      withoutWindows.source.size() != QSize(300, 200) ||
+      withoutWindows.preview.size() != QSize(300, 200) ||
+      !withoutWindows.windows.isEmpty()) {
+    if (error.isEmpty())
+      error = QStringLiteral("Capture without window discovery was incorrect");
+    restoreEnvironment();
+    return false;
+  }
+
+  // A grim that exits cleanly but streams undecodable bytes must still explain
+  // itself instead of reporting an empty error.
+  qputenv("OMASNAP_TEST_GRIM_GARBAGE", QByteArrayLiteral("1"));
+  CaptureData undecodable;
+  QString decodeError;
+  const bool decoded = captureFocusedMonitor(undecodable, false, decodeError);
+  qunsetenv("OMASNAP_TEST_GRIM_GARBAGE");
+  if (decoded || decodeError.isEmpty()) {
+    error = QStringLiteral("Undecodable capture data did not report an error");
+    restoreEnvironment();
+    return false;
+  }
+
+  restoreEnvironment();
 
   const QImage upright = indexedImage({{1, 2}, {3, 4}, {5, 6}});
   const QVector<QPair<std::uint32_t, QImage>> transformedImages{


### PR DESCRIPTION
Three pieces of waste on the keypress-to-overlay path:

- grim wrote a full-monitor PPM to a temp file that was immediately re-read and decoded — 42.2 MiB written and read back per capture at 5K. grim now writes to stdout and the bytes decode in memory. The pipe is drained as it fills into one pre-sized buffer (`runStreamingProcess`): letting QProcess buffer the whole frame and calling `readAllStandardOutput` costs an extra full-frame copy and measured *slower* than the temp file (61.1 ms vs 50.9 ms on the grim stage).
- `hyprctl clients` ran serially after grim but is independent of it; it now starts before grim and is collected after, hiding its ~3.4 ms round trip. Callers that never show the overlay (fullscreen quick output) skip window discovery entirely via a new `includeWindows` argument.
- A grim run that succeeds but returns undecodable data reported an empty error (interpolated grim's empty stderr); it now names the byte count, and a silent grim failure names the exit code or timeout.

Measured rebased on 1.13.0 (5120x2880 display, scale 2, Release, live Hyprland, n=15): `captureFocusedMonitor` min 73.4 ms → 64.6 ms; in-memory decode 13.8 → 10.3 ms median; 42.2 MiB per capture no longer round-tripped.

Transform smoke now drives the streaming grim, asserts window discovery is honoured and skipped as requested, and checks that undecodable data produces a non-empty error.
