### PR TITLE
Cache the selection backdrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,8 +311,11 @@ QT_QPA_PLATFORM=offscreen \
 
 The smoke executable exercises region/window/fullscreen startup modes, capture selection,
 temporary snapshot updates, annotation tools, undo/redo, vector movement and scaling,
-text editing, OCR, native-DPI output, endpoint-only line selection, and external crop
-handles.
+text editing, OCR, native-DPI output, endpoint-only line selection, cached backdrop
+brightness, and external crop handles.
+
+`OMASNAP_SMOKE_BENCH=1` turns the same executable into a repaint benchmark on a 5K
+capture, printing milliseconds per frame in both editor phases.
 
 `.github/workflows/build-linux.yml` performs the same release build and interaction smoke
 in an Arch Linux container, stages the CMake installation, and uploads a versioned Linux

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -41,6 +41,7 @@ constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
 constexpr qreal kToolbarWidth = 760;
 constexpr qreal kMinimumRedactionExtent = 5.0;
+constexpr int kBackdropDim = 143;
 
 qreal toolbarScale(qreal availableWidth) {
   constexpr qreal sideMargins = 16.0;
@@ -2299,19 +2300,56 @@ void CaptureEditor::updatePointerCursor() {
     setCursor(Qt::CrossCursor);
 }
 
+/** Scales the capture to the widget once instead of on every repaint. */
+void CaptureEditor::refreshBackdropCache() {
+  const qreal ratio = devicePixelRatioF();
+  const QSize device = (QSizeF(size()) * ratio).toSize();
+  const qint64 key = capture_.source.cacheKey();
+  if (device.isEmpty()) {
+    backdrop_ = {};
+    dimmedBackdrop_ = {};
+    backdropSize_ = {};
+    return;
+  }
+  if (!backdrop_.isNull() && backdropSize_ == device && backdropKey_ == key &&
+      qFuzzyCompare(backdropRatio_, ratio))
+    return;
+
+  backdropSize_ = device;
+  backdropRatio_ = ratio;
+  backdropKey_ = key;
+  backdrop_ = QPixmap(device);
+  backdrop_.setDevicePixelRatio(ratio);
+  backdrop_.fill(Qt::transparent);
+  {
+    QPainter cache(&backdrop_);
+    cache.setRenderHint(QPainter::SmoothPixmapTransform, true);
+    cache.drawImage(QRectF(QPointF(), QSizeF(device) / ratio), capture_.source);
+  }
+  dimmedBackdrop_ = backdrop_.copy();
+  {
+    QPainter cache(&dimmedBackdrop_);
+    cache.fillRect(QRectF(QPointF(), QSizeF(device) / ratio),
+                   QColor(0, 0, 0, kBackdropDim));
+  }
+}
+
 void CaptureEditor::paintSelect(QPainter &painter) {
   if (capture_.source.isNull()) {
-    painter.fillRect(rect(), QColor(0, 0, 0, 143));
+    painter.fillRect(rect(), QColor(0, 0, 0, kBackdropDim));
     drawStatusPill(painter, rect(), status_);
     return;
   }
-  painter.drawImage(rect(), capture_.source);
-  painter.fillRect(rect(), QColor(0, 0, 0, 143));
+  refreshBackdropCache();
+  painter.drawPixmap(rect(), dimmedBackdrop_);
 
   if (windowMode_) {
     if (hoveredWindow_ >= 0 && hoveredWindow_ < capture_.windows.size()) {
       const QRect window = capture_.windows.at(hoveredWindow_).rect;
-      painter.drawImage(window, capture_.source, sourceRect(window));
+      painter.save();
+      painter.setClipRect(window);
+      painter.drawPixmap(rect(), backdrop_);
+      painter.restore();
     }
     for (int index = 0; index < capture_.windows.size(); ++index) {
       const WindowTarget &window = capture_.windows.at(index);
@@ -2321,7 +2359,10 @@ void CaptureEditor::paintSelect(QPainter &painter) {
       painter.drawRect(window.rect);
     }
   } else if (!selection_.isEmpty()) {
-    painter.drawImage(selection_, capture_.source, sourceRect(selection_));
+    painter.save();
+    painter.setClipRect(selection_);
+    painter.drawPixmap(rect(), backdrop_);
+    painter.restore();
     painter.setPen(QPen(Qt::white, 2));
     painter.setBrush(Qt::NoBrush);
     painter.drawRect(selection_);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -5,6 +5,7 @@
 #include <QElapsedTimer>
 #include <QFutureWatcher>
 #include <QLineEdit>
+#include <QPixmap>
 #include <QWidget>
 
 class QKeyEvent;
@@ -164,6 +165,7 @@ private:
   void handleToolbar(const QString &action);
   void paintEdit(QPainter &painter);
   void paintSelect(QPainter &painter);
+  void refreshBackdropCache();
   void runOcr(const QRectF &localSelection = {});
   void setStatus(QString status);
   void scaleSelectedAnnotation(qreal factor);
@@ -211,6 +213,15 @@ private:
   QImage redactionBase_;
   QSize redactionBaseSize_;
   bool redactionBaseStale_ = true;
+  // Select-phase backdrop scaled to the widget, keyed on capture_.source's
+  // cacheKey so a replaced capture rebuilds it. The edit phase needs no
+  // equivalent: redactionBase_ already holds the selection at display
+  // resolution. Export paths keep rendering from capture_.source natively.
+  QPixmap backdrop_;
+  QPixmap dimmedBackdrop_;
+  QSize backdropSize_;
+  qreal backdropRatio_ = 0.0;
+  qint64 backdropKey_ = 0;
   // Background/gui-thread snapshot persistence with latest-wins coalescing.
   QFutureWatcher<bool> snapshotWatcher_;
   bool snapshotBusy_ = false;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -20,6 +20,7 @@
 #include <QFileInfo>
 #include <QFontMetricsF>
 #include <QPainter>
+#include <QPixmap>
 #include <QTemporaryDir>
 #include <QUrl>
 #include <QWheelEvent>
@@ -27,6 +28,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <numbers>
 #include <csignal>
 #include <sys/resource.h>
@@ -39,6 +41,126 @@ template <typename Editor>
 QImage flushedSnapshot(Editor &editor, const QString &) {
   return editor.renderCurrentOutput();
 }
+
+/** The cached backdrop must still show the capture inside the selection and
+ *  the dimmed capture outside it. */
+bool runBackdropCacheRenderingCheck(const CaptureData &capture,
+                                    QString &error) {
+  if (capture.source.size() != QSize(800, 600) ||
+      capture.preview.size() != capture.source.size()) {
+    error = QStringLiteral("Backdrop check expects an unscaled 800x600 capture");
+    return false;
+  }
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  QApplication::processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(150, 120));
+  QTest::mouseMove(&editor, QPoint(600, 430), 20);
+  QApplication::processEvents();
+  const QImage ui = editor.grab().toImage();
+
+  for (const QPoint &inside : {QPoint(300, 250), QPoint(500, 400)}) {
+    if (ui.pixelColor(inside) != capture.source.pixelColor(inside)) {
+      error = QStringLiteral("Selection preview no longer matches the capture");
+      return false;
+    }
+  }
+  // Outside the selection the capture stays visible under a 143/255 black
+  // wash, exactly as the per-frame resample used to draw it.
+  for (const QPoint &outside : {QPoint(40, 40), QPoint(720, 540)}) {
+    const QColor source = capture.source.pixelColor(outside);
+    const QColor dimmed = ui.pixelColor(outside);
+    const auto matches = [](int actual, int expected) {
+      return std::abs(actual - expected) <= 2;
+    };
+    if (!matches(dimmed.red(), source.red() * (255 - 143) / 255) ||
+        !matches(dimmed.green(), source.green() * (255 - 143) / 255) ||
+        !matches(dimmed.blue(), source.blue() * (255 - 143) / 255)) {
+      error = QStringLiteral("Dimmed backdrop brightness changed");
+      return false;
+    }
+  }
+  editor.close();
+  return true;
+}
+
+/** Reports repaint cost on a 5K capture. Enabled with OMASNAP_SMOKE_BENCH=1;
+ *  uses only public API so the same harness builds against any revision of
+ *  the editor. */
+void runEditorBenchmark() {
+  constexpr QSize nativeSize(5120, 2880);
+  constexpr QSize logicalSize(2560, 1440);
+  constexpr int frames = 20;
+
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("BENCH");
+  capture.monitor.geometry = {0, 0, logicalSize.width(), logicalSize.height()};
+  capture.monitor.pixelSize = nativeSize;
+  capture.monitor.scale = 2.0;
+  capture.source = QImage(nativeSize, QImage::Format_ARGB32_Premultiplied);
+  {
+    QPainter painter(&capture.source);
+    QLinearGradient gradient(0, 0, nativeSize.width(), nativeSize.height());
+    gradient.setColorAt(0, QColor(QStringLiteral("#172033")));
+    gradient.setColorAt(1, QColor(QStringLiteral("#5278b5")));
+    painter.fillRect(capture.source.rect(), gradient);
+  }
+  capture.preview = capture.source.scaled(logicalSize, Qt::IgnoreAspectRatio,
+                                          Qt::SmoothTransformation);
+
+  CaptureEditor editor(capture);
+  editor.resize(logicalSize);
+  editor.show();
+  QApplication::processEvents();
+
+  QPixmap target(logicalSize);
+  const auto renderFrames = [&editor, &target] {
+    QElapsedTimer timer;
+    timer.start();
+    for (int frame = 0; frame < frames; ++frame)
+      editor.render(&target);
+    return timer.nsecsElapsed() / 1e6 / frames;
+  };
+
+  // Select phase, mid-drag: dimmed backdrop plus the bright selection.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 200));
+  QTest::mouseMove(&editor, QPoint(2300, 1300), 5);
+  QApplication::processEvents();
+  const double selectMs = renderFrames();
+
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(2300, 1300));
+  QApplication::processEvents();
+
+  // Edit phase: the frozen crop plus annotation layers.
+  QTest::keyClick(&editor, Qt::Key_L);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(600, 500));
+  QTest::mouseMove(&editor, QPoint(1400, 900), 5);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(1400, 900));
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(1000, 700));
+  QApplication::processEvents();
+  const double editMs = renderFrames();
+
+  // Edit phase with an active redaction: the canvas draws the already
+  // display-resolution redaction layer.
+  QTest::keyClick(&editor, Qt::Key_D);
+  QTest::keyClick(&editor, Qt::Key_D);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(700, 600));
+  QTest::mouseMove(&editor, QPoint(1500, 1000), 5);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(1500, 1000));
+  QApplication::processEvents();
+  const double redactedEditMs = renderFrames();
+
+  std::printf("bench.paint.select.ms_per_frame=%.2f\n", selectMs);
+  std::printf("bench.paint.edit.ms_per_frame=%.2f\n", editMs);
+  std::printf("bench.paint.edit_redacted.ms_per_frame=%.2f\n", redactedEditMs);
+  std::fflush(stdout);
+}
+
 /** Checks that positional local image targets are recognized. */
 bool runPositionalImageTargetCheck(QString &error) {
   QTemporaryDir directory;
@@ -1380,6 +1502,10 @@ int main(int argc, char **argv) {
   QApplication application(argc, argv);
   if (!loadCaptureFonts())
     return 17;
+  if (qEnvironmentVariableIsSet("OMASNAP_SMOKE_BENCH")) {
+    runEditorBenchmark();
+    return 0;
+  }
   QString snapshotError;
   if (!runPositionalImageTargetCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
@@ -2330,6 +2456,12 @@ int main(int argc, char **argv) {
       qWarning().noquote() << clipboardError;
       return 64;
     }
+  }
+
+  QString backdropError;
+  if (!runBackdropCacheRenderingCheck(capture, backdropError)) {
+    qWarning().noquote() << backdropError;
+    return 88;
   }
 
   QString transformError;


### PR DESCRIPTION
| select-phase repaint, 5120x2880 source (Release, median of 3) | before | after |
|---|---|---|
| ms/frame | 3.42 | **0.62** (5.5x) |
| edit phase | 1.32 | 1.30 (untouched) |

`paintSelect` smooth-resamples the full native-resolution capture to the widget on every repaint — and `mouseMoveEvent` triggers full-rect updates, so during any selection drag that's 3.4 ms of per-frame CPU raster (~40% of a core at 120 Hz pointer rate) on fast hardware, proportionally worse on lower-power machines driving big displays.

The select phase now blits two cached pixmaps (scaled backdrop, pre-dimmed variant) built once per widget size/DPR and invalidated by `capture_.source.cacheKey()`; hovered-window and selection regions clip-blit from the cache. 62 source lines.

The edit phase is deliberately untouched: f462005's `redactionBase_` already renders the selection at canvas resolution and caches it, so edit repaints are a 1:1 blit with nothing left to win (measured identical before/after).

Smoke: `runBackdropCacheRenderingCheck` (exit 88) pins rendering equivalence — dim level and selection pixels — and was verified to also pass against the uncached upstream `paintSelect`, so it asserts behavior, not implementation. A repaint benchmark ships behind `OMASNAP_SMOKE_BENCH=1`.

Note: independent of #39; whichever merges second needs a one-line touch-up of two `preview` references in the test harness.
