### PR TITLE
fix: restore zoom for Spotlight tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Install the corresponding Tesseract language data before adding a language to
 | `O` | Drag an OCR region and copy recognized text |
 | `B` | Cycle backdrop |
 | `1`–`6` | Set annotation color |
-| Wheel | Scale selected layer or change active tool size |
+| Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size |
 | Hold `Shift` while dragging | Make rectangles and spotlights 1:1; snap lines and arrows to 45° |
 | Double-click text | Reopen text editing |
 | `Delete` | Delete selected layer |

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -562,6 +562,15 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
   return -1;
 }
 
+int CaptureEditor::hoveredSpotlightAt(const QPointF &position) const {
+  if (dragging_ || !editImageRect().contains(position))
+    return -1;
+  const int index = annotationAt(toAnnotationPoint(position));
+  if (index < 0 || annotations_.at(index).kind != Annotation::Kind::Spotlight)
+    return -1;
+  return index;
+}
+
 void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
   if (selectedAnnotation_ < 0 || selectedAnnotation_ >= annotations_.size())
     return;
@@ -2202,11 +2211,23 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
                   .arg(QString::fromLatin1(kTextSizeNames.at(
                       static_cast<std::size_t>(textSizeIndex_)))));
   } else if (tool_ == Tool::Spotlight) {
-    spotlightMagnification_ =
-        std::clamp(spotlightMagnification_ + (step > 0 ? 0.25 : -0.25), 1.0,
-                   4.0);
-    setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
-                  .arg(spotlightMagnification_, 0, 'f', 1));
+    const qreal delta = step > 0 ? 0.25 : -0.25;
+    const int hovered = hoveredSpotlightAt(event->position());
+    if (hovered >= 0) {
+      recordEdit();
+      Annotation &annotation = annotations_[hovered];
+      annotation.magnification =
+          std::clamp(annotation.magnification + delta, 1.0, 4.0);
+      spotlightMagnification_ = annotation.magnification;
+      setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
+                    .arg(annotation.magnification, 0, 'f', 1));
+      scheduleSnapshot();
+    } else {
+      spotlightMagnification_ =
+          std::clamp(spotlightMagnification_ + delta, 1.0, 4.0);
+      setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
+                    .arg(spotlightMagnification_, 0, 'f', 1));
+    }
   } else if (tool_ == Tool::Arrow || tool_ == Tool::Line ||
              tool_ == Tool::Freehand || tool_ == Tool::Highlighter ||
              tool_ == Tool::Marker) {

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -124,6 +124,7 @@ private:
   [[nodiscard]] QRectF selectedAnnotationsBounds() const;
   [[nodiscard]] bool annotationSelected(int index) const;
   [[nodiscard]] int annotationAt(const QPointF &point) const;
+  [[nodiscard]] int hoveredSpotlightAt(const QPointF &position) const;
   [[nodiscard]] QRectF normalizedSelection(const QPointF &first,
                                            const QPointF &second) const;
   [[nodiscard]] QRectF colorPaletteRect() const;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -830,6 +830,117 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Checks that the wheel retargets the spotlight under the cursor. */
+bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  // Fine banding so a magnification change moves the sampled loupe pixels.
+  for (int y = 0; y < capture.source.height(); ++y) {
+    for (int x = 0; x < capture.source.width(); ++x) {
+      const int band = ((x / 3) + (y / 5)) % 3;
+      capture.source.setPixelColor(
+          x, y, QColor(40 + band * 70, 60 + band * 50, 90 + band * 40));
+    }
+  }
+  capture.preview = capture.source;
+
+  const QString snapshotPath = temporarySnapshotPath();
+  QFile::remove(snapshotPath);
+
+  const auto armSpotlightTool = [&application](CaptureEditor &editor) {
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+    QTest::mouseMove(&editor, QPoint(700, 500), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(700, 500));
+    QTest::keyClick(&editor, Qt::Key_S);
+    application.processEvents();
+  };
+  const auto drawSpotlight = [&application](CaptureEditor &editor) {
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 250));
+    QTest::mouseMove(&editor, QPoint(500, 400), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(500, 400));
+    application.processEvents();
+  };
+  const auto sendWheel = [&application](CaptureEditor &editor,
+                                        const QPointF &position, int notches) {
+    for (int notch = 0; notch < notches; ++notch) {
+      QWheelEvent wheel(position, position, {}, {0, 120}, Qt::NoButton,
+                        Qt::NoModifier, Qt::NoScrollPhase, false);
+      QApplication::sendEvent(&editor, &wheel);
+    }
+    application.processEvents();
+  };
+  // Widget centre of the spotlight drawn above, and a point clear of it.
+  const QPointF overSpotlight(400, 325);
+  const QPointF awayFromSpotlight(160, 160);
+
+  CaptureEditor editor(capture);
+  armSpotlightTool(editor);
+  drawSpotlight(editor);
+  if (editor.cursor().shape() != Qt::CrossCursor) {
+    error = QStringLiteral("Spotlight tool did not stay armed after placement");
+    return false;
+  }
+  const QImage placed = flushedSnapshot(editor, snapshotPath);
+  if (placed.isNull()) {
+    error = QStringLiteral("Spotlight placement did not render a snapshot");
+    return false;
+  }
+
+  sendWheel(editor, overSpotlight, 4);
+  const QImage adjusted = flushedSnapshot(editor, snapshotPath);
+  if (adjusted.isNull() || adjusted == placed) {
+    error = QStringLiteral(
+        "Wheel over a placed spotlight did not change its magnification");
+    return false;
+  }
+  for (int notch = 0; notch < 4; ++notch)
+    QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (flushedSnapshot(editor, snapshotPath) != placed) {
+    error = QStringLiteral("Undo did not restore the spotlight magnification");
+    return false;
+  }
+  for (int notch = 0; notch < 4; ++notch)
+    QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  if (flushedSnapshot(editor, snapshotPath) != adjusted) {
+    error = QStringLiteral("Redo did not restore the adjusted magnification");
+    return false;
+  }
+
+  sendWheel(editor, awayFromSpotlight, 4);
+  if (flushedSnapshot(editor, snapshotPath) != adjusted) {
+    error = QStringLiteral(
+        "Wheel away from a spotlight changed the placed spotlight");
+    return false;
+  }
+  editor.close();
+
+  // Away from any spotlight the wheel still moves the default that the next
+  // spotlight inherits.
+  CaptureEditor defaultEditor(capture);
+  armSpotlightTool(defaultEditor);
+  sendWheel(defaultEditor, awayFromSpotlight, 4);
+  drawSpotlight(defaultEditor);
+  const QImage inherited = flushedSnapshot(defaultEditor, snapshotPath);
+  if (inherited.isNull() || inherited == placed) {
+    error = QStringLiteral(
+        "Wheel away from any spotlight did not move the default magnification");
+    return false;
+  }
+  defaultEditor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
 int main(int argc, char **argv) {
@@ -880,6 +991,10 @@ int main(int argc, char **argv) {
   if (!runContinuousAnnotationToolsSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 80;
+  }
+  if (!runSpotlightWheelSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 94;
   }
   const QString outputRoot =
       argc > 1 ? QString::fromLocal8Bit(argv[1])


### PR DESCRIPTION
The regression noted in #35: since continuous annotation tools (e80595f, #33), placing a spotlight leaves the tool armed, and the wheel then hits the `Tool::Spotlight` branch — which only adjusts `spotlightMagnification_`, the default for the *next* spotlight. The status number moves; the loupe the user just placed doesn't.

With the Spotlight tool armed, the wheel now adjusts the spotlight under the cursor when there is one (reusing the `annotationAt` hit-test; each notch is a proper undoable edit, mirroring `scaleSelectedAnnotation`), and keeps the default in sync so the next loupe inherits it. Away from any spotlight, behavior is unchanged. The Select-tool wheel path is untouched.

Smoke: `runSpotlightWheelSmoke` (exit 94) asserts the tool stays armed, notches over the loupe change the persisted snapshot, 4x undo/redo restore it byte-exactly, notches away from the loupe leave it untouched, and the next spotlight inherits the moved default.

Note for #41 (snapshot debouncing): this adds one `persistSnapshot()` call site; whichever lands second switches it to the debounced path — I'll carry that one-line adjustment on rebase.
