### PR TITLE
fix: cancel the running overlay on second invocation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ pinned always-on-top layer surface.
 | Path | Purpose |
 |---|---|
 | `src/main.cpp` | CLI parsing, single-instance lock, mode dispatch (capture / edit file / pin) |
+| `src/instance-lock.cpp/.hpp` | Single-instance handover: cancel a running overlay, or stop it and take over for `--file` |
 | `src/capture.cpp/.hpp` | Capture selection overlay, rendering, output, and private runtime snapshots |
 | `src/editor.cpp/.hpp` | Annotation editor: tools, vector layers, undo/redo, rendering, export |
 | `src/pin.cpp/.hpp` | Pinned-capture layer-shell surfaces (bottom-right, all workspaces) |
@@ -36,7 +37,7 @@ pinned always-on-top layer surface.
 | `src/cli-path.cpp/.hpp` | Command-line image target resolution |
 | `src/eyedropper.cpp/.hpp` | Display-to-source color sampling |
 | `src/pin-file.cpp/.hpp`, `src/pin-layout.cpp/.hpp` | Pin file lifecycle and layout helpers |
-| `tests/*-smoke.cpp/.hpp` | Headless Qt Test coverage, including offscreen region-click and async-capture checks |
+| `tests/*-smoke.cpp/.hpp` | Headless Qt Test coverage, including offscreen region-click, async-capture, and single-instance handover checks |
 | `install-omarchy` | Omarchy installer (deps via `omarchy-pkg-add`, installs to `~/.local`) |
 | `CMakeLists.txt` | Build definition; **the version lives here** (`project(omasnap VERSION ...)`) |
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ qt_add_executable(omasnap
   src/cli-path.hpp
   src/icons.cpp
   src/icons.hpp
+  src/instance-lock.cpp
+  src/instance-lock.hpp
   src/pin.cpp
   src/pin.hpp
   src/pin-file.cpp
@@ -79,6 +81,10 @@ qt_add_executable(omasnap-smoke
   tests/editor-smoke.cpp
   src/icons.cpp
   src/icons.hpp
+  src/instance-lock.cpp
+  src/instance-lock.hpp
+  tests/instance-lock-smoke.cpp
+  tests/instance-lock-smoke.hpp
   tests/transform-smoke.cpp
   tests/transform-smoke.hpp
   src/cli-path.cpp

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ QMLLINT ?= qmllint
 LINT_SOURCES := \
 	src/main.cpp src/capture.cpp src/editor.cpp src/surface-capture.cpp \
 	src/cli-path.cpp src/icons.cpp src/pin.cpp src/pin-file.cpp \
-	src/pin-layout.cpp src/eyedropper.cpp \
+	src/pin-layout.cpp src/eyedropper.cpp src/instance-lock.cpp \
 	tests/editor-smoke.cpp tests/transform-smoke.cpp \
 	tests/surface-capture-smoke.cpp tests/pin-layout-smoke.cpp \
-	tests/pin-lifecycle-smoke.cpp
+	tests/pin-lifecycle-smoke.cpp tests/instance-lock-smoke.cpp
 LINT_CHECKS ?= -*,clang-analyzer-*,bugprone-*,performance-*,misc-*
 
 .PHONY: all configure build clean install check smoke lint qt-lint

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ hl.layer_rule({
 })
 ```
 
+Each of these keys toggles: the first press opens the overlay, the next press dismisses it.
+
 Apply and verify:
 
 ```bash
@@ -163,6 +165,33 @@ Quick output skips the annotation editor. Add `--copy` to copy only, `--save` to
 only, or both flags to copy and save. Region and window captures output after selection;
 fullscreen captures output immediately. Quick output cannot be combined with `--file` or
 `--pin`.
+
+### One instance, toggled by the same hotkey
+
+Only one capture overlay runs at a time, guarded by a lock file in the runtime snapshot
+directory. Starting omasnap while an overlay is open sends the running instance `SIGTERM`,
+which it handles with a clean Qt shutdown; the new process then exits without capturing.
+Pressing `PRINT` therefore opens the overlay and pressing it again dismisses it.
+
+Every capture invocation dismisses this way, quick output included: `--copy`/`--save`
+while an overlay is open closes the overlay and outputs nothing, rather than screenshotting
+the overlay that is still on screen.
+
+Editing an existing image is never cancelled this way: `--file` (or an image path) stops
+the running instance, waits up to two seconds for the lock, and opens the editor on that
+image. That is how a pin's Edit button and a notification click always land in the editor.
+
+A lock left behind by a crashed instance is removed and reclaimed. A lock file that cannot
+be read or written at all is reported on stderr instead of being mistaken for a running
+instance.
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success, including dismissing a running overlay |
+| `1` | Capture, image, or single-instance lock failure |
+| `2` | Usage error |
 
 ### Edit an existing image
 

--- a/src/instance-lock.cpp
+++ b/src/instance-lock.cpp
@@ -1,0 +1,165 @@
+/** @fileoverview Hands the single-instance lock over to a starting process. */
+#include "instance-lock.hpp"
+
+#include <QDeadlineTimer>
+#include <QLockFile>
+#include <QThread>
+
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+
+namespace {
+/** How long a starting editor waits for the running instance to let go. */
+constexpr int kHandoverTimeoutMs = 2000;
+/** Poll interval while waiting for the lock file to disappear. */
+constexpr int kHandoverPollMs = 20;
+
+InstanceLockProbe probeLock(QLockFile &lock) {
+  if (lock.tryLock(0))
+    return InstanceLockProbe::Acquired;
+  switch (lock.error()) {
+  case QLockFile::LockFailedError:
+    return InstanceLockProbe::HeldByOther;
+  case QLockFile::PermissionError:
+    return InstanceLockProbe::PermissionError;
+  case QLockFile::NoError:
+  case QLockFile::UnknownError:
+    break;
+  }
+  return InstanceLockProbe::UnknownError;
+}
+
+/** Reads the lock holder's pid and whether that process still exists. */
+InstanceHolder readHolder(QLockFile &lock, qint64 &pid) {
+  qint64 lockPid = 0;
+  QString hostname;
+  QString application;
+  if (!lock.getLockInfo(&lockPid, &hostname, &application) || lockPid <= 0)
+    return InstanceHolder::Unknown;
+  pid = lockPid;
+  if (::kill(static_cast<pid_t>(lockPid), 0) != 0 && errno == ESRCH)
+    return InstanceHolder::Dead;
+  return InstanceHolder::Alive;
+}
+
+enum class SignalOutcome { Sent, AlreadyGone, Failed };
+
+SignalOutcome terminateHolder(qint64 pid, QString &error) {
+  if (::kill(static_cast<pid_t>(pid), SIGTERM) == 0)
+    return SignalOutcome::Sent;
+  if (errno == ESRCH)
+    return SignalOutcome::AlreadyGone;
+  error = QStringLiteral("Could not stop the running omasnap instance "
+                         "(pid %1): %2")
+              .arg(pid)
+              .arg(QString::fromLocal8Bit(std::strerror(errno)));
+  return SignalOutcome::Failed;
+}
+
+/** Claims a lock file whose owner is gone. */
+InstanceLockResult claimAbandonedLock(QLockFile &lock) {
+  lock.removeStaleLockFile();
+  if (lock.tryLock(0))
+    return {true, 0, {}, 0};
+  return {false, kInstanceLockErrorExitCode,
+          QStringLiteral("Could not claim the abandoned single-instance lock "
+                         "file %1")
+              .arg(lock.fileName()),
+          0};
+}
+
+/** Waits for the terminated instance to release the lock, then takes it. */
+bool waitForHandover(QLockFile &lock) {
+  QDeadlineTimer deadline(kHandoverTimeoutMs);
+  for (;;) {
+    if (lock.tryLock(0))
+      return true;
+    qint64 pid = 0;
+    if (lock.error() == QLockFile::LockFailedError &&
+        readHolder(lock, pid) != InstanceHolder::Alive) {
+      // The old process died without unlinking its lock file.
+      lock.removeStaleLockFile();
+      if (lock.tryLock(0))
+        return true;
+    }
+    if (deadline.hasExpired())
+      return false;
+    QThread::msleep(kHandoverPollMs);
+  }
+}
+} // namespace
+
+InstanceAction decideInstanceAction(InstanceLockProbe probe,
+                                    InstanceHolder holder, InstanceMode mode) {
+  switch (probe) {
+  case InstanceLockProbe::Acquired:
+    return InstanceAction::Proceed;
+  case InstanceLockProbe::PermissionError:
+  case InstanceLockProbe::UnknownError:
+    return InstanceAction::Fail;
+  case InstanceLockProbe::HeldByOther:
+    break;
+  }
+  if (holder != InstanceHolder::Alive)
+    return InstanceAction::ClearStaleLock;
+  return mode == InstanceMode::EditFile ? InstanceAction::ReplaceRunning
+                                        : InstanceAction::CancelRunning;
+}
+
+InstanceLockResult acquireInstanceLock(QLockFile &lock, InstanceMode mode) {
+  // Never expire a lock by age: a long annotation session is not stale.
+  lock.setStaleLockTime(0);
+  const InstanceLockProbe probe = probeLock(lock);
+  qint64 holderPid = 0;
+  const InstanceHolder holder = probe == InstanceLockProbe::HeldByOther
+                                    ? readHolder(lock, holderPid)
+                                    : InstanceHolder::Unknown;
+
+  QString error;
+  switch (decideInstanceAction(probe, holder, mode)) {
+  case InstanceAction::Proceed:
+    return {true, 0, {}, 0};
+  case InstanceAction::ClearStaleLock:
+    return claimAbandonedLock(lock);
+  case InstanceAction::CancelRunning:
+    switch (terminateHolder(holderPid, error)) {
+    case SignalOutcome::Sent:
+      return {false, kInstanceCancelledExitCode, {}, holderPid};
+    case SignalOutcome::AlreadyGone:
+      return claimAbandonedLock(lock); // Nothing to cancel; act as the first.
+    case SignalOutcome::Failed:
+      return {false, kInstanceLockErrorExitCode, error, 0};
+    }
+    break;
+  case InstanceAction::ReplaceRunning:
+    switch (terminateHolder(holderPid, error)) {
+    case SignalOutcome::Sent:
+      break;
+    case SignalOutcome::AlreadyGone:
+      return claimAbandonedLock(lock);
+    case SignalOutcome::Failed:
+      return {false, kInstanceLockErrorExitCode, error, 0};
+    }
+    if (waitForHandover(lock))
+      return {true, 0, {}, holderPid};
+    return {false, kInstanceLockErrorExitCode,
+            QStringLiteral("Timed out waiting for omasnap (pid %1) to release "
+                           "the single-instance lock")
+                .arg(holderPid),
+            holderPid};
+  case InstanceAction::Fail:
+    return {false, kInstanceLockErrorExitCode,
+            (probe == InstanceLockProbe::PermissionError
+                 ? QStringLiteral("No permission to use the single-instance "
+                                  "lock file %1")
+                 : QStringLiteral("Could not use the single-instance lock "
+                                  "file %1"))
+                .arg(lock.fileName()),
+            0};
+  }
+  return {false, kInstanceLockErrorExitCode,
+          QStringLiteral("Could not use the single-instance lock file %1")
+              .arg(lock.fileName()),
+          0};
+}

--- a/src/instance-lock.hpp
+++ b/src/instance-lock.hpp
@@ -1,0 +1,60 @@
+/** @fileoverview Declares single-instance lock handover decisions. */
+#pragma once
+
+#include <QString>
+
+class QLockFile;
+
+/** Exit code for a capture invocation that cancelled a running overlay. */
+inline constexpr int kInstanceCancelledExitCode = 0;
+/** Exit code for a lock that could neither be taken nor handed over. */
+inline constexpr int kInstanceLockErrorExitCode = 1;
+
+/** What the starting process wants to do, which decides how it treats a
+ * running instance. */
+enum class InstanceMode {
+  Capture,  // Screen-capture overlay: a second launch dismisses the first.
+  EditFile, // Editor for an existing image: it must always appear.
+};
+
+/** Result of a single non-blocking attempt to take the lock. */
+enum class InstanceLockProbe {
+  Acquired,        // The lock is ours; no other instance is running.
+  HeldByOther,     // Another process holds the lock.
+  PermissionError, // The lock path is not writable.
+  UnknownError,    // Anything else; never treat it as "already running".
+};
+
+/** Liveness of the process recorded in the lock file. */
+enum class InstanceHolder {
+  Alive,
+  Dead,
+  Unknown, // The lock info could not be read.
+};
+
+/** What the starting process should do about the lock. */
+enum class InstanceAction {
+  Proceed,        // Start normally.
+  ClearStaleLock, // Remove the abandoned lock file, then start normally.
+  CancelRunning,  // Terminate the running instance and exit without starting.
+  ReplaceRunning, // Terminate the running instance, wait, then start.
+  Fail,           // Report the lock error and exit non-zero.
+};
+
+/** Maps the observed lock state and the requested mode onto an action. */
+[[nodiscard]] InstanceAction decideInstanceAction(InstanceLockProbe probe,
+                                                  InstanceHolder holder,
+                                                  InstanceMode mode);
+
+/** Outcome of acting on the single-instance lock. */
+struct InstanceLockResult {
+  bool proceed = false; // Start the overlay or editor.
+  int exitCode = 0;     // Used when proceed is false.
+  QString error;        // Non-empty only for failures.
+  qint64 signalledPid = 0; // Instance that was asked to quit, if any.
+};
+
+/** Takes the lock, terminating and waiting for a running instance as the mode
+ * requires. */
+[[nodiscard]] InstanceLockResult acquireInstanceLock(QLockFile &lock,
+                                                     InstanceMode mode);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "capture.hpp"
 #include "cli-path.hpp"
 #include "editor.hpp"
+#include "instance-lock.hpp"
 #include "pin.hpp"
 
 #include <LayerShellQt/Window>
@@ -97,9 +98,20 @@ int main(int argc, char **argv) {
   PosixSignalNotifier signalNotifier(&application);
 
   QCommandLineParser parser;
-  parser.setApplicationDescription(
-      QStringLiteral("Native Wayland screenshot and annotation overlay for "
-                     "Hyprland and Omarchy."));
+  parser.setApplicationDescription(QStringLiteral(
+      "Native Wayland screenshot and annotation overlay for Hyprland and "
+      "Omarchy.\n"
+      "\n"
+      "Only one capture overlay runs at a time. Starting omasnap again while "
+      "an\noverlay is open dismisses it: the running instance is asked to "
+      "quit and the\nnew process exits without capturing, so the same hotkey "
+      "opens and closes the\noverlay. Quick output (--copy, --save) dismisses "
+      "it the same way instead of\nscreenshotting the overlay. With --file (or "
+      "an image path) the running\ninstance is stopped and the editor opens on "
+      "that image instead.\n"
+      "\n"
+      "Exit codes: 0 success, including dismissing a running overlay; 1 "
+      "capture,\nimage, or single-instance lock failure; 2 usage error."));
   parser.addHelpOption();
   parser.addVersionOption();
   const QCommandLineOption fullscreenOption(
@@ -220,9 +232,21 @@ int main(int argc, char **argv) {
   }
   QLockFile instanceLock(
       QDir(runtime).filePath(QStringLiteral("omasnap.instance")));
-  instanceLock.setStaleLockTime(0);
-  if (!instanceLock.tryLock(0))
-    return 0;
+  // Every capture, quick output included, dismisses a running overlay instead
+  // of starting a second one: grim would otherwise photograph that overlay.
+  // filePath already covers --file and a positional image path or file URL.
+  const InstanceLockResult lockResult = acquireInstanceLock(
+      instanceLock,
+      filePath.isEmpty() ? InstanceMode::Capture : InstanceMode::EditFile);
+  if (lockResult.signalledPid != 0)
+    qInfo().noquote() << QStringLiteral("Asked the running omasnap (pid %1) to "
+                                        "quit")
+                             .arg(lockResult.signalledPid);
+  if (!lockResult.proceed) {
+    if (!lockResult.error.isEmpty())
+      qCritical().noquote() << lockResult.error;
+    return lockResult.exitCode;
+  }
 
   CaptureData capture;
   QString error;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -3,6 +3,7 @@
 #include "capture.hpp"
 #include "cli-path.hpp"
 #include "editor.hpp"
+#include "instance-lock-smoke.hpp"
 #include "pin-layout-smoke.hpp"
 #include "pin-lifecycle-smoke.hpp"
 #include "transform-smoke.hpp"
@@ -833,6 +834,12 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
 int main(int argc, char **argv) {
+  // Re-executed by the instance-lock checks as the process holding the lock.
+  const QString heldLockPath =
+      qEnvironmentVariable(kInstanceLockHolderVariable);
+  if (!heldLockPath.isEmpty())
+    return runInstanceLockHolder(heldLockPath);
+
   QApplication application(argc, argv);
   if (!loadCaptureFonts())
     return 17;
@@ -1775,6 +1782,11 @@ int main(int argc, char **argv) {
   if (!runTransformSmoke(transformError)) {
     qWarning().noquote() << transformError;
     return 67;
+  }
+  QString instanceError;
+  if (!runInstanceLockSmoke(instanceError)) {
+    qWarning().noquote() << instanceError;
+    return 85;
   }
   return 0;
 }

--- a/tests/instance-lock-smoke.cpp
+++ b/tests/instance-lock-smoke.cpp
@@ -1,0 +1,249 @@
+/** @fileoverview Tests single-instance handover decisions and live SIGTERM. */
+#include "instance-lock-smoke.hpp"
+
+#include "instance-lock.hpp"
+
+#include <QCoreApplication>
+#include <QDeadlineTimer>
+#include <QDir>
+#include <QFile>
+#include <QLockFile>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QTemporaryDir>
+#include <QThread>
+
+#include <csignal>
+#include <unistd.h>
+
+namespace {
+volatile sig_atomic_t holderTerminated = 0;
+
+struct DecisionCase {
+  const char *name;
+  InstanceLockProbe probe;
+  InstanceHolder holder;
+  InstanceMode mode;
+  InstanceAction expected;
+};
+
+/** The full decision table; every row doubles as a named check. */
+constexpr DecisionCase kDecisionCases[] = {
+    {"free lock proceeds for capture", InstanceLockProbe::Acquired,
+     InstanceHolder::Unknown, InstanceMode::Capture, InstanceAction::Proceed},
+    {"free lock proceeds for file edit", InstanceLockProbe::Acquired,
+     InstanceHolder::Unknown, InstanceMode::EditFile, InstanceAction::Proceed},
+    {"live holder cancels a capture invocation", InstanceLockProbe::HeldByOther,
+     InstanceHolder::Alive, InstanceMode::Capture,
+     InstanceAction::CancelRunning},
+    {"live holder is replaced for a file edit", InstanceLockProbe::HeldByOther,
+     InstanceHolder::Alive, InstanceMode::EditFile,
+     InstanceAction::ReplaceRunning},
+    {"dead holder clears the stale lock for capture",
+     InstanceLockProbe::HeldByOther, InstanceHolder::Dead, InstanceMode::Capture,
+     InstanceAction::ClearStaleLock},
+    {"dead holder clears the stale lock for a file edit",
+     InstanceLockProbe::HeldByOther, InstanceHolder::Dead,
+     InstanceMode::EditFile, InstanceAction::ClearStaleLock},
+    {"unreadable lock info clears the stale lock",
+     InstanceLockProbe::HeldByOther, InstanceHolder::Unknown,
+     InstanceMode::Capture, InstanceAction::ClearStaleLock},
+    {"permission error fails instead of pretending to be a second instance",
+     InstanceLockProbe::PermissionError, InstanceHolder::Unknown,
+     InstanceMode::Capture, InstanceAction::Fail},
+    {"permission error fails for a file edit too",
+     InstanceLockProbe::PermissionError, InstanceHolder::Unknown,
+     InstanceMode::EditFile, InstanceAction::Fail},
+    {"unknown lock error fails", InstanceLockProbe::UnknownError,
+     InstanceHolder::Unknown, InstanceMode::Capture, InstanceAction::Fail},
+};
+
+bool runDecisionTableChecks(QString &error) {
+  for (const DecisionCase &check : kDecisionCases) {
+    if (decideInstanceAction(check.probe, check.holder, check.mode) !=
+        check.expected) {
+      error = QStringLiteral("Instance decision failed: %1")
+                  .arg(QString::fromLatin1(check.name));
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Starts this executable in lock-holder mode and waits until it owns it. */
+bool startLockHolder(QProcess &holder, const QString &lockPath, QString &error) {
+  QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+  environment.insert(QString::fromLatin1(kInstanceLockHolderVariable),
+                     lockPath);
+  holder.setProcessEnvironment(environment);
+  holder.setProgram(QCoreApplication::applicationFilePath());
+  holder.start();
+  if (!holder.waitForStarted(5000)) {
+    error = QStringLiteral("Could not start the lock-holder process");
+    return false;
+  }
+  QDeadlineTimer deadline(5000);
+  for (;;) {
+    qint64 pid = 0;
+    QString hostname;
+    QString application;
+    QLockFile probe(lockPath);
+    if (QFile::exists(lockPath) &&
+        probe.getLockInfo(&pid, &hostname, &application) &&
+        pid == holder.processId())
+      return true;
+    if (deadline.hasExpired()) {
+      error = QStringLiteral("Lock-holder process never took the lock");
+      return false;
+    }
+    QThread::msleep(10);
+  }
+}
+
+/** A file edit must terminate the overlay, wait for it, and still open. */
+bool runFileEditHandoverCheck(const QString &lockPath, QString &error) {
+  QProcess holder;
+  if (!startLockHolder(holder, lockPath, error))
+    return false;
+  const qint64 holderPid = holder.processId();
+
+  QLockFile lock(lockPath);
+  const InstanceLockResult result =
+      acquireInstanceLock(lock, InstanceMode::EditFile);
+  if (!result.proceed || !result.error.isEmpty() || !lock.isLocked() ||
+      result.signalledPid != holderPid) {
+    error = QStringLiteral("File edit did not take over the lock: %1")
+                .arg(result.error.isEmpty()
+                         ? QStringLiteral("no editor would have opened")
+                         : result.error);
+    holder.kill();
+    holder.waitForFinished(2000);
+    return false;
+  }
+  if (!holder.waitForFinished(2000) || holder.exitCode() != 0) {
+    error = QStringLiteral("Lock holder did not exit cleanly on SIGTERM");
+    return false;
+  }
+  lock.unlock();
+  return true;
+}
+
+/** A second capture invocation cancels the overlay without starting one. */
+bool runCaptureCancelCheck(const QString &lockPath, QString &error) {
+  QProcess holder;
+  if (!startLockHolder(holder, lockPath, error))
+    return false;
+  const qint64 holderPid = holder.processId();
+
+  QLockFile lock(lockPath);
+  const InstanceLockResult result =
+      acquireInstanceLock(lock, InstanceMode::Capture);
+  if (result.proceed || result.exitCode != kInstanceCancelledExitCode ||
+      !result.error.isEmpty() || result.signalledPid != holderPid) {
+    error = QStringLiteral("Second capture invocation did not cancel the "
+                           "running overlay");
+    holder.kill();
+    holder.waitForFinished(2000);
+    return false;
+  }
+  if (!holder.waitForFinished(2000) || holder.exitCode() != 0) {
+    error = QStringLiteral("Cancelled overlay did not shut down on SIGTERM");
+    return false;
+  }
+  QLockFile released(lockPath);
+  released.setStaleLockTime(0);
+  if (!released.tryLock(0)) {
+    error = QStringLiteral("SIGTERM did not release the single-instance lock");
+    return false;
+  }
+  released.unlock();
+  return true;
+}
+
+/** A killed instance leaves a lock file that the next launch must reclaim. */
+bool runStaleLockCheck(const QString &lockPath, QString &error) {
+  QProcess holder;
+  if (!startLockHolder(holder, lockPath, error))
+    return false;
+  holder.kill();
+  if (!holder.waitForFinished(2000)) {
+    error = QStringLiteral("Could not kill the lock-holder process");
+    return false;
+  }
+  if (!QFile::exists(lockPath)) {
+    error = QStringLiteral("Killed lock holder unexpectedly cleaned up");
+    return false;
+  }
+  QLockFile lock(lockPath);
+  const InstanceLockResult result =
+      acquireInstanceLock(lock, InstanceMode::Capture);
+  if (!result.proceed || !lock.isLocked() || result.signalledPid != 0) {
+    error = QStringLiteral("Stale lock was not reclaimed: %1").arg(result.error);
+    return false;
+  }
+  lock.unlock();
+  return true;
+}
+
+/** An unusable lock path must fail loudly, not look like a second instance. */
+bool runUnwritableLockCheck(const QString &root, QString &error) {
+  if (::geteuid() == 0)
+    return true; // Root ignores the permission bits this check relies on.
+  const QString locked = QDir(root).filePath(QStringLiteral("no-write"));
+  if (!QDir().mkdir(locked) ||
+      !QFile::setPermissions(locked, QFileDevice::ReadOwner |
+                                         QFileDevice::ExeOwner)) {
+    error = QStringLiteral("Could not create the read-only lock directory");
+    return false;
+  }
+  QLockFile lock(QDir(locked).filePath(QStringLiteral("omasnap.instance")));
+  const InstanceLockResult result =
+      acquireInstanceLock(lock, InstanceMode::Capture);
+  const bool ok = !result.proceed &&
+                  result.exitCode == kInstanceLockErrorExitCode &&
+                  !result.error.isEmpty();
+  static_cast<void>(QFile::setPermissions(locked, QFileDevice::ReadOwner |
+                                                      QFileDevice::WriteOwner |
+                                                      QFileDevice::ExeOwner));
+  if (!ok) {
+    error = QStringLiteral("Unwritable lock path did not fail loudly");
+    return false;
+  }
+  return true;
+}
+} // namespace
+
+bool runInstanceLockSmoke(QString &error) {
+  if (!runDecisionTableChecks(error))
+    return false;
+  QTemporaryDir lockRoot;
+  if (!lockRoot.isValid()) {
+    error = QStringLiteral("Could not create the instance-lock test directory");
+    return false;
+  }
+  const QString lockPath =
+      QDir(lockRoot.path()).filePath(QStringLiteral("omasnap.instance"));
+  return runFileEditHandoverCheck(lockPath, error) &&
+         runCaptureCancelCheck(lockPath, error) &&
+         runStaleLockCheck(lockPath, error) &&
+         runUnwritableLockCheck(lockRoot.path(), error);
+}
+
+int runInstanceLockHolder(const QString &lockPath) {
+  struct sigaction action{};
+  action.sa_handler = [](int) { holderTerminated = 1; };
+  sigemptyset(&action.sa_mask);
+  if (::sigaction(SIGTERM, &action, nullptr) != 0)
+    return 95;
+  QLockFile lock(lockPath);
+  lock.setStaleLockTime(0);
+  if (!lock.tryLock(0))
+    return 96;
+  QDeadlineTimer guard(30000);
+  while (holderTerminated == 0 && !guard.hasExpired())
+    QThread::msleep(5);
+  if (holderTerminated == 0)
+    return 97;
+  lock.unlock(); // Mirrors the overlay's clean Qt teardown.
+  return 0;
+}

--- a/tests/instance-lock-smoke.hpp
+++ b/tests/instance-lock-smoke.hpp
@@ -1,0 +1,14 @@
+/** @fileoverview Declares single-instance lock smoke checks. */
+#pragma once
+
+#include <QString>
+
+/** Environment variable that turns this executable into a lock holder. */
+inline constexpr char kInstanceLockHolderVariable[] =
+    "OMASNAP_SMOKE_HOLD_INSTANCE_LOCK";
+
+/** Checks the handover decision table and live SIGTERM handovers. */
+[[nodiscard]] bool runInstanceLockSmoke(QString &error);
+
+/** Holds the given lock file until SIGTERM, then releases it and exits. */
+[[nodiscard]] int runInstanceLockHolder(const QString &lockPath);


### PR DESCRIPTION
A second omasnap while one was running silently exited 0: pressing the screenshot key twice did nothing, and anything spawning `omasnap --file` against a live instance (a notification click) failed invisibly.

Second invocation now signals the holder and the behavior depends on mode:

| Lock state | Mode | Action | Exit |
|---|---|---|---|
| held by live instance | capture (incl. `--copy`/`--save`) | SIGTERM the holder, don't capture — the hotkey becomes a toggle | 0 |
| held by live instance | `--file` / positional path / URL | SIGTERM, wait for the lock (≤2 s), open the editor | — |
| held by dead process | any | reclaim the stale lock, start normally | — |
| permission/unknown lock error, signal failure, handover timeout | any | descriptive stderr | 1 |

Quick output also cancels rather than capturing: the overlay is a mapped layer surface, so grim would photograph omasnap itself. Cancels are announced (`Asked the running omasnap (pid N) to quit`), and `--help` documents the exit codes.

The decision logic lives in `instance-lock.cpp` as a pure function. Smoke: a 10-row decision table plus process-level checks — SIGTERM handover for `--file`, capture cancel, SIGKILLed holder's lock reclaimed, unwritable lock dir fails with exit 1.

<details>
<summary>Manual test script (drives the "second keypress" scenarios; the overlay holds exclusive keyboard focus, so a script started beforehand does the invoking)</summary>

```bash
#!/usr/bin/env bash
# Emulates "press the hotkey again while the overlay is up" for pr/4 testing.
# A terminal can't do this by hand (the overlay holds exclusive keyboard
# focus), but a script started beforehand keeps running underneath it.
# Run from a terminal and watch the screen; everything closes itself.

set -u
here="$(cd "$(dirname "$0")" && pwd)"
run="$here/run-local"
lock="/run/user/$(id -u)/omasnap/omasnap.instance"
pass=0 fail=0

say() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
ok()  { echo "PASS: $*"; pass=$((pass + 1)); }
bad() { echo "FAIL: $*"; fail=$((fail + 1)); }
wait_lock() { for _ in $(seq 50); do [ -e "$lock" ] && return 0; sleep 0.1; done; return 1; }
wait_gone() { for _ in $(seq 50); do kill -0 "$1" 2>/dev/null || return 0; sleep 0.1; done; return 1; }

say "1/5 Toggle: a second invocation dismisses the running overlay"
"$run" & first=$!
wait_lock || bad "overlay never took the instance lock"
sleep 0.6
out="$("$run" 2>&1)" rc=$?
echo "   second invocation: '$out' (exit $rc)"
if [ "$rc" -eq 0 ] && grep -q "quit" <<<"$out"; then
  ok "exit 0 with cancel message"
else
  bad "expected exit 0 + 'Asked the running omasnap (pid N) to quit'"
fi
if wait_gone "$first"; then ok "overlay closed"; else bad "overlay still running"; kill "$first" 2>/dev/null; fi

say "2/5 File handover: --file replaces the overlay with an editor (auto-closes after 4s)"
img="$(mktemp --suffix=.png -t omasnap-pr4-XXXX)"
magick -size 640x400 gradient:navy-orange "$img"
"$run" & first=$!
wait_lock; sleep 0.6
"$run" --file "$img" & second=$!
if wait_gone "$first"; then ok "overlay handed the lock over"; else bad "overlay did not exit"; fi
sleep 4
if kill -0 "$second" 2>/dev/null; then
  ok "editor opened and stayed up (closing it now)"
  kill "$second"; wait_gone "$second" || kill -9 "$second"
else
  bad "editor did not stay open"
fi
rm -f "$img"

say "3/5 Quick output while overlay is open: cancels instead of photographing the overlay"
"$run" & first=$!
wait_lock; sleep 0.6
out="$("$run" --capture-fullscreen --copy 2>&1)" rc=$?
echo "   quick invocation: '$out' (exit $rc)"
if [ "$rc" -eq 0 ] && grep -q "quit" <<<"$out"; then ok "cancelled with exit 0, no capture"; else bad "unexpected quick-output behavior"; fi
if wait_gone "$first"; then ok "overlay dismissed"; else bad "overlay still running"; kill "$first" 2>/dev/null; fi

say "4/5 Stale lock: a SIGKILLed instance does not block the next start"
"$run" & first=$!
wait_lock; sleep 0.6
kill -9 "$first"; sleep 0.3
"$run" & second=$!
sleep 1.2
if kill -0 "$second" 2>/dev/null; then
  ok "new overlay started despite the stale lock (toggling it closed)"
  "$run" >/dev/null 2>&1
  wait_gone "$second" || kill "$second" 2>/dev/null
else
  bad "start after SIGKILL failed"
fi

say "5/5 --help documents exit codes"
if "$run" --help 2>/dev/null | grep -qi "exit code"; then ok "--help mentions exit codes"; else bad "--help missing exit-code paragraph"; fi

printf '\n\033[1m%d passed, %d failed\033[0m\n' "$pass" "$fail"
exit "$((fail > 0))"
```

Expects a `run-local` wrapper that launches the built binary; replace `$run` with your omasnap path. 5/5 pass on a live Hyprland session.
</details>
