### PR TITLE
perf: replace the unused preview image with its size

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -525,11 +525,11 @@ void applyRedactions(QImage &image, const QVector<Annotation> &annotations,
 
 QRect pixelSelection(const CaptureData &capture, const QRectF &selection) {
   const QRectF bounded = selection.normalized().intersected(
-      QRectF(QPointF(), capture.preview.size()));
+      QRectF(QPointF(), capture.previewSize));
   const qreal scaleX =
-      capture.source.width() / static_cast<qreal>(capture.preview.width());
-  const qreal scaleY =
-      capture.source.height() / static_cast<qreal>(capture.preview.height());
+      capture.source.width() / static_cast<qreal>(capture.previewSize.width());
+  const qreal scaleY = capture.source.height() /
+                       static_cast<qreal>(capture.previewSize.height());
   const int left =
       std::clamp(static_cast<int>(std::floor(bounded.left() * scaleX)), 0,
                  capture.source.width());
@@ -782,12 +782,7 @@ bool captureMonitorPixels(const MonitorInfo &monitor, CaptureData &capture,
     return false;
   }
 
-  capture.preview = capture.source.scaled(
-      geometry.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-  if (capture.preview.isNull()) {
-    error = QStringLiteral("Could not prepare screenshot preview");
-    return false;
-  }
+  capture.previewSize = geometry.size();
 
   if (includeWindows) {
     if (!clients.waitForFinished(10000))
@@ -816,9 +811,9 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   QImage cropped = capture.source.copy(pixels).convertToFormat(
       QImage::Format_ARGB32_Premultiplied);
   const qreal sourceScaleX =
-      capture.source.width() / static_cast<qreal>(capture.preview.width());
-  const qreal sourceScaleY =
-      capture.source.height() / static_cast<qreal>(capture.preview.height());
+      capture.source.width() / static_cast<qreal>(capture.previewSize.width());
+  const qreal sourceScaleY = capture.source.height() /
+                             static_cast<qreal>(capture.previewSize.height());
   const bool highDpi = capture.monitor.scale > 1.0;
   const qreal scaleX = highDpi ? capture.monitor.scale : sourceScaleX;
   const qreal scaleY = highDpi ? capture.monitor.scale : sourceScaleY;

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -31,7 +31,8 @@ struct WindowTarget {
 struct CaptureData {
   MonitorInfo monitor;
   QImage source;
-  QImage preview;
+  /** Logical size the source is presented at; source pixels stay native. */
+  QSize previewSize;
   QVector<WindowTarget> windows;
 };
 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -318,7 +318,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
             redactionBaseStale_ = true;
             switch (pendingMode_) {
             case CaptureMode::Fullscreen:
-              selection_ = QRectF(QPointF(), capture_.preview.size());
+              selection_ = QRectF(QPointF(), capture_.previewSize);
               enterEdit(QStringLiteral(
                   "Full screen selected · native resolution · outer handles "
                   "crop"));
@@ -352,9 +352,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
       return;
     }
     capture_.source = job.image;
-    capture_.preview =
-        job.image.scaled(job.scaledSize, Qt::IgnoreAspectRatio,
-                         Qt::SmoothTransformation);
+    capture_.previewSize = job.scaledSize;
     selection_ = QRectF(QPointF(), job.scaledSize);
     redactionBaseStale_ = true;
     windowMode_ = false;
@@ -392,7 +390,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     pendingMode_ = mode;
     setStatus(QStringLiteral("Capturing screen…"));
   } else if (mode == CaptureMode::Fullscreen || mode == CaptureMode::File) {
-    selection_ = QRectF(QPointF(), capture_.preview.size());
+    selection_ = QRectF(QPointF(), capture_.previewSize);
     enterEdit(
         mode == CaptureMode::File
             ? QStringLiteral("Editing image from file · Copy/Save to output")
@@ -758,13 +756,13 @@ QPointF CaptureEditor::toAnnotationPoint(const QPointF &position) const {
 }
 
 QRectF CaptureEditor::sourceRect(const QRectF &logicalRect) const {
-  if (capture_.preview.isNull() || capture_.source.isNull() ||
-      capture_.preview.width() <= 0 || capture_.preview.height() <= 0)
+  if (capture_.source.isNull() || capture_.previewSize.width() <= 0 ||
+      capture_.previewSize.height() <= 0)
     return {};
   const qreal scaleX =
-      capture_.source.width() / static_cast<qreal>(capture_.preview.width());
-  const qreal scaleY =
-      capture_.source.height() / static_cast<qreal>(capture_.preview.height());
+      capture_.source.width() / static_cast<qreal>(capture_.previewSize.width());
+  const qreal scaleY = capture_.source.height() /
+                       static_cast<qreal>(capture_.previewSize.height());
   return {logicalRect.x() * scaleX, logicalRect.y() * scaleY,
           logicalRect.width() * scaleX, logicalRect.height() * scaleY};
 }
@@ -1444,7 +1442,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
       windowMode_ = false;
       dragging_ = false;
       hoveredWindow_ = -1;
-      selection_ = QRectF(QPointF(), capture_.preview.size());
+      selection_ = QRectF(QPointF(), capture_.previewSize);
       enterEdit(QStringLiteral(
           "Full screen selected · native resolution · outer handles crop"));
       update();
@@ -1630,7 +1628,7 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
         return;
       const int handle = static_cast<int>(interaction_) -
                          static_cast<int>(Interaction::CropTopLeft);
-      const QSizeF previewSize = capture_.preview.size();
+      const QSizeF previewSize = capture_.previewSize;
       if (previewSize.width() <= 0.0 || previewSize.height() <= 0.0)
         return;
       const qreal sourceX = originalSelection_.left() +
@@ -1904,7 +1902,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
 
   const QPointF point = toAnnotationPoint(cursor_);
   if (tool_ == Tool::Eyedropper) {
-    customColor_ = sampleSourceColor(capture_.source, capture_.preview.size(),
+    customColor_ = sampleSourceColor(capture_.source, capture_.previewSize,
                                      selection_, editImageRect(), cursor_);
     usingCustomColor_ = true;
     if (customColor_.hsvHueF() >= 0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -261,7 +261,7 @@ int main(int argc, char **argv) {
       return 1;
     }
     capture.source = image;
-    capture.preview = image;
+    capture.previewSize = image.size();
     capture.monitor.scale = 1.0;
     capture.monitor.pixelSize = image.size();
     capture.monitor.geometry = QRect(QPoint(0, 0), image.size());
@@ -311,7 +311,7 @@ int main(int argc, char **argv) {
                        if (!quickOutput(
                                renderCapture(
                                    data,
-                                   QRectF(QPointF(), data.preview.size()), {},
+                                   QRectF(QPointF(), data.previewSize), {},
                                    BackgroundStyle::None),
                                quickOutputMode, outputError)) {
                          qCritical().noquote() << outputError;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -218,7 +218,7 @@ bool runHighlighterRenderingCheck(QString &error) {
   // white source would make every alpha check read 255.
   capture.source = QImage(200, 100, QImage::Format_ARGB32_Premultiplied);
   capture.source.fill(Qt::transparent);
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   Annotation highlight;
   highlight.kind = Annotation::Kind::Highlighter;
@@ -265,7 +265,7 @@ bool runSecureRedactionChecks(QString &error) {
           x, y, QColor((x * 3) % 256, (y * 5) % 256, ((x + y) * 7) % 256));
     }
   }
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   Annotation pixelate;
   pixelate.kind = Annotation::Kind::Redaction;
@@ -314,7 +314,7 @@ bool runSecureRedactionChecks(QString &error) {
           x, y, capture.source.pixelColor(capture.source.width() - x - 1, y));
     }
   }
-  mirroredCapture.preview = mirroredCapture.source;
+  mirroredCapture.previewSize = mirroredCapture.source.size();
   const QImage mirrored = renderCapture(mirroredCapture, QRectF(0, 0, 96, 72),
                                         {pixelate}, BackgroundStyle::None);
   if (first.copy(redactionBounds) != mirrored.copy(redactionBounds))
@@ -364,7 +364,7 @@ bool runSecureRedactionChecks(QString &error) {
   highDpi.monitor.pixelSize = {192, 144};
   highDpi.source = capture.source.scaled(192, 144, Qt::IgnoreAspectRatio,
                                          Qt::SmoothTransformation);
-  highDpi.preview = capture.source;
+  highDpi.previewSize = capture.source.size();
   Annotation highDpiSolid = solid;
   highDpiSolid.start = {10, 10};
   highDpiSolid.end = {30, 30};
@@ -381,8 +381,7 @@ bool runSecureRedactionChecks(QString &error) {
   // final mask through the resampling kernel.
   CaptureData fractional;
   fractional.monitor.scale = 1.25;
-  fractional.preview = QImage(100, 100, QImage::Format_RGB32);
-  fractional.preview.fill(Qt::white);
+  fractional.previewSize = QSize(100, 100);
   fractional.source = QImage(125, 125, QImage::Format_RGB32);
   fractional.source.fill(Qt::white);
   for (int y = 13; y <= 38; ++y) {
@@ -409,8 +408,7 @@ bool runSecureRedactionChecks(QString &error) {
 
   CaptureData matchingFractional;
   matchingFractional.monitor.scale = 1.25;
-  matchingFractional.preview = QImage(160, 160, QImage::Format_RGB32);
-  matchingFractional.preview.fill(Qt::white);
+  matchingFractional.previewSize = QSize(160, 160);
   matchingFractional.source = QImage(200, 200, QImage::Format_RGB32);
   matchingFractional.source.fill(Qt::white);
   for (int y = 13; y <= 26; ++y) {
@@ -431,8 +429,7 @@ bool runSecureRedactionChecks(QString &error) {
 
   CaptureData nonIntegralSourceScale;
   nonIntegralSourceScale.monitor.scale = 1.5;
-  nonIntegralSourceScale.preview = QImage(1707, 100, QImage::Format_RGB32);
-  nonIntegralSourceScale.preview.fill(Qt::white);
+  nonIntegralSourceScale.previewSize = QSize(1707, 100);
   nonIntegralSourceScale.source = QImage(2561, 150, QImage::Format_RGB32);
   nonIntegralSourceScale.source.fill(Qt::white);
   for (int y = 0; y < nonIntegralSourceScale.source.height(); ++y)
@@ -622,7 +619,7 @@ bool runSpotlightAndSampleChecks(QString &error) {
   capture.source = QImage(80, 40, QImage::Format_ARGB32_Premultiplied);
   capture.source.fill(QColor(QStringLiteral("#204080")));
   capture.source.setPixelColor(10, 20, QColor(QStringLiteral("#ff0000")));
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   Annotation line;
   line.kind = Annotation::Kind::Line;
@@ -673,7 +670,7 @@ bool runTextClickAwayCommitCheck(QApplication &application, QString &error) {
   capture.monitor.scale = 1.0;
   capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
   capture.source.fill(QColor(QStringLiteral("#182030")));
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   const QString snapshotPath = temporarySnapshotPath();
   const QRectF selection(100, 100, 550, 370);
@@ -790,7 +787,7 @@ bool runAnnotationLayerChecks(QApplication &application, QString &error) {
     for (int x = 20; x < 40; ++x)
       capture.source.setPixelColor(x, y, secret);
   }
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   Annotation redaction;
   redaction.kind = Annotation::Kind::Redaction;
@@ -856,7 +853,7 @@ bool runAnnotationLayerChecks(QApplication &application, QString &error) {
     QPainter painter(&editorCapture.source);
     painter.fillRect(QRect(200, 200, 100, 60), secret);
   }
-  editorCapture.preview = editorCapture.source;
+  editorCapture.previewSize = editorCapture.source.size();
 
   // Fullscreen draws the 800x600 capture at 84,68 scaled by 0.79. The secret
   // then covers 242,226 to 321,273, centered on 281,250. A loupe smaller than
@@ -938,7 +935,7 @@ bool runAnnotationLayerChecks(QApplication &application, QString &error) {
       QPainter painter(&offsetCapture.source);
       painter.fillRect(QRect(450, 350, 80, 60), secret);
     }
-    offsetCapture.preview = offsetCapture.source;
+    offsetCapture.previewSize = offsetCapture.source.size();
     CaptureEditor editor(offsetCapture);
     editor.resize(800, 600);
     editor.show();
@@ -1000,7 +997,7 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
   capture.monitor.scale = 1.0;
   capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
   capture.source.fill(QColor(QStringLiteral("#182030")));
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   CaptureEditor editor(capture);
   editor.resize(800, 600);
@@ -1273,7 +1270,7 @@ bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
           x, y, QColor(40 + band * 70, 60 + band * 50, 90 + band * 40));
     }
   }
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   const QString snapshotPath = temporarySnapshotPath();
   QFile::remove(snapshotPath);
@@ -1481,7 +1478,7 @@ int main(int argc, char **argv) {
     painter.drawText(capture.source.rect(), Qt::AlignCenter,
                      QStringLiteral("Native Qt capture editor"));
   }
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
   capture.windows = {
       {{80, 80, 300, 220}, QStringLiteral("1"), QStringLiteral("first")},
       {{420, 120, 300, 320}, QStringLiteral("2"), QStringLiteral("second")}};
@@ -1571,7 +1568,7 @@ int main(int argc, char **argv) {
     cropCapture.monitor.pixelSize = {64, 64};
     cropCapture.source = QImage(64, 64, QImage::Format_ARGB32_Premultiplied);
     cropCapture.source.fill(QColor(QStringLiteral("#112233")));
-    cropCapture.preview = cropCapture.source;
+    cropCapture.previewSize = cropCapture.source.size();
     CaptureEditor cropEditor(cropCapture, CaptureEditor::CaptureMode::File);
     cropEditor.resize(800, 600);
     cropEditor.show();
@@ -1607,15 +1604,15 @@ int main(int argc, char **argv) {
   QTest::mouseMove(&editor, QPoint(200, 160), 20);
   application.processEvents();
   const QImage hoverUi = editor.grab().toImage();
-  if (hoverUi.pixelColor(200, 160) != capture.preview.pixelColor(200, 160))
+  if (hoverUi.pixelColor(200, 160) != capture.source.pixelColor(200, 160))
     return 7;
   QTest::keyClick(&editor, Qt::Key_Right, Qt::MetaModifier);
   application.processEvents();
   const QImage keyboardWindowUi = editor.grab().toImage();
   if (keyboardWindowUi.pixelColor(500, 200) !=
-          capture.preview.pixelColor(500, 200) ||
+          capture.source.pixelColor(500, 200) ||
       keyboardWindowUi.pixelColor(200, 160) ==
-          capture.preview.pixelColor(200, 160))
+          capture.source.pixelColor(200, 160))
     return 8;
   QTest::keyClick(&editor, Qt::Key_Space);
   QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
@@ -2024,8 +2021,7 @@ int main(int argc, char **argv) {
   nativePreviewCapture.monitor.pixelSize = {1600, 1200};
   nativePreviewCapture.source = QImage(1600, 1200, QImage::Format_RGB32);
   nativePreviewCapture.source.fill(QColor(QStringLiteral("#123456")));
-  nativePreviewCapture.preview = QImage(800, 600, QImage::Format_RGB32);
-  nativePreviewCapture.preview.fill(QColor(QStringLiteral("#ff00ff")));
+  nativePreviewCapture.previewSize = QSize(800, 600);
   CaptureEditor nativePreviewEditor(nativePreviewCapture,
                                     CaptureEditor::CaptureMode::Fullscreen);
   nativePreviewEditor.resize(800, 600);
@@ -2048,7 +2044,7 @@ int main(int argc, char **argv) {
   fileData.monitor.pixelSize = {300, 200};
   fileData.source = QImage(300, 200, QImage::Format_RGB32);
   fileData.source.fill(QColor(QStringLiteral("#1a2b3c")));
-  fileData.preview = fileData.source;
+  fileData.previewSize = fileData.source.size();
   CaptureEditor fileEditor(fileData, CaptureEditor::CaptureMode::File);
   fileEditor.resize(800, 600);
   fileEditor.show();
@@ -2065,7 +2061,7 @@ int main(int argc, char **argv) {
   windowSurfaceCapture.source =
       QImage(320, 180, QImage::Format_ARGB32_Premultiplied);
   windowSurfaceCapture.source.fill(QColor(QStringLiteral("#d12f45")));
-  windowSurfaceCapture.preview = windowSurfaceCapture.source;
+  windowSurfaceCapture.previewSize = windowSurfaceCapture.source.size();
   CaptureEditor windowSurfaceEditor(windowSurfaceCapture,
                                     CaptureEditor::CaptureMode::Fullscreen);
   windowSurfaceEditor.resize(800, 600);
@@ -2212,7 +2208,7 @@ int main(int argc, char **argv) {
   clippingCapture.monitor.scale = 1.0;
   clippingCapture.source = QImage(100, 100, QImage::Format_RGB32);
   clippingCapture.source.fill(Qt::white);
-  clippingCapture.preview = clippingCapture.source;
+  clippingCapture.previewSize = clippingCapture.source.size();
   Annotation croppedOut;
   croppedOut.kind = Annotation::Kind::Rectangle;
   croppedOut.start = {120, 20};

--- a/tests/transform-smoke.cpp
+++ b/tests/transform-smoke.cpp
@@ -101,7 +101,7 @@ bool runTransformSmoke(QString &error) {
     CaptureData rotatedCapture;
     if (!captureFocusedMonitor(rotatedCapture, true, error) ||
         rotatedCapture.monitor.geometry.size() != QSize(200, 300) ||
-        rotatedCapture.preview.size() != QSize(200, 300) ||
+        rotatedCapture.previewSize != QSize(200, 300) ||
         rotatedCapture.windows.size() != 1) {
       if (error.isEmpty())
         error = QStringLiteral("Quarter-turn monitor geometry was not swapped");
@@ -115,7 +115,7 @@ bool runTransformSmoke(QString &error) {
   CaptureData withoutWindows;
   if (!captureFocusedMonitor(withoutWindows, false, error) ||
       withoutWindows.source.size() != QSize(300, 200) ||
-      withoutWindows.preview.size() != QSize(300, 200) ||
+      withoutWindows.previewSize != QSize(300, 200) ||
       !withoutWindows.windows.isEmpty()) {
     if (error.isEmpty())
       error = QStringLiteral("Capture without window discovery was incorrect");


### PR DESCRIPTION
`CaptureData::preview` was a full QImage produced by a full-monitor `scaled(..., SmoothTransformation)` — but its pixels are never drawn anywhere; every consumer reads only its size (selection mapping, crop handles, eyedropper coordinates, source-rect scaling). The window-capture path paid a second `scaled()` per pick.

Replaced with a plain `QSize previewSize`, computed with no pixel work. Net −10 lines. Gains: ~1.8 ms (measured, 5120x2880 at scale 2) off every capture, the per-pick `scaled()` in window mode, and ~15 MB of resident memory per running editor or pin (a logical-size ARGB buffer held for the process lifetime, unused).

Mechanical sweep; no behavior change. `grep '\.preview\b'` across src/ and tests/ comes back empty.
