### PR TITLE
perf: write working snapshots asynchronously with fast encoding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,13 @@ pinned always-on-top layer surface.
 | Path | Purpose |
 |---|---|
 | `main.cpp` | CLI parsing, single-instance lock, mode dispatch (capture / edit file / pin) |
+| `instance-lock.cpp/.hpp` | Single-instance handover: cancel a running overlay, or stop it and take over for `--file` |
 | `capture.cpp/.hpp` | Capture selection overlay, snapshot lifecycle under `/run/user/<UID>/omasnap/` |
 | `editor.cpp/.hpp` | Annotation editor: tools, layers, undo/redo, rendering, export |
 | `pin.cpp/.hpp` | Pinned-capture layer-shell surfaces (bottom-right, all workspaces) |
 | `surface-capture.cpp` | Clean window capture via `ext-image-copy-capture` Wayland protocol |
 | `icons.cpp/.hpp` | Vector icon renderer for toolbar and pin controls |
-| `editor-smoke.cpp`, `transform-smoke.cpp` | Headless smoke tests (Qt Test, offscreen platform) |
+| `editor-smoke.cpp`, `transform-smoke.cpp`, `instance-lock-smoke.cpp` | Headless smoke tests (Qt Test, offscreen platform) |
 | `install-omarchy` | Omarchy installer (deps via `omarchy-pkg-add`, installs to `~/.local`) |
 | `CMakeLists.txt` | Build definition; **the version lives here** (`project(omasnap VERSION ...)`) |
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ qt_add_executable(omasnap
   cli-path.hpp
   icons.cpp
   icons.hpp
+  instance-lock.cpp
+  instance-lock.hpp
   pin.cpp
   pin.hpp
   pin-file.cpp
@@ -75,6 +77,10 @@ qt_add_executable(omasnap-smoke
   editor-smoke.cpp
   icons.cpp
   icons.hpp
+  instance-lock.cpp
+  instance-lock.hpp
+  instance-lock-smoke.cpp
+  instance-lock-smoke.hpp
   transform-smoke.cpp
   transform-smoke.hpp
   cli-path.cpp

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   from the same `omasnap` executable and visible on every workspace.
 - Crash-resistant working snapshots under `/run/user/<UID>/omasnap/` (falling back to
   a private `/tmp/omasnap-<UID>/`), written immediately after selection and overwritten
-  after every completed edit. Saving moves that file into `~/Pictures/Screenshots`;
-  clipboard output streams the same PNG.
+  after every completed edit. Rapid adjustments (wheel scaling, color picking and
+  sampling, backdrop cycling, redaction style toggling) coalesce into one write
+  shortly after the burst, and saving, pinning or closing flushes it first.
+  Saving moves that file into `~/Pictures/Screenshots`; clipboard output streams
+  the same PNG.
 - Verified PNG clipboard output through `wl-copy`/`wl-paste`, plus timestamped files
   under `~/Pictures/Screenshots` by default.
 - Correct native-pixel export on fractional or integer-scaled monitors.
@@ -310,12 +313,14 @@ QT_QPA_PLATFORM=offscreen \
 ```
 
 The smoke executable exercises region/window/fullscreen startup modes, capture selection,
-temporary snapshot updates, annotation tools, undo/redo, vector movement and scaling,
-text editing, OCR, native-DPI output, endpoint-only line selection, cached backdrop
-brightness, redacted canvas caching, and external crop handles.
+temporary snapshot updates and their debounced coalescing, annotation tools, undo/redo,
+vector movement and scaling, text editing, OCR, native-DPI output, endpoint-only line
+selection, cached backdrop brightness, redacted canvas caching, and external crop
+handles.
 
-`OMASNAP_SMOKE_BENCH=1` turns the same executable into a repaint benchmark on a 5K
-capture, printing milliseconds per frame in both editor phases.
+`OMASNAP_SMOKE_BENCH=1` turns the same executable into a repaint/snapshot benchmark on a
+5K capture, printing milliseconds per frame in both editor phases and the write count of
+a ten-notch scaling burst.
 
 `.github/workflows/build-linux.yml` performs the same release build and interaction smoke
 in an Arch Linux container, stages the CMake installation, and uploads a versioned Linux

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   a private `/tmp/omasnap-<UID>/`), written immediately after selection and overwritten
   after every completed edit. Rapid adjustments (wheel scaling, color picking and
   sampling, backdrop cycling, redaction style toggling) coalesce into one write
-  shortly after the burst, and saving, pinning or closing flushes it first.
-  Saving moves that file into `~/Pictures/Screenshots`; clipboard output streams
-  the same PNG.
+  shortly after the burst, and those writes render and encode on a worker thread
+  so the editor never stalls on them. Saving, pinning or closing flushes the
+  snapshot first. Saving moves that file into `~/Pictures/Screenshots` at the
+  default PNG compression; clipboard output streams the same PNG.
 - Verified PNG clipboard output through `wl-copy`/`wl-paste`, plus timestamped files
   under `~/Pictures/Screenshots` by default.
 - Correct native-pixel export on fractional or integer-scaled monitors.
@@ -313,14 +314,15 @@ QT_QPA_PLATFORM=offscreen \
 ```
 
 The smoke executable exercises region/window/fullscreen startup modes, capture selection,
-temporary snapshot updates and their debounced coalescing, annotation tools, undo/redo,
-vector movement and scaling, text editing, OCR, native-DPI output, endpoint-only line
-selection, cached backdrop brightness, redacted canvas caching, and external crop
-handles.
+temporary snapshot updates with their debounced coalescing and asynchronous writes,
+annotation tools, undo/redo, vector movement and scaling, text editing, OCR, native-DPI
+output, endpoint-only line selection, cached backdrop brightness, redacted canvas
+caching, and external crop handles.
 
 `OMASNAP_SMOKE_BENCH=1` turns the same executable into a repaint/snapshot benchmark on a
-5K capture, printing milliseconds per frame in both editor phases and the write count of
-a ten-notch scaling burst.
+5K capture, printing milliseconds per frame in both editor phases, the time select-all
+blocks the GUI thread, the write count of a ten-notch scaling burst, and fast versus
+default PNG encoding cost.
 
 `.github/workflows/build-linux.yml` performs the same release build and interaction smoke
 in an Arch Linux container, stages the CMake installation, and uploads a versioned Linux

--- a/README.md
+++ b/README.md
@@ -311,8 +311,11 @@ QT_QPA_PLATFORM=offscreen \
 
 The smoke executable exercises region/window/fullscreen startup modes, capture selection,
 temporary snapshot updates, annotation tools, undo/redo, vector movement and scaling,
-text editing, OCR, native-DPI output, endpoint-only line selection, and external crop
-handles.
+text editing, OCR, native-DPI output, endpoint-only line selection, cached backdrop
+brightness, redacted canvas caching, and external crop handles.
+
+`OMASNAP_SMOKE_BENCH=1` turns the same executable into a repaint benchmark on a 5K
+capture, printing milliseconds per frame in both editor phases.
 
 `.github/workflows/build-linux.yml` performs the same release build and interaction smoke
 in an Arch Linux container, stages the CMake installation, and uploads a versioned Linux

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ hl.layer_rule({
 })
 ```
 
+Each of these keys toggles: the first press opens the overlay, the next press dismisses it.
+
 Apply and verify:
 
 ```bash
@@ -163,6 +165,33 @@ Quick output skips the annotation editor. Add `--copy` to copy only, `--save` to
 only, or both flags to copy and save. Region and window captures output after selection;
 fullscreen captures output immediately. Quick output cannot be combined with `--file` or
 `--pin`.
+
+### One instance, toggled by the same hotkey
+
+Only one capture overlay runs at a time, guarded by a lock file in the runtime snapshot
+directory. Starting omasnap while an overlay is open sends the running instance `SIGTERM`,
+which it handles with a clean Qt shutdown; the new process then exits without capturing.
+Pressing `PRINT` therefore opens the overlay and pressing it again dismisses it.
+
+Every capture invocation dismisses this way, quick output included: `--copy`/`--save`
+while an overlay is open closes the overlay and outputs nothing, rather than screenshotting
+the overlay that is still on screen.
+
+Editing an existing image is never cancelled this way: `--file` (or an image path) stops
+the running instance, waits up to two seconds for the lock, and opens the editor on that
+image. That is how a pin's Edit button and a notification click always land in the editor.
+
+A lock left behind by a crashed instance is removed and reclaimed. A lock file that cannot
+be read or written at all is reported on stderr instead of being mistaken for a running
+instance.
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success, including dismissing a running overlay |
+| `1` | Capture, image, or single-instance lock failure |
+| `2` | Usage error |
 
 ### Edit an existing image
 

--- a/capture.cpp
+++ b/capture.cpp
@@ -5,6 +5,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
+#include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
 #include <QFontDatabase>
@@ -18,7 +19,6 @@
 #include <QRandomGenerator>
 #include <QSaveFile>
 #include <QStandardPaths>
-#include <QTemporaryFile>
 
 #include <QUrl>
 #include <algorithm>
@@ -111,6 +111,51 @@ ProcessResult runProcess(const QString &program, const QStringList &arguments,
   if (!finished)
     process.kill();
   return {process.readAllStandardOutput(), process.readAllStandardError(),
+          finished ? process.exitCode() : -1, finished};
+}
+
+/**
+ * Runs a process whose stdout carries a large payload, draining the pipe as it
+ * arrives into one buffer sized up front. Letting QProcess buffer the whole
+ * payload first costs an extra copy of the full frame.
+ */
+ProcessResult runStreamingProcess(const QString &program,
+                                  const QStringList &arguments,
+                                  qsizetype expectedBytes, int timeoutMs) {
+  QProcess process;
+  process.setProcessChannelMode(QProcess::SeparateChannels);
+  process.start(program, arguments, QIODevice::ReadOnly);
+  if (!process.waitForStarted(2000))
+    return {{}, process.errorString().toUtf8(), -1, false};
+
+  QByteArray output;
+  output.reserve(std::max<qsizetype>(expectedBytes, 0));
+  const auto drain = [&process, &output] {
+    const qint64 available = process.bytesAvailable();
+    if (available <= 0)
+      return;
+    const qsizetype offset = output.size();
+    output.resize(offset + available);
+    const qint64 read = process.read(output.data() + offset, available);
+    output.resize(offset + std::max<qint64>(read, 0));
+  };
+
+  QElapsedTimer clock;
+  clock.start();
+  const auto remainingMs = [&clock, timeoutMs] {
+    return std::max<qint64>(0, timeoutMs - clock.elapsed());
+  };
+  while (remainingMs() > 0 &&
+         process.waitForReadyRead(static_cast<int>(remainingMs())))
+    drain();
+
+  const bool finished =
+      process.state() == QProcess::NotRunning ||
+      process.waitForFinished(static_cast<int>(remainingMs()));
+  if (!finished)
+    process.kill();
+  drain();
+  return {std::move(output), process.readAllStandardError(),
           finished ? process.exitCode() : -1, finished};
 }
 
@@ -662,7 +707,8 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
   }
 }
 
-bool captureFocusedMonitor(CaptureData &capture, QString &error) {
+bool captureFocusedMonitor(CaptureData &capture, bool includeWindows,
+                           QString &error) {
   const ProcessResult monitors =
       runProcess(QStringLiteral("hyprctl"),
                  {QStringLiteral("monitors"), QStringLiteral("-j")});
@@ -673,38 +719,54 @@ bool captureFocusedMonitor(CaptureData &capture, QString &error) {
     return false;
   }
 
-  const QString sourceTemplate =
-      runtimePath(QStringLiteral("omasnap-capture-XXXXXX.ppm"));
-  if (sourceTemplate.isEmpty()) {
-    error = QStringLiteral("Could not create private runtime directory");
-    return false;
-  }
-  QTemporaryFile sourceFile(sourceTemplate);
-  sourceFile.setAutoRemove(true);
-  if (!sourceFile.open()) {
-    error = sourceFile.errorString();
-    return false;
-  }
-  const QString sourcePath = sourceFile.fileName();
-  sourceFile.close();
-
   const QRect geometry = capture.monitor.geometry;
+  if (geometry.size().isEmpty()) {
+    error = QStringLiteral("Focused monitor reported an empty geometry");
+    return false;
+  }
+
+  // Window discovery is independent of the screen grab, so let the hyprctl
+  // round trip overlap grim instead of running after it.
+  QProcess clients;
+  if (includeWindows) {
+    clients.setProcessChannelMode(QProcess::SeparateChannels);
+    clients.start(QStringLiteral("hyprctl"),
+                  {QStringLiteral("clients"), QStringLiteral("-j")});
+    clients.closeWriteChannel();
+  }
+
   const QString grimGeometry = QStringLiteral("%1,%2 %3x%4")
                                    .arg(geometry.x())
                                    .arg(geometry.y())
                                    .arg(geometry.width())
                                    .arg(geometry.height());
-  const ProcessResult grim = runProcess(
+  // A PPM frame is three bytes per pixel plus a short header.
+  const qsizetype expectedBytes =
+      static_cast<qsizetype>(capture.monitor.pixelSize.width()) *
+          capture.monitor.pixelSize.height() * 3 +
+      64;
+  const ProcessResult grim = runStreamingProcess(
       QStringLiteral("grim"),
       {QStringLiteral("-t"), QStringLiteral("ppm"), QStringLiteral("-s"),
        QString::number(capture.monitor.scale, 'g', 8), QStringLiteral("-g"),
-       grimGeometry, sourcePath},
-      {}, 10000);
+       grimGeometry, QStringLiteral("-")},
+      expectedBytes, 10000);
 
-  if (!grim.finished || grim.exitCode != 0 ||
-      !capture.source.load(sourcePath)) {
-    error = QStringLiteral("Screen capture failed: %1")
-                .arg(QString::fromUtf8(grim.error).trimmed());
+  if (!grim.finished || grim.exitCode != 0) {
+    QString detail = QString::fromUtf8(grim.error).trimmed();
+    if (detail.isEmpty()) {
+      detail = grim.finished ? QStringLiteral("grim exited with code %1")
+                                   .arg(grim.exitCode)
+                             : QStringLiteral("grim did not finish in time");
+    }
+    error = QStringLiteral("Screen capture failed: %1").arg(detail);
+    return false;
+  }
+  if (!capture.source.loadFromData(grim.output, "PPM")) {
+    error = QStringLiteral(
+                "Screen capture failed: could not decode %1 bytes of PPM data "
+                "from grim")
+                .arg(grim.output.size());
     return false;
   }
 
@@ -715,11 +777,13 @@ bool captureFocusedMonitor(CaptureData &capture, QString &error) {
     return false;
   }
 
-  const ProcessResult clients =
-      runProcess(QStringLiteral("hyprctl"),
-                 {QStringLiteral("clients"), QStringLiteral("-j")});
-  if (clients.finished && clients.exitCode == 0)
-    capture.windows = parseWindows(clients.output, capture.monitor);
+  if (includeWindows) {
+    if (!clients.waitForFinished(10000))
+      clients.kill();
+    else if (clients.exitCode() == 0)
+      capture.windows =
+          parseWindows(clients.readAllStandardOutput(), capture.monitor);
+  }
   return true;
 }
 

--- a/capture.cpp
+++ b/capture.cpp
@@ -526,11 +526,11 @@ void applyRedactions(QImage &image, const QVector<Annotation> &annotations,
 
 QRect pixelSelection(const CaptureData &capture, const QRectF &selection) {
   const QRectF bounded = selection.normalized().intersected(
-      QRectF(QPointF(), capture.preview.size()));
+      QRectF(QPointF(), capture.previewSize));
   const qreal scaleX =
-      capture.source.width() / static_cast<qreal>(capture.preview.width());
-  const qreal scaleY =
-      capture.source.height() / static_cast<qreal>(capture.preview.height());
+      capture.source.width() / static_cast<qreal>(capture.previewSize.width());
+  const qreal scaleY = capture.source.height() /
+                       static_cast<qreal>(capture.previewSize.height());
   const int left =
       std::clamp(static_cast<int>(std::floor(bounded.left() * scaleX)), 0,
                  capture.source.width());
@@ -770,12 +770,7 @@ bool captureFocusedMonitor(CaptureData &capture, bool includeWindows,
     return false;
   }
 
-  capture.preview = capture.source.scaled(
-      geometry.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-  if (capture.preview.isNull()) {
-    error = QStringLiteral("Could not prepare screenshot preview");
-    return false;
-  }
+  capture.previewSize = geometry.size();
 
   if (includeWindows) {
     if (!clients.waitForFinished(10000))
@@ -797,9 +792,9 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   QImage cropped = capture.source.copy(pixels).convertToFormat(
       QImage::Format_ARGB32_Premultiplied);
   const qreal sourceScaleX =
-      capture.source.width() / static_cast<qreal>(capture.preview.width());
-  const qreal sourceScaleY =
-      capture.source.height() / static_cast<qreal>(capture.preview.height());
+      capture.source.width() / static_cast<qreal>(capture.previewSize.width());
+  const qreal sourceScaleY = capture.source.height() /
+                             static_cast<qreal>(capture.previewSize.height());
   const bool highDpi = capture.monitor.scale > 1.0;
   const qreal scaleX = highDpi ? capture.monitor.scale : sourceScaleX;
   const qreal scaleY = highDpi ? capture.monitor.scale : sourceScaleY;

--- a/capture.cpp
+++ b/capture.cpp
@@ -970,7 +970,8 @@ void prunePinnedSnapshots() {
   }
 }
 
-bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
+bool saveTemporarySnapshot(const QImage &image, QString path, QString &error,
+                           SnapshotEncoding encoding) {
   if (image.isNull()) {
     error = QStringLiteral("Temporary snapshot is empty");
     return false;
@@ -998,7 +999,11 @@ bool saveTemporarySnapshot(const QImage &image, QString path, QString &error) {
     return false;
   }
 
-  if (!image.save(&file, "PNG")) {
+  // Qt maps PNG "quality" onto the inverse zlib level, so 80 asks for level 1:
+  // roughly a third off the encode time for a snapshot the editor overwrites
+  // on the next edit anyway.
+  const int quality = encoding == SnapshotEncoding::Fast ? 80 : -1;
+  if (!image.save(&file, "PNG", quality)) {
     file.cancelWriting();
     error = QStringLiteral("Could not save temporary snapshot: %1").arg(path);
     return false;

--- a/capture.hpp
+++ b/capture.hpp
@@ -42,6 +42,12 @@ enum class QuickOutputMode { None, Copy, Save, Both };
 enum class SpotlightShape { Ellipse, Rectangle, RoundedRectangle };
 enum class RedactionStyle { Solid, Pixelate };
 
+/** How much zlib effort a snapshot write spends. Working snapshots are
+ *  crash-recovery files on tmpfs that every edit rewrites, so they use Fast.
+ *  Anything the user keeps — the saved screenshot, a pinned capture — uses
+ *  Default so the file stays small. */
+enum class SnapshotEncoding { Default, Fast };
+
 struct Annotation {
   enum class Kind {
     Arrow,
@@ -105,8 +111,9 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
 [[nodiscard]] QString temporarySnapshotPath();
 [[nodiscard]] QString pinnedSnapshotPath(int index);
 void prunePinnedSnapshots();
-[[nodiscard]] bool saveTemporarySnapshot(const QImage &image, QString path,
-                                         QString &error);
+[[nodiscard]] bool saveTemporarySnapshot(
+    const QImage &image, QString path, QString &error,
+    SnapshotEncoding encoding = SnapshotEncoding::Default);
 [[nodiscard]] QString recognizeText(const QImage &image, QString &error);
 void sendCaptureNotification(const QString &message,
                              const QString &imagePath = {});

--- a/capture.hpp
+++ b/capture.hpp
@@ -31,7 +31,8 @@ struct WindowTarget {
 struct CaptureData {
   MonitorInfo monitor;
   QImage source;
-  QImage preview;
+  /** Logical size the source is presented at; source pixels stay native. */
+  QSize previewSize;
   QVector<WindowTarget> windows;
 };
 

--- a/capture.hpp
+++ b/capture.hpp
@@ -72,7 +72,9 @@ struct Annotation {
 
 [[nodiscard]] bool loadCaptureFonts();
 [[nodiscard]] QFont annotationTextFont(qreal size);
-[[nodiscard]] bool captureFocusedMonitor(CaptureData &capture, QString &error);
+/** Captures the focused monitor; window discovery runs only when requested. */
+[[nodiscard]] bool captureFocusedMonitor(CaptureData &capture,
+                                         bool includeWindows, QString &error);
 [[nodiscard]] bool captureWindowSurface(const WindowTarget &window,
                                         QImage &image, QString &error);
 /** Returns an upright image for captured Wayland buffer contents. */

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -12,10 +12,12 @@
 #include <QApplication>
 #include <QDebug>
 #include <QDir>
+#include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
 #include <QFontMetricsF>
 #include <QPainter>
+#include <QPixmap>
 #include <QTemporaryDir>
 #include <QUrl>
 #include <QWheelEvent>
@@ -23,11 +25,183 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
+#include <cstdlib>
 #include <numbers>
 #include <csignal>
 #include <sys/resource.h>
 
 namespace {
+/** The cached backdrop must still show the capture inside the selection and
+ *  the dimmed capture outside it. */
+bool runBackdropCacheRenderingCheck(const CaptureData &capture,
+                                    QString &error) {
+  if (capture.source.size() != QSize(800, 600) ||
+      capture.previewSize != capture.source.size()) {
+    error =
+        QStringLiteral("Backdrop check expects an unscaled 800x600 capture");
+    return false;
+  }
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  QApplication::processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(150, 120));
+  QTest::mouseMove(&editor, QPoint(600, 430), 20);
+  QApplication::processEvents();
+  const QImage ui = editor.grab().toImage();
+
+  for (const QPoint &inside : {QPoint(300, 250), QPoint(500, 400)}) {
+    if (ui.pixelColor(inside) != capture.source.pixelColor(inside)) {
+      error = QStringLiteral("Selection preview no longer matches the capture");
+      return false;
+    }
+  }
+  // Outside the selection the capture stays visible under a 143/255 black
+  // wash, exactly as the per-frame resample used to draw it.
+  for (const QPoint &outside : {QPoint(40, 40), QPoint(720, 540)}) {
+    const QColor source = capture.source.pixelColor(outside);
+    const QColor dimmed = ui.pixelColor(outside);
+    const auto matches = [](int actual, int expected) {
+      return std::abs(actual - expected) <= 2;
+    };
+    if (!matches(dimmed.red(), source.red() * (255 - 143) / 255) ||
+        !matches(dimmed.green(), source.green() * (255 - 143) / 255) ||
+        !matches(dimmed.blue(), source.blue() * (255 - 143) / 255)) {
+      error = QStringLiteral("Dimmed backdrop brightness changed");
+      return false;
+    }
+  }
+  editor.close();
+  return true;
+}
+
+/** The cached canvas crop must switch to the redacted preview the moment a
+ *  redaction exists, and keep showing untouched pixels elsewhere. */
+bool runRedactedCropCacheCheck(QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  {
+    QPainter painter(&capture.source);
+    painter.fillRect(QRect(200, 200, 100, 60),
+                     QColor(QStringLiteral("#ff0000")));
+  }
+  capture.previewSize = capture.source.size();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  QApplication::processEvents();
+  // Selecting 100,100 to 650,470 draws the capture unscaled at 125,120, so the
+  // secret patch covers 225,220 to 325,280 in widget coordinates.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(650, 470), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(650, 470));
+  QApplication::processEvents();
+
+  const auto isSecret = [](const QColor &color) {
+    return color.red() > 180 && color.green() < 70 && color.blue() < 70;
+  };
+  if (!isSecret(editor.grab().toImage().pixelColor(QPoint(275, 250)))) {
+    error = QStringLiteral("Cached canvas crop did not show the capture");
+    return false;
+  }
+
+  // D selects the redact tool, D again switches it to solid.
+  QTest::keyClick(&editor, Qt::Key_D);
+  QTest::keyClick(&editor, Qt::Key_D);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(215, 210));
+  QTest::mouseMove(&editor, QPoint(335, 290), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(335, 290));
+  QApplication::processEvents();
+  const QImage redactedUi = editor.grab().toImage();
+  if (isSecret(redactedUi.pixelColor(QPoint(275, 250)))) {
+    error = QStringLiteral("Cached canvas crop leaked redacted pixels");
+    return false;
+  }
+  if (redactedUi.pixelColor(QPoint(500, 400)) !=
+      QColor(QStringLiteral("#182030"))) {
+    error = QStringLiteral("Redacted crop lost the surrounding capture");
+    return false;
+  }
+  editor.close();
+  return true;
+}
+
+/** Reports repaint and working-snapshot cost on a 5K capture. Enabled with
+ *  OMASNAP_SMOKE_BENCH=1; uses only public API so the same harness builds
+ *  against any revision of the editor. */
+void runEditorBenchmark() {
+  constexpr QSize nativeSize(5120, 2880);
+  constexpr QSize logicalSize(2560, 1440);
+  constexpr int frames = 20;
+
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("BENCH");
+  capture.monitor.geometry = {0, 0, logicalSize.width(), logicalSize.height()};
+  capture.monitor.pixelSize = nativeSize;
+  capture.monitor.scale = 2.0;
+  capture.source = QImage(nativeSize, QImage::Format_ARGB32_Premultiplied);
+  {
+    QPainter painter(&capture.source);
+    QLinearGradient gradient(0, 0, nativeSize.width(), nativeSize.height());
+    gradient.setColorAt(0, QColor(QStringLiteral("#172033")));
+    gradient.setColorAt(1, QColor(QStringLiteral("#5278b5")));
+    painter.fillRect(capture.source.rect(), gradient);
+  }
+  capture.previewSize = logicalSize;
+
+  CaptureEditor editor(capture);
+  editor.resize(logicalSize);
+  editor.show();
+  QApplication::processEvents();
+
+  QPixmap target(logicalSize);
+  const auto renderFrames = [&editor, &target] {
+    QElapsedTimer timer;
+    timer.start();
+    for (int frame = 0; frame < frames; ++frame)
+      editor.render(&target);
+    return timer.nsecsElapsed() / 1e6 / frames;
+  };
+
+  // Select phase, mid-drag: dimmed backdrop plus the bright selection.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 200));
+  QTest::mouseMove(&editor, QPoint(2300, 1300), 5);
+  QApplication::processEvents();
+  const double selectMs = renderFrames();
+
+  QElapsedTimer singleWrite;
+  singleWrite.start();
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(2300, 1300));
+  QApplication::processEvents();
+  const double enterEditMs = singleWrite.nsecsElapsed() / 1e6;
+
+  // Edit phase: the frozen crop plus annotation layers.
+  QTest::keyClick(&editor, Qt::Key_L);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(600, 500));
+  QTest::mouseMove(&editor, QPoint(1400, 900), 5);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(1400, 900));
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(1000, 700));
+  QApplication::processEvents();
+  const double editMs = renderFrames();
+
+  std::printf("bench.paint.select.ms_per_frame=%.2f\n", selectMs);
+  std::printf("bench.paint.edit.ms_per_frame=%.2f\n", editMs);
+  std::printf("bench.snapshot.single_write_ms=%.2f\n", enterEditMs);
+  std::fflush(stdout);
+}
+
 /** Checks that positional local image targets are recognized. */
 bool runPositionalImageTargetCheck(QString &error) {
   QTemporaryDir directory;
@@ -911,6 +1085,11 @@ int main(int argc, char **argv) {
                      .filePath(QStringLiteral("omasnap-native-smoke"));
   const QString snapshotPath = temporarySnapshotPath();
   QFile::remove(snapshotPath);
+  if (qEnvironmentVariableIsSet("OMASNAP_SMOKE_BENCH")) {
+    runEditorBenchmark();
+    QFile::remove(snapshotPath);
+    return 0;
+  }
   const QString savedRoot = QDir(outputRoot).filePath(QStringLiteral("saved"));
   QDir(savedRoot).removeRecursively();
   qputenv("OMASNAP_SCREENSHOT_DIR", savedRoot.toUtf8());
@@ -1790,6 +1969,16 @@ int main(int argc, char **argv) {
       qWarning().noquote() << clipboardError;
       return 64;
     }
+  }
+
+  QString previewError;
+  if (!runBackdropCacheRenderingCheck(capture, previewError)) {
+    qWarning().noquote() << previewError;
+    return 87;
+  }
+  if (!runRedactedCropCacheCheck(previewError)) {
+    qWarning().noquote() << previewError;
+    return 88;
   }
 
   QString transformError;

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -10,6 +10,7 @@
 #include "eyedropper.hpp"
 
 #include <QApplication>
+#include <QBuffer>
 #include <QDateTime>
 #include <QDebug>
 #include <QDir>
@@ -28,13 +29,64 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <functional>
 #include <numbers>
+#include <utility>
 #include <csignal>
 #include <sys/resource.h>
 
 namespace {
 // Comfortably longer than the editor's snapshot debounce window.
 constexpr int kSnapshotSettleMs = 400;
+// Working snapshots are debounced and then written off the GUI thread, so the
+// file lands some time after the edit. Every read below is bounded by this.
+constexpr int kSnapshotTimeoutMs = 5000;
+
+/** Pumps the event loop until the working snapshot satisfies `ready`, then
+ *  returns the last content read. On timeout it returns that same content so
+ *  the caller's own assertion reports the failure. */
+QImage awaitSnapshot(const QString &path,
+                     const std::function<bool(const QImage &)> &ready) {
+  QElapsedTimer timer;
+  timer.start();
+  QImage snapshot(path);
+  while (!ready(snapshot) && timer.elapsed() < kSnapshotTimeoutMs) {
+    QTest::qWait(10);
+    snapshot = QImage(path);
+  }
+  return snapshot;
+}
+
+/** Waits for the working snapshot to reach an expected image. */
+QImage awaitSnapshotMatch(const QString &path, const QImage &expected) {
+  return awaitSnapshot(path, [&expected](const QImage &snapshot) {
+    return !snapshot.isNull() &&
+           snapshot.convertToFormat(expected.format()) == expected;
+  });
+}
+
+/** Waits for the working snapshot to move on from a previous image. */
+QImage awaitSnapshotChange(const QString &path, const QImage &previous) {
+  return awaitSnapshot(path, [&previous](const QImage &snapshot) {
+    return !snapshot.isNull() && snapshot != previous;
+  });
+}
+
+/** Reads the working snapshot once no debounced or in-flight write can still
+ *  change it. For the few reads with no expected content to wait for. */
+QImage settledSnapshot(const QString &path) {
+  QElapsedTimer timer;
+  timer.start();
+  QImage snapshot(path);
+  while (timer.elapsed() < kSnapshotTimeoutMs) {
+    QTest::qWait(kSnapshotSettleMs);
+    const QImage next(path);
+    if (next == snapshot)
+      break;
+    snapshot = next;
+  }
+  return snapshot;
+}
 
 /** Sends one wheel notch to the editor, like a mouse scroll. */
 void sendWheelNotch(QWidget &editor, int direction) {
@@ -117,14 +169,10 @@ bool runSnapshotDebounceCheck(const CaptureData &capture,
   editor.show();
   QApplication::processEvents();
   prepareSelectedLine(editor);
-  if (!QFileInfo::exists(snapshotPath)) {
-    error = QStringLiteral("Selecting an area did not write a snapshot");
-    return false;
-  }
-  QTest::qWait(kSnapshotSettleMs);
-  const QImage beforeSingle(snapshotPath);
+  const QImage beforeSingle = awaitSnapshot(
+      snapshotPath, [](const QImage &snapshot) { return !snapshot.isNull(); });
   if (beforeSingle.isNull()) {
-    error = QStringLiteral("Working snapshot was unreadable");
+    error = QStringLiteral("Selecting an area did not write a snapshot");
     return false;
   }
 
@@ -133,8 +181,7 @@ bool runSnapshotDebounceCheck(const CaptureData &capture,
     error = QStringLiteral("Wheel scaling wrote its snapshot synchronously");
     return false;
   }
-  QTest::qWait(kSnapshotSettleMs);
-  const QImage afterSingle(snapshotPath);
+  const QImage afterSingle = awaitSnapshotChange(snapshotPath, beforeSingle);
   if (afterSingle.isNull() || afterSingle == beforeSingle) {
     error = QStringLiteral("Debounced snapshot never landed");
     return false;
@@ -146,8 +193,7 @@ bool runSnapshotDebounceCheck(const CaptureData &capture,
     error = QStringLiteral("Burst of edits was not coalesced");
     return false;
   }
-  QTest::qWait(kSnapshotSettleMs);
-  const QImage afterBurst(snapshotPath);
+  const QImage afterBurst = awaitSnapshotChange(snapshotPath, afterSingle);
   if (afterBurst.isNull() || afterBurst == afterSingle) {
     error = QStringLiteral("Coalesced snapshot never landed");
     return false;
@@ -167,6 +213,97 @@ bool runSnapshotDebounceCheck(const CaptureData &capture,
   }
   if (QImage(QDir(savedRoot).filePath(saved.constFirst())) != afterBurst) {
     error = QStringLiteral("Saved screenshot did not match the final state");
+    return false;
+  }
+  return true;
+}
+
+/** Working snapshots are written off the GUI thread, so they must land on
+ *  their own, the last edit must win no matter which worker started first, and
+ *  saving must flush ahead of everything still queued. */
+bool runAsyncSnapshotCheck(const CaptureData &capture,
+                           const QString &snapshotPath,
+                           const QString &savedRoot, QString &error) {
+  QFile::remove(snapshotPath);
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  QApplication::processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(650, 470), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(650, 470));
+  QApplication::processEvents();
+  // Entering the edit phase hands the write to the pool; it lands on its own.
+  if (awaitSnapshot(snapshotPath, [](const QImage &snapshot) {
+        return !snapshot.isNull();
+      }).isNull()) {
+    error = QStringLiteral("Entering the edit phase never wrote a snapshot");
+    return false;
+  }
+
+  // A rectangle writes immediately, and the backdrop cycles pile six more
+  // requests on top of that worker. Six cycles land back on Aurora.
+  QTest::keyClick(&editor, Qt::Key_R);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 220));
+  QTest::mouseMove(&editor, QPoint(420, 280), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(420, 280));
+  for (int cycle = 0; cycle < 6; ++cycle)
+    QTest::keyClick(&editor, Qt::Key_B);
+  QApplication::processEvents();
+
+  Annotation rectangle;
+  rectangle.kind = Annotation::Kind::Rectangle;
+  rectangle.start = {175, 100};
+  rectangle.end = {295, 160};
+  rectangle.color = QColor(QStringLiteral("#ff375f"));
+  rectangle.size = 4;
+  const QImage expected = renderCapture(capture, QRectF(100, 100, 550, 370),
+                                        {rectangle}, BackgroundStyle::Aurora);
+  if (settledSnapshot(snapshotPath).convertToFormat(expected.format()) !=
+      expected) {
+    error = QStringLiteral("A stale write outlived the last edit");
+    return false;
+  }
+
+  const QStringList before =
+      QDir(savedRoot).entryList({QStringLiteral("*.png")}, QDir::Files);
+  QTest::keyClick(&editor, Qt::Key_S, Qt::ControlModifier);
+  QApplication::processEvents();
+  QStringList saved =
+      QDir(savedRoot).entryList({QStringLiteral("*.png")}, QDir::Files);
+  for (const QString &existing : before)
+    saved.removeAll(existing);
+  if (editor.isVisible() || saved.size() != 1) {
+    error = QStringLiteral("Saving after async edits produced no file");
+    return false;
+  }
+  const QString savedPath = QDir(savedRoot).filePath(saved.constFirst());
+  if (QImage(savedPath).convertToFormat(expected.format()) != expected) {
+    error = QStringLiteral("Saved screenshot did not match a fresh render");
+    return false;
+  }
+  QTest::qWait(kSnapshotSettleMs);
+  if (QFileInfo::exists(snapshotPath)) {
+    error = QStringLiteral("A late write recreated the moved working snapshot");
+    return false;
+  }
+
+  // Saving hands the working snapshot itself to the user, so it must carry the
+  // default compression rather than the fast one the editor writes with.
+  QByteArray reference;
+  QBuffer buffer(&reference);
+  if (!buffer.open(QIODevice::WriteOnly) || !expected.save(&buffer, "PNG")) {
+    error = QStringLiteral("Could not encode the reference screenshot");
+    return false;
+  }
+  const qint64 savedSize = QFileInfo(savedPath).size();
+  if (savedSize <= 0 || savedSize * 2 > reference.size() * 3) {
+    error = QStringLiteral("Saved screenshot is %1 bytes against a %2 byte "
+                           "default-compressed reference")
+                .arg(savedSize)
+                .arg(reference.size());
     return false;
   }
   return true;
@@ -315,12 +452,48 @@ void runEditorBenchmark(const QString &snapshotPath) {
   QTest::qWait(kSnapshotSettleMs);
   const int settledWrites = snapshotStamp() != stamp ? 1 : 0;
 
+  // Ctrl+A is the harshest case: select-all enters the edit phase and persists
+  // the whole 5K capture in one go. This is the time the GUI thread is gone.
+  CaptureEditor selectAllEditor(capture);
+  selectAllEditor.resize(logicalSize);
+  selectAllEditor.show();
+  QApplication::processEvents();
+  QElapsedTimer selectAll;
+  selectAll.start();
+  QTest::keyClick(&selectAllEditor, Qt::Key_A, Qt::ControlModifier);
+  const double selectAllMs = selectAll.nsecsElapsed() / 1e6;
+
+  // Encoding cost of that same snapshot, fast versus default compression.
+  const QImage fullFrame = renderCapture(
+      capture, QRectF(QPointF(), logicalSize), {}, BackgroundStyle::None);
+  const auto encode = [&fullFrame](int quality) {
+    QByteArray payload;
+    QBuffer buffer(&payload);
+    if (!buffer.open(QIODevice::WriteOnly))
+      return std::pair<double, qint64>(0.0, 0);
+    QElapsedTimer timer;
+    timer.start();
+    const bool saved = fullFrame.save(&buffer, "PNG", quality);
+    const double ms = timer.nsecsElapsed() / 1e6;
+    return std::pair<double, qint64>(ms, saved ? payload.size() : 0);
+  };
+  const auto defaultEncode = encode(-1);
+  const auto fastEncode = encode(80);
+  QTest::qWait(kSnapshotSettleMs);
+
   std::printf("bench.paint.select.ms_per_frame=%.2f\n", selectMs);
   std::printf("bench.paint.edit.ms_per_frame=%.2f\n", editMs);
   std::printf("bench.snapshot.single_write_ms=%.2f\n", enterEditMs);
+  std::printf("bench.snapshot.select_all_enter_edit_ms=%.2f\n", selectAllMs);
   std::printf("bench.snapshot.burst_writes=%d\n", burstWrites);
   std::printf("bench.snapshot.burst_ms=%.2f\n", burstMs);
   std::printf("bench.snapshot.writes_after_settle=%d\n", settledWrites);
+  std::printf("bench.encode.default_ms=%.2f\n", defaultEncode.first);
+  std::printf("bench.encode.default_bytes=%lld\n",
+              static_cast<long long>(defaultEncode.second));
+  std::printf("bench.encode.fast_ms=%.2f\n", fastEncode.first);
+  std::printf("bench.encode.fast_bytes=%lld\n",
+              static_cast<long long>(fastEncode.second));
   std::fflush(stdout);
 }
 
@@ -383,6 +556,17 @@ bool runTemporarySnapshotChecks(QString &error) {
     return false;
   }
 
+  // Every working-snapshot write uses the fast encoding: cheaper, and just as
+  // lossless as the default one.
+  QImage fastImage(64, 64, QImage::Format_ARGB32_Premultiplied);
+  fastImage.fill(QColor(QStringLiteral("#0fa1c3")));
+  if (!saveTemporarySnapshot(fastImage, path, error, SnapshotEncoding::Fast))
+    return false;
+  if (reload(path) != fastImage) {
+    error = QStringLiteral("Fast-encoded snapshot did not round-trip");
+    return false;
+  }
+
   QImage secondImage(64, 64, QImage::Format_ARGB32_Premultiplied);
   secondImage.fill(QColor(QStringLiteral("#654321")));
   if (!saveTemporarySnapshot(secondImage, path, error))
@@ -411,6 +595,8 @@ bool runTemporarySnapshotChecks(QString &error) {
     }
   }
 
+  // The file-size limit below is process-wide, so this check runs before any
+  // editor exists: an editor's snapshot worker would fail its write too.
   struct rlimit originalLimit{};
   struct sigaction originalSignal{};
   struct sigaction ignoredSignal{};
@@ -942,7 +1128,8 @@ bool runTextClickAwayCommitCheck(QApplication &application, QString &error) {
   };
   const auto snapshotMatches = [&snapshotPath](const QImage &expected) {
     return !expected.isNull() &&
-           QImage(snapshotPath).convertToFormat(expected.format()) == expected;
+           awaitSnapshotMatch(snapshotPath, expected)
+                   .convertToFormat(expected.format()) == expected;
   };
 
   CaptureEditor editor(capture);
@@ -1295,15 +1482,16 @@ int main(int argc, char **argv) {
 
     dragRectangle(true);
     const QImage freeExpected = expectedRectangle(QPointF(295, 160));
-    if (QImage(snapshotPath).convertToFormat(freeExpected.format()) !=
-        freeExpected)
+    if (awaitSnapshotMatch(snapshotPath, freeExpected)
+            .convertToFormat(freeExpected.format()) != freeExpected)
       return 91;
     QTest::keyClick(&constraintEditor, Qt::Key_Z, Qt::ControlModifier);
     application.processEvents();
 
     dragRectangle(false);
     const QImage constrainedExpected = expectedRectangle(QPointF(295, 220));
-    if (QImage(snapshotPath).convertToFormat(constrainedExpected.format()) !=
+    if (awaitSnapshotMatch(snapshotPath, constrainedExpected)
+            .convertToFormat(constrainedExpected.format()) !=
         constrainedExpected)
       return 92;
     constraintEditor.close();
@@ -1354,7 +1542,10 @@ int main(int argc, char **argv) {
     QTest::mouseRelease(&cropEditor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(0, leftHandle.y()));
     application.processEvents();
-    const QImage cropped(snapshotPath);
+    const QImage cropped =
+        awaitSnapshot(snapshotPath, [](const QImage &snapshot) {
+          return !snapshot.isNull() && snapshot.width() < 64;
+        });
     if (cropped.isNull() || cropped.width() < 16 || cropped.width() > 64 ||
         cropped.height() != 64)
       return 93;
@@ -1387,8 +1578,9 @@ int main(int argc, char **argv) {
   QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(650, 470));
   application.processEvents();
+  const QImage initialSnapshot = awaitSnapshot(
+      snapshotPath, [](const QImage &snapshot) { return !snapshot.isNull(); });
   const QFileInfo initialSnapshotInfo(snapshotPath);
-  const QImage initialSnapshot(snapshotPath);
   if (!initialSnapshotInfo.exists() || initialSnapshotInfo.size() <= 0 ||
       initialSnapshot.isNull())
     return 37;
@@ -1409,7 +1601,8 @@ int main(int argc, char **argv) {
   application.processEvents();
   if (editor.cursor().shape() != Qt::CrossCursor)
     return 26;
-  const QImage arrowSnapshot(snapshotPath);
+  const QImage arrowSnapshot =
+      awaitSnapshotChange(snapshotPath, initialSnapshot);
   if (arrowSnapshot.isNull() || arrowSnapshot == initialSnapshot)
     return 38;
   QTest::mouseClick(&editor, Qt::RightButton, Qt::NoModifier, QPoint(100, 100));
@@ -1423,17 +1616,17 @@ int main(int argc, char **argv) {
   QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(420, 315));
   application.processEvents();
-  if (QImage(snapshotPath) != initialSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, initialSnapshot) != initialSnapshot)
     return 56;
   QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
   application.processEvents();
-  if (QImage(snapshotPath) != arrowSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, arrowSnapshot) != arrowSnapshot)
     return 57;
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(140, 140));
   application.processEvents();
   QTest::keyClick(&editor, Qt::Key_Delete);
   application.processEvents();
-  if (QImage(snapshotPath) != arrowSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, arrowSnapshot) != arrowSnapshot)
     return 39;
   QTest::keyClick(&editor, Qt::Key_L);
   QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(260, 210));
@@ -1443,16 +1636,16 @@ int main(int argc, char **argv) {
   application.processEvents();
   if (editor.cursor().shape() != Qt::CrossCursor)
     return 27;
-  const QImage lineSnapshot(snapshotPath);
+  const QImage lineSnapshot = awaitSnapshotChange(snapshotPath, arrowSnapshot);
   if (lineSnapshot.isNull() || lineSnapshot == arrowSnapshot)
     return 40;
   QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
   application.processEvents();
-  if (QImage(snapshotPath) != arrowSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, arrowSnapshot) != arrowSnapshot)
     return 41;
   QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier | Qt::ShiftModifier);
   application.processEvents();
-  if (QImage(snapshotPath) != lineSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, lineSnapshot) != lineSnapshot)
     return 42;
 
   QTest::keyClick(&editor, Qt::Key_V);
@@ -1483,17 +1676,18 @@ int main(int argc, char **argv) {
   if (beforeSelectorZoom == afterSelectorZoom)
     return 30;
   // Wheel scaling debounces its working-snapshot write.
-  QTest::qWait(kSnapshotSettleMs);
-  const QImage scaledLineSnapshot(snapshotPath);
+  const QImage scaledLineSnapshot =
+      awaitSnapshotChange(snapshotPath, lineSnapshot);
   if (scaledLineSnapshot.isNull() || scaledLineSnapshot == lineSnapshot)
     return 45;
   QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
   application.processEvents();
-  if (QImage(snapshotPath) != lineSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, lineSnapshot) != lineSnapshot)
     return 46;
   QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier | Qt::ShiftModifier);
   application.processEvents();
-  if (QImage(snapshotPath) != scaledLineSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, scaledLineSnapshot) !=
+      scaledLineSnapshot)
     return 47;
   const QImage beforeFreehandSnapshot(snapshotPath);
   QTest::keyClick(&editor, Qt::Key_F);
@@ -1505,7 +1699,8 @@ int main(int argc, char **argv) {
                       QPoint(530, 420));
   application.processEvents();
   if (editor.cursor().shape() != Qt::CrossCursor ||
-      QImage(snapshotPath) == beforeFreehandSnapshot)
+      awaitSnapshotChange(snapshotPath, beforeFreehandSnapshot) ==
+          beforeFreehandSnapshot)
     return 28;
   const QImage beforeMarkerSnapshot(snapshotPath);
   QTest::keyClick(&editor, Qt::Key_2);
@@ -1513,7 +1708,8 @@ int main(int argc, char **argv) {
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(470, 300));
   application.processEvents();
   if (editor.cursor().shape() != Qt::PointingHandCursor ||
-      QImage(snapshotPath) == beforeMarkerSnapshot)
+      awaitSnapshotChange(snapshotPath, beforeMarkerSnapshot) ==
+          beforeMarkerSnapshot)
     return 48;
   const QImage beforeTextSnapshot(snapshotPath);
   QTest::keyClick(&editor, Qt::Key_T);
@@ -1537,7 +1733,8 @@ int main(int argc, char **argv) {
   application.processEvents();
   if (!editor.grab().save(outputRoot + QStringLiteral("-text-committed.png"),
                           "PNG") ||
-      QImage(snapshotPath) == beforeTextSnapshot)
+      awaitSnapshotChange(snapshotPath, beforeTextSnapshot) ==
+          beforeTextSnapshot)
     return 20;
   const QImage beforeMoveSnapshot(snapshotPath);
   QTest::keyClick(&editor, Qt::Key_V);
@@ -1546,16 +1743,18 @@ int main(int argc, char **argv) {
   QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(420, 315));
   application.processEvents();
-  const QImage movedSnapshot(snapshotPath);
+  const QImage movedSnapshot =
+      awaitSnapshotChange(snapshotPath, beforeMoveSnapshot);
   if (movedSnapshot.isNull() || movedSnapshot == beforeMoveSnapshot)
     return 49;
   QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
   application.processEvents();
-  if (QImage(snapshotPath) != beforeMoveSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, beforeMoveSnapshot) !=
+      beforeMoveSnapshot)
     return 50;
   QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
   application.processEvents();
-  if (QImage(snapshotPath) != movedSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, movedSnapshot) != movedSnapshot)
     return 51;
   const QImage beforeEndpointSnapshot(snapshotPath);
   QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(590, 365));
@@ -1563,16 +1762,18 @@ int main(int argc, char **argv) {
   QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(620, 380));
   application.processEvents();
-  const QImage resizedSnapshot(snapshotPath);
+  const QImage resizedSnapshot =
+      awaitSnapshotChange(snapshotPath, beforeEndpointSnapshot);
   if (resizedSnapshot.isNull() || resizedSnapshot == beforeEndpointSnapshot)
     return 52;
   QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
   application.processEvents();
-  if (QImage(snapshotPath) != beforeEndpointSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, beforeEndpointSnapshot) !=
+      beforeEndpointSnapshot)
     return 53;
   QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
   application.processEvents();
-  if (QImage(snapshotPath) != resizedSnapshot)
+  if (awaitSnapshotMatch(snapshotPath, resizedSnapshot) != resizedSnapshot)
     return 54;
   if (!editor.grab().save(outputRoot + QStringLiteral("-vector-selected.png"),
                           "PNG"))
@@ -1586,11 +1787,13 @@ int main(int argc, char **argv) {
   } else {
     return 22;
   }
-  const QImage beforeBackdropSnapshot(snapshotPath);
+  // The committed text edit writes before the backdrop is touched.
+  const QImage beforeBackdropSnapshot =
+      awaitSnapshotChange(snapshotPath, resizedSnapshot);
   QTest::keyClick(&editor, Qt::Key_B);
   // Backdrop cycling debounces its working-snapshot write.
-  QTest::qWait(kSnapshotSettleMs);
-  if (QImage(snapshotPath) == beforeBackdropSnapshot)
+  if (awaitSnapshotChange(snapshotPath, beforeBackdropSnapshot) ==
+      beforeBackdropSnapshot)
     return 55;
   // Palette toolbar button (index 8 after Highlighter was inserted).
   QTest::mouseMove(&editor, QPoint(398, 92), 20);
@@ -1623,7 +1826,11 @@ int main(int argc, char **argv) {
     QTest::mouseMove(&redactionEditor, QPoint(650, 470), 20);
     QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(650, 470));
-    const QImage beforeRedaction(snapshotPath);
+    // Both editors write to the same working snapshot, so wait for the new
+    // one's plain crop instead of assuming the file already moved on.
+    const QImage beforeRedaction = awaitSnapshotMatch(
+        snapshotPath, renderCapture(capture, QRectF(100, 100, 550, 370), {},
+                                    BackgroundStyle::None));
     QTest::keyClick(&redactionEditor, Qt::Key_D);
     QTest::mousePress(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(300, 200));
@@ -1631,7 +1838,7 @@ int main(int argc, char **argv) {
     QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(420, 200));
     application.processEvents();
-    if (QImage(snapshotPath) != beforeRedaction)
+    if (awaitSnapshotMatch(snapshotPath, beforeRedaction) != beforeRedaction)
       return 72;
     QTest::mousePress(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(300, 200));
@@ -1639,7 +1846,8 @@ int main(int argc, char **argv) {
     QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(420, 260));
     application.processEvents();
-    const QImage pixelatedRedaction(snapshotPath);
+    const QImage pixelatedRedaction =
+        awaitSnapshotChange(snapshotPath, beforeRedaction);
     if (pixelatedRedaction.isNull() || pixelatedRedaction == beforeRedaction)
       return 73;
 
@@ -1648,17 +1856,18 @@ int main(int argc, char **argv) {
                       QPoint(360, 230));
     QTest::keyClick(&redactionEditor, Qt::Key_D);
     // Redaction style toggling debounces its working-snapshot write.
-    QTest::qWait(kSnapshotSettleMs);
-    const QImage solidRedaction(snapshotPath);
+    const QImage solidRedaction =
+        awaitSnapshotChange(snapshotPath, pixelatedRedaction);
     if (solidRedaction.isNull() || solidRedaction == pixelatedRedaction)
       return 74;
     QTest::keyClick(&redactionEditor, Qt::Key_Z, Qt::ControlModifier);
     application.processEvents();
-    if (QImage(snapshotPath) != pixelatedRedaction)
+    if (awaitSnapshotMatch(snapshotPath, pixelatedRedaction) !=
+        pixelatedRedaction)
       return 75;
     QTest::keyClick(&redactionEditor, Qt::Key_Y, Qt::ControlModifier);
     application.processEvents();
-    if (QImage(snapshotPath) != solidRedaction)
+    if (awaitSnapshotMatch(snapshotPath, solidRedaction) != solidRedaction)
       return 76;
 
     QTest::mousePress(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
@@ -1667,12 +1876,13 @@ int main(int argc, char **argv) {
     QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(380, 245));
     application.processEvents();
-    const QImage movedRedaction(snapshotPath);
+    const QImage movedRedaction =
+        awaitSnapshotChange(snapshotPath, solidRedaction);
     if (movedRedaction.isNull() || movedRedaction == solidRedaction)
       return 77;
     QTest::keyClick(&redactionEditor, Qt::Key_Z, Qt::ControlModifier);
     application.processEvents();
-    if (QImage(snapshotPath) != solidRedaction)
+    if (awaitSnapshotMatch(snapshotPath, solidRedaction) != solidRedaction)
       return 78;
 
     QTest::keyClick(&redactionEditor, Qt::Key_D);
@@ -1682,7 +1892,7 @@ int main(int argc, char **argv) {
     QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(280, 190));
     application.processEvents();
-    if (QImage(snapshotPath) == solidRedaction ||
+    if (awaitSnapshotChange(snapshotPath, solidRedaction) == solidRedaction ||
         !redactionEditor.grab().save(
             outputRoot + QStringLiteral("-secure-redaction.png"), "PNG"))
       return 79;
@@ -1692,7 +1902,7 @@ int main(int argc, char **argv) {
     QTest::mouseRelease(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(420, 190));
     application.processEvents();
-    if (QImage(snapshotPath) == beforeRedaction)
+    if (awaitSnapshotChange(snapshotPath, beforeRedaction) == beforeRedaction)
       return 81;
   }
 
@@ -2077,7 +2287,7 @@ int main(int argc, char **argv) {
     QTest::mouseClick(&finishEditor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(470, 300));
     application.processEvents();
-    const QImage snapshotBeforeSave(snapshotPath);
+    const QImage snapshotBeforeSave = settledSnapshot(snapshotPath);
     if (snapshotBeforeSave.isNull())
       return 59;
     QTest::keyClick(&finishEditor, Qt::Key_S, Qt::ControlModifier);
@@ -2115,6 +2325,10 @@ int main(int argc, char **argv) {
                                 previewError)) {
     qWarning().noquote() << previewError;
     return 89;
+  }
+  if (!runAsyncSnapshotCheck(capture, snapshotPath, savedRoot, previewError)) {
+    qWarning().noquote() << previewError;
+    return 98;
   }
 
   QString transformError;

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -557,6 +557,70 @@ bool runSpotlightAndSampleChecks(QString &error) {
   return true;
 }
 
+/** Checks that the live preview magnifies redacted pixels, never the source. */
+bool runSpotlightRedactionPreviewCheck(QApplication &application,
+                                       QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  {
+    QPainter painter(&capture.source);
+    painter.fillRect(QRect(200, 200, 100, 60),
+                     QColor(QStringLiteral("#ff0000")));
+  }
+  capture.preview = capture.source;
+
+  // Selecting 100,100 to 650,470 draws the capture unscaled at 125,120, so the
+  // secret patch covers 225,220 to 325,280 in widget coordinates.
+  const auto spotlightCenterColor = [&](bool redact) {
+    CaptureEditor editor(capture);
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+    QTest::mouseMove(&editor, QPoint(650, 470), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(650, 470));
+    application.processEvents();
+    if (redact) {
+      QTest::keyClick(&editor, Qt::Key_D);
+      QTest::keyClick(&editor, Qt::Key_D);
+      QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(215, 210));
+      QTest::mouseMove(&editor, QPoint(335, 290), 20);
+      QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                          QPoint(335, 290));
+      application.processEvents();
+    }
+    QTest::keyClick(&editor, Qt::Key_S);
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(245, 230));
+    QTest::mouseMove(&editor, QPoint(305, 270), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(305, 270));
+    application.processEvents();
+    const QColor color = editor.grab().toImage().pixelColor(QPoint(275, 250));
+    editor.close();
+    return color;
+  };
+
+  const auto showsSecret = [](const QColor &color) {
+    return color.red() > 180 && color.green() < 70 && color.blue() < 70;
+  };
+  if (!showsSecret(spotlightCenterColor(false))) {
+    error = QStringLiteral("Spotlight preview did not magnify the capture");
+    return false;
+  }
+  if (showsSecret(spotlightCenterColor(true))) {
+    error = QStringLiteral("Spotlight preview magnified un-redacted pixels");
+    return false;
+  }
+  return true;
+}
+
 bool runContinuousAnnotationToolsSmoke(QApplication &application,
                                        QString &error) {
   CaptureData capture;
@@ -746,6 +810,10 @@ int main(int argc, char **argv) {
   if (!runSpotlightAndSampleChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 79;
+  }
+  if (!runSpotlightRedactionPreviewCheck(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 86;
   }
   if (!runContinuousAnnotationToolsSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -10,6 +10,7 @@
 #include "eyedropper.hpp"
 
 #include <QApplication>
+#include <QDateTime>
 #include <QDebug>
 #include <QDir>
 #include <QElapsedTimer>
@@ -32,6 +33,35 @@
 #include <sys/resource.h>
 
 namespace {
+// Comfortably longer than the editor's snapshot debounce window.
+constexpr int kSnapshotSettleMs = 400;
+
+/** Sends one wheel notch to the editor, like a mouse scroll. */
+void sendWheelNotch(QWidget &editor, int direction) {
+  QWheelEvent wheel(QPointF(400, 300), QPointF(400, 300), {},
+                    {0, 120 * direction}, Qt::NoButton, Qt::NoModifier,
+                    Qt::NoScrollPhase, false);
+  QApplication::sendEvent(&editor, &wheel);
+  QApplication::processEvents();
+}
+
+/** Selects a region, draws a line and selects that line for scaling. */
+void prepareSelectedLine(QWidget &editor) {
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(650, 470), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(650, 470));
+  QTest::keyClick(&editor, Qt::Key_L);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(260, 210));
+  QTest::mouseMove(&editor, QPoint(520, 265), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(520, 265));
+  // Annotation tools stay active, so return to Select before picking the line.
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(390, 238));
+  QApplication::processEvents();
+}
+
 /** The cached backdrop must still show the capture inside the selection and
  *  the dimmed capture outside it. */
 bool runBackdropCacheRenderingCheck(const CaptureData &capture,
@@ -73,6 +103,72 @@ bool runBackdropCacheRenderingCheck(const CaptureData &capture,
     }
   }
   editor.close();
+  return true;
+}
+
+/** Rapid edits must coalesce into one snapshot write that still lands, and
+ *  saving must output the final state. */
+bool runSnapshotDebounceCheck(const CaptureData &capture,
+                              const QString &snapshotPath,
+                              const QString &savedRoot, QString &error) {
+  QFile::remove(snapshotPath);
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  QApplication::processEvents();
+  prepareSelectedLine(editor);
+  if (!QFileInfo::exists(snapshotPath)) {
+    error = QStringLiteral("Selecting an area did not write a snapshot");
+    return false;
+  }
+  QTest::qWait(kSnapshotSettleMs);
+  const QImage beforeSingle(snapshotPath);
+  if (beforeSingle.isNull()) {
+    error = QStringLiteral("Working snapshot was unreadable");
+    return false;
+  }
+
+  sendWheelNotch(editor, 1);
+  if (QImage(snapshotPath) != beforeSingle) {
+    error = QStringLiteral("Wheel scaling wrote its snapshot synchronously");
+    return false;
+  }
+  QTest::qWait(kSnapshotSettleMs);
+  const QImage afterSingle(snapshotPath);
+  if (afterSingle.isNull() || afterSingle == beforeSingle) {
+    error = QStringLiteral("Debounced snapshot never landed");
+    return false;
+  }
+
+  for (int notch = 0; notch < 5; ++notch)
+    sendWheelNotch(editor, 1);
+  if (QImage(snapshotPath) != afterSingle) {
+    error = QStringLiteral("Burst of edits was not coalesced");
+    return false;
+  }
+  QTest::qWait(kSnapshotSettleMs);
+  const QImage afterBurst(snapshotPath);
+  if (afterBurst.isNull() || afterBurst == afterSingle) {
+    error = QStringLiteral("Coalesced snapshot never landed");
+    return false;
+  }
+
+  const QStringList before =
+      QDir(savedRoot).entryList({QStringLiteral("*.png")}, QDir::Files);
+  QTest::keyClick(&editor, Qt::Key_S, Qt::ControlModifier);
+  QApplication::processEvents();
+  QStringList saved =
+      QDir(savedRoot).entryList({QStringLiteral("*.png")}, QDir::Files);
+  for (const QString &existing : before)
+    saved.removeAll(existing);
+  if (editor.isVisible() || saved.size() != 1) {
+    error = QStringLiteral("Saving after a burst of edits produced no file");
+    return false;
+  }
+  if (QImage(QDir(savedRoot).filePath(saved.constFirst())) != afterBurst) {
+    error = QStringLiteral("Saved screenshot did not match the final state");
+    return false;
+  }
   return true;
 }
 
@@ -138,7 +234,7 @@ bool runRedactedCropCacheCheck(QString &error) {
 /** Reports repaint and working-snapshot cost on a 5K capture. Enabled with
  *  OMASNAP_SMOKE_BENCH=1; uses only public API so the same harness builds
  *  against any revision of the editor. */
-void runEditorBenchmark() {
+void runEditorBenchmark(const QString &snapshotPath) {
   constexpr QSize nativeSize(5120, 2880);
   constexpr QSize logicalSize(2560, 1440);
   constexpr int frames = 20;
@@ -196,9 +292,35 @@ void runEditorBenchmark() {
   QApplication::processEvents();
   const double editMs = renderFrames();
 
+  // Wheel-scaling burst: how many snapshot writes land, and at what cost.
+  const auto snapshotStamp = [&snapshotPath] {
+    const QFileInfo info(snapshotPath);
+    return QStringLiteral("%1/%2")
+        .arg(info.lastModified().toMSecsSinceEpoch())
+        .arg(info.size());
+  };
+  QString stamp = snapshotStamp();
+  int burstWrites = 0;
+  QElapsedTimer burst;
+  burst.start();
+  for (int notch = 0; notch < 10; ++notch) {
+    sendWheelNotch(editor, 1);
+    const QString current = snapshotStamp();
+    if (current != stamp) {
+      ++burstWrites;
+      stamp = current;
+    }
+  }
+  const double burstMs = burst.nsecsElapsed() / 1e6;
+  QTest::qWait(kSnapshotSettleMs);
+  const int settledWrites = snapshotStamp() != stamp ? 1 : 0;
+
   std::printf("bench.paint.select.ms_per_frame=%.2f\n", selectMs);
   std::printf("bench.paint.edit.ms_per_frame=%.2f\n", editMs);
   std::printf("bench.snapshot.single_write_ms=%.2f\n", enterEditMs);
+  std::printf("bench.snapshot.burst_writes=%d\n", burstWrites);
+  std::printf("bench.snapshot.burst_ms=%.2f\n", burstMs);
+  std::printf("bench.snapshot.writes_after_settle=%d\n", settledWrites);
   std::fflush(stdout);
 }
 
@@ -1086,7 +1208,7 @@ int main(int argc, char **argv) {
   const QString snapshotPath = temporarySnapshotPath();
   QFile::remove(snapshotPath);
   if (qEnvironmentVariableIsSet("OMASNAP_SMOKE_BENCH")) {
-    runEditorBenchmark();
+    runEditorBenchmark(snapshotPath);
     QFile::remove(snapshotPath);
     return 0;
   }
@@ -1360,6 +1482,8 @@ int main(int argc, char **argv) {
       editor.grab().toImage().copy(QRect(100, 150, 600, 350));
   if (beforeSelectorZoom == afterSelectorZoom)
     return 30;
+  // Wheel scaling debounces its working-snapshot write.
+  QTest::qWait(kSnapshotSettleMs);
   const QImage scaledLineSnapshot(snapshotPath);
   if (scaledLineSnapshot.isNull() || scaledLineSnapshot == lineSnapshot)
     return 45;
@@ -1464,7 +1588,8 @@ int main(int argc, char **argv) {
   }
   const QImage beforeBackdropSnapshot(snapshotPath);
   QTest::keyClick(&editor, Qt::Key_B);
-  application.processEvents();
+  // Backdrop cycling debounces its working-snapshot write.
+  QTest::qWait(kSnapshotSettleMs);
   if (QImage(snapshotPath) == beforeBackdropSnapshot)
     return 55;
   // Palette toolbar button (index 8 after Highlighter was inserted).
@@ -1475,6 +1600,8 @@ int main(int argc, char **argv) {
   // Custom color control in the open palette strip.
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(470, 134));
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(320, 200));
+  // Color picking debounces its write; land it before the next editor opens.
+  QTest::qWait(kSnapshotSettleMs);
   // Freehand toolbar button.
   QTest::mouseMove(&editor, QPoint(198, 92), 20);
   application.processEvents();
@@ -1520,7 +1647,8 @@ int main(int argc, char **argv) {
     QTest::mouseClick(&redactionEditor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(360, 230));
     QTest::keyClick(&redactionEditor, Qt::Key_D);
-    application.processEvents();
+    // Redaction style toggling debounces its working-snapshot write.
+    QTest::qWait(kSnapshotSettleMs);
     const QImage solidRedaction(snapshotPath);
     if (solidRedaction.isNull() || solidRedaction == pixelatedRedaction)
       return 74;
@@ -1782,7 +1910,10 @@ int main(int argc, char **argv) {
   QTest::mouseMove(&previewClipEditor, QPoint(500, 305), 20);
   QTest::mouseRelease(&previewClipEditor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(500, 305));
-  application.processEvents();
+  // Backdrop cycling above debounced a write, and this editor stays open for
+  // the rest of the run: land it now instead of during a later check, since
+  // every editor in this process shares one working-snapshot path.
+  QTest::qWait(kSnapshotSettleMs);
   const QImage clippedPreview = previewClipEditor.grab().toImage();
   for (int y = 270; y <= 330; ++y) {
     for (int x = 690; x <= 760; ++x) {
@@ -1979,6 +2110,11 @@ int main(int argc, char **argv) {
   if (!runRedactedCropCacheCheck(previewError)) {
     qWarning().noquote() << previewError;
     return 88;
+  }
+  if (!runSnapshotDebounceCheck(capture, snapshotPath, savedRoot,
+                                previewError)) {
+    qWarning().noquote() << previewError;
+    return 89;
   }
 
   QString transformError;

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -3,6 +3,7 @@
 #include "capture.hpp"
 #include "cli-path.hpp"
 #include "editor.hpp"
+#include "instance-lock-smoke.hpp"
 #include "pin-layout-smoke.hpp"
 #include "pin-lifecycle-smoke.hpp"
 #include "transform-smoke.hpp"
@@ -849,6 +850,12 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
 int main(int argc, char **argv) {
+  // Re-executed by the instance-lock checks as the process holding the lock.
+  const QString heldLockPath =
+      qEnvironmentVariable(kInstanceLockHolderVariable);
+  if (!heldLockPath.isEmpty())
+    return runInstanceLockHolder(heldLockPath);
+
   QApplication application(argc, argv);
   if (!loadCaptureFonts())
     return 17;
@@ -1793,6 +1800,11 @@ int main(int argc, char **argv) {
   if (!runTransformSmoke(transformError)) {
     qWarning().noquote() << transformError;
     return 67;
+  }
+  QString instanceError;
+  if (!runInstanceLockSmoke(instanceError)) {
+    qWarning().noquote() << instanceError;
+    return 85;
   }
   return 0;
 }

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -207,7 +207,7 @@ bool runHighlighterRenderingCheck(QString &error) {
   // white source would make every alpha check read 255.
   capture.source = QImage(200, 100, QImage::Format_ARGB32_Premultiplied);
   capture.source.fill(Qt::transparent);
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   Annotation highlight;
   highlight.kind = Annotation::Kind::Highlighter;
@@ -254,7 +254,7 @@ bool runSecureRedactionChecks(QString &error) {
           x, y, QColor((x * 3) % 256, (y * 5) % 256, ((x + y) * 7) % 256));
     }
   }
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   Annotation pixelate;
   pixelate.kind = Annotation::Kind::Redaction;
@@ -303,7 +303,7 @@ bool runSecureRedactionChecks(QString &error) {
           x, y, capture.source.pixelColor(capture.source.width() - x - 1, y));
     }
   }
-  mirroredCapture.preview = mirroredCapture.source;
+  mirroredCapture.previewSize = mirroredCapture.source.size();
   const QImage mirrored = renderCapture(mirroredCapture, QRectF(0, 0, 96, 72),
                                         {pixelate}, BackgroundStyle::None);
   if (first.copy(redactionBounds) != mirrored.copy(redactionBounds))
@@ -353,7 +353,7 @@ bool runSecureRedactionChecks(QString &error) {
   highDpi.monitor.pixelSize = {192, 144};
   highDpi.source = capture.source.scaled(192, 144, Qt::IgnoreAspectRatio,
                                          Qt::SmoothTransformation);
-  highDpi.preview = capture.source;
+  highDpi.previewSize = capture.source.size();
   Annotation highDpiSolid = solid;
   highDpiSolid.start = {10, 10};
   highDpiSolid.end = {30, 30};
@@ -370,8 +370,7 @@ bool runSecureRedactionChecks(QString &error) {
   // final mask through the resampling kernel.
   CaptureData fractional;
   fractional.monitor.scale = 1.25;
-  fractional.preview = QImage(100, 100, QImage::Format_RGB32);
-  fractional.preview.fill(Qt::white);
+  fractional.previewSize = QSize(100, 100);
   fractional.source = QImage(125, 125, QImage::Format_RGB32);
   fractional.source.fill(Qt::white);
   for (int y = 13; y <= 38; ++y) {
@@ -398,8 +397,7 @@ bool runSecureRedactionChecks(QString &error) {
 
   CaptureData matchingFractional;
   matchingFractional.monitor.scale = 1.25;
-  matchingFractional.preview = QImage(160, 160, QImage::Format_RGB32);
-  matchingFractional.preview.fill(Qt::white);
+  matchingFractional.previewSize = QSize(160, 160);
   matchingFractional.source = QImage(200, 200, QImage::Format_RGB32);
   matchingFractional.source.fill(Qt::white);
   for (int y = 13; y <= 26; ++y) {
@@ -420,8 +418,7 @@ bool runSecureRedactionChecks(QString &error) {
 
   CaptureData nonIntegralSourceScale;
   nonIntegralSourceScale.monitor.scale = 1.5;
-  nonIntegralSourceScale.preview = QImage(1707, 100, QImage::Format_RGB32);
-  nonIntegralSourceScale.preview.fill(Qt::white);
+  nonIntegralSourceScale.previewSize = QSize(1707, 100);
   nonIntegralSourceScale.source = QImage(2561, 150, QImage::Format_RGB32);
   nonIntegralSourceScale.source.fill(Qt::white);
   for (int y = 0; y < nonIntegralSourceScale.source.height(); ++y)
@@ -517,7 +514,7 @@ bool runSpotlightAndSampleChecks(QString &error) {
   capture.source = QImage(80, 40, QImage::Format_ARGB32_Premultiplied);
   capture.source.fill(QColor(QStringLiteral("#204080")));
   capture.source.setPixelColor(10, 20, QColor(QStringLiteral("#ff0000")));
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   Annotation line;
   line.kind = Annotation::Kind::Line;
@@ -574,7 +571,7 @@ bool runSpotlightRedactionPreviewCheck(QApplication &application,
     painter.fillRect(QRect(200, 200, 100, 60),
                      QColor(QStringLiteral("#ff0000")));
   }
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   // Selecting 100,100 to 650,470 draws the capture unscaled at 125,120, so the
   // secret patch covers 225,220 to 325,280 in widget coordinates.
@@ -632,7 +629,7 @@ bool runTextClickAwayCommitCheck(QApplication &application, QString &error) {
   capture.monitor.scale = 1.0;
   capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
   capture.source.fill(QColor(QStringLiteral("#182030")));
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   const QString snapshotPath = temporarySnapshotPath();
   const QRectF selection(100, 100, 550, 370);
@@ -709,7 +706,7 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
   capture.monitor.scale = 1.0;
   capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
   capture.source.fill(QColor(QStringLiteral("#182030")));
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
 
   CaptureEditor editor(capture);
   editor.resize(800, 600);
@@ -952,7 +949,7 @@ int main(int argc, char **argv) {
     painter.drawText(capture.source.rect(), Qt::AlignCenter,
                      QStringLiteral("Native Qt capture editor"));
   }
-  capture.preview = capture.source;
+  capture.previewSize = capture.source.size();
   capture.windows = {
       {{80, 80, 300, 220}, QStringLiteral("1"), QStringLiteral("first")},
       {{420, 120, 300, 320}, QStringLiteral("2"), QStringLiteral("second")}};
@@ -1037,7 +1034,7 @@ int main(int argc, char **argv) {
     cropCapture.monitor.pixelSize = {64, 64};
     cropCapture.source = QImage(64, 64, QImage::Format_ARGB32_Premultiplied);
     cropCapture.source.fill(QColor(QStringLiteral("#112233")));
-    cropCapture.preview = cropCapture.source;
+    cropCapture.previewSize = cropCapture.source.size();
     CaptureEditor cropEditor(cropCapture, CaptureEditor::CaptureMode::File);
     cropEditor.resize(800, 600);
     cropEditor.show();
@@ -1073,15 +1070,15 @@ int main(int argc, char **argv) {
   QTest::mouseMove(&editor, QPoint(200, 160), 20);
   application.processEvents();
   const QImage hoverUi = editor.grab().toImage();
-  if (hoverUi.pixelColor(200, 160) != capture.preview.pixelColor(200, 160))
+  if (hoverUi.pixelColor(200, 160) != capture.source.pixelColor(200, 160))
     return 7;
   QTest::keyClick(&editor, Qt::Key_Right, Qt::MetaModifier);
   application.processEvents();
   const QImage keyboardWindowUi = editor.grab().toImage();
   if (keyboardWindowUi.pixelColor(500, 200) !=
-          capture.preview.pixelColor(500, 200) ||
+          capture.source.pixelColor(500, 200) ||
       keyboardWindowUi.pixelColor(200, 160) ==
-          capture.preview.pixelColor(200, 160))
+          capture.source.pixelColor(200, 160))
     return 8;
   QTest::keyClick(&editor, Qt::Key_Space);
   QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
@@ -1492,8 +1489,7 @@ int main(int argc, char **argv) {
   nativePreviewCapture.monitor.pixelSize = {1600, 1200};
   nativePreviewCapture.source = QImage(1600, 1200, QImage::Format_RGB32);
   nativePreviewCapture.source.fill(QColor(QStringLiteral("#123456")));
-  nativePreviewCapture.preview = QImage(800, 600, QImage::Format_RGB32);
-  nativePreviewCapture.preview.fill(QColor(QStringLiteral("#ff00ff")));
+  nativePreviewCapture.previewSize = QSize(800, 600);
   CaptureEditor nativePreviewEditor(nativePreviewCapture,
                                     CaptureEditor::CaptureMode::Fullscreen);
   nativePreviewEditor.resize(800, 600);
@@ -1516,7 +1512,7 @@ int main(int argc, char **argv) {
   fileData.monitor.pixelSize = {300, 200};
   fileData.source = QImage(300, 200, QImage::Format_RGB32);
   fileData.source.fill(QColor(QStringLiteral("#1a2b3c")));
-  fileData.preview = fileData.source;
+  fileData.previewSize = fileData.source.size();
   CaptureEditor fileEditor(fileData, CaptureEditor::CaptureMode::File);
   fileEditor.resize(800, 600);
   fileEditor.show();
@@ -1533,7 +1529,7 @@ int main(int argc, char **argv) {
   windowSurfaceCapture.source =
       QImage(320, 180, QImage::Format_ARGB32_Premultiplied);
   windowSurfaceCapture.source.fill(QColor(QStringLiteral("#d12f45")));
-  windowSurfaceCapture.preview = windowSurfaceCapture.source;
+  windowSurfaceCapture.previewSize = windowSurfaceCapture.source.size();
   CaptureEditor windowSurfaceEditor(windowSurfaceCapture,
                                     CaptureEditor::CaptureMode::Fullscreen);
   windowSurfaceEditor.resize(800, 600);
@@ -1680,7 +1676,7 @@ int main(int argc, char **argv) {
   clippingCapture.monitor.scale = 1.0;
   clippingCapture.source = QImage(100, 100, QImage::Format_RGB32);
   clippingCapture.source.fill(Qt::white);
-  clippingCapture.preview = clippingCapture.source;
+  clippingCapture.previewSize = clippingCapture.source.size();
   Annotation croppedOut;
   croppedOut.kind = Annotation::Kind::Rectangle;
   croppedOut.start = {120, 20};

--- a/editor-smoke.cpp
+++ b/editor-smoke.cpp
@@ -13,6 +13,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QFontMetricsF>
 #include <QPainter>
 #include <QTemporaryDir>
 #include <QUrl>
@@ -621,6 +622,83 @@ bool runSpotlightRedactionPreviewCheck(QApplication &application,
   return true;
 }
 
+/** Checks that clicking away commits in-progress text instead of losing it. */
+bool runTextClickAwayCommitCheck(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.preview = capture.source;
+
+  const QString snapshotPath = temporarySnapshotPath();
+  const QRectF selection(100, 100, 550, 370);
+  const qreal ascent = QFontMetricsF(annotationTextFont(5.0)).ascent();
+  const auto textAnnotation = [&ascent](const QPointF &origin,
+                                        const QString &value) {
+    Annotation text;
+    text.kind = Annotation::Kind::Text;
+    text.start = origin + QPointF(0, ascent);
+    text.text = value;
+    text.color = QColor(QStringLiteral("#ff375f"));
+    text.size = 5.0;
+    return text;
+  };
+  const auto snapshotMatches = [&snapshotPath](const QImage &expected) {
+    return !expected.isNull() &&
+           QImage(snapshotPath).convertToFormat(expected.format()) == expected;
+  };
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(650, 470), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(650, 470));
+  application.processEvents();
+
+  QTest::keyClick(&editor, Qt::Key_T);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 220));
+  application.processEvents();
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(250, 400));
+  application.processEvents();
+  if (!snapshotMatches(
+          renderCapture(capture, selection, {}, BackgroundStyle::None))) {
+    error = QStringLiteral("Clicking away from empty text added an annotation");
+    return false;
+  }
+
+  const Annotation clicked =
+      textAnnotation({125, 280}, QStringLiteral("Clicked away"));
+  QTest::keyClicks(QApplication::focusWidget(), clicked.text);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(450, 300));
+  application.processEvents();
+  if (!snapshotMatches(
+          renderCapture(capture, selection, {clicked}, BackgroundStyle::None))) {
+    error = QStringLiteral("Clicking the canvas discarded in-progress text");
+    return false;
+  }
+
+  const Annotation toolbar =
+      textAnnotation({325, 180}, QStringLiteral("Toolbar"));
+  // 118,92 is the arrow tool button: the toolbar row sits above the capture.
+  QTest::keyClicks(QApplication::focusWidget(), toolbar.text);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(118, 92));
+  QTest::mouseMove(&editor, QPoint(400, 300), 10);
+  application.processEvents();
+  if (!snapshotMatches(renderCapture(capture, selection, {clicked, toolbar},
+                                     BackgroundStyle::None)) ||
+      editor.cursor().shape() != Qt::CrossCursor) {
+    error = QStringLiteral("Clicking the toolbar discarded in-progress text");
+    return false;
+  }
+  editor.close();
+  return true;
+}
+
 bool runContinuousAnnotationToolsSmoke(QApplication &application,
                                        QString &error) {
   CaptureData capture;
@@ -814,6 +892,10 @@ int main(int argc, char **argv) {
   if (!runSpotlightRedactionPreviewCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 86;
+  }
+  if (!runTextClickAwayCommitCheck(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 82;
   }
   if (!runContinuousAnnotationToolsSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/editor.cpp
+++ b/editor.cpp
@@ -297,7 +297,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
   });
 
   if (mode == CaptureMode::Fullscreen || mode == CaptureMode::File) {
-    selection_ = QRectF(QPointF(), capture_.preview.size());
+    selection_ = QRectF(QPointF(), capture_.previewSize);
     enterEdit(
         mode == CaptureMode::File
             ? QStringLiteral("Editing image from file · Copy/Save to output")
@@ -632,13 +632,13 @@ QPointF CaptureEditor::toAnnotationPoint(const QPointF &position) const {
 }
 
 QRectF CaptureEditor::sourceRect(const QRectF &logicalRect) const {
-  if (capture_.preview.isNull() || capture_.source.isNull() ||
-      capture_.preview.width() <= 0 || capture_.preview.height() <= 0)
+  if (capture_.source.isNull() || capture_.previewSize.width() <= 0 ||
+      capture_.previewSize.height() <= 0)
     return {};
-  const qreal scaleX =
-      capture_.source.width() / static_cast<qreal>(capture_.preview.width());
-  const qreal scaleY =
-      capture_.source.height() / static_cast<qreal>(capture_.preview.height());
+  const qreal scaleX = capture_.source.width() /
+                       static_cast<qreal>(capture_.previewSize.width());
+  const qreal scaleY = capture_.source.height() /
+                       static_cast<qreal>(capture_.previewSize.height());
   return {logicalRect.x() * scaleX, logicalRect.y() * scaleY,
           logicalRect.width() * scaleX, logicalRect.height() * scaleY};
 }
@@ -970,8 +970,7 @@ void CaptureEditor::chooseWindow(int index) {
   }
 
   capture_.source = surface;
-  capture_.preview = surface.scaled(target.rect.size(), Qt::IgnoreAspectRatio,
-                                    Qt::SmoothTransformation);
+  capture_.previewSize = target.rect.size();
   selection_ = QRectF(QPointF(), target.rect.size());
   windowMode_ = false;
   enterEdit(QStringLiteral(
@@ -1251,7 +1250,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
       windowMode_ = false;
       dragging_ = false;
       hoveredWindow_ = -1;
-      selection_ = QRectF(QPointF(), capture_.preview.size());
+      selection_ = QRectF(QPointF(), capture_.previewSize);
       enterEdit(QStringLiteral(
           "Full screen selected · native resolution · outer handles crop"));
       update();
@@ -1423,7 +1422,7 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
         return;
       const int handle = static_cast<int>(interaction_) -
                          static_cast<int>(Interaction::CropTopLeft);
-      const QSizeF previewSize = capture_.preview.size();
+      const QSizeF previewSize = capture_.previewSize;
       if (previewSize.width() <= 0.0 || previewSize.height() <= 0.0)
         return;
       const qreal sourceX = originalSelection_.left() +
@@ -1676,7 +1675,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
 
   const QPointF point = toAnnotationPoint(cursor_);
   if (tool_ == Tool::Eyedropper) {
-    customColor_ = sampleSourceColor(capture_.source, capture_.preview.size(),
+    customColor_ = sampleSourceColor(capture_.source, capture_.previewSize,
                                      selection_, editImageRect(), cursor_);
     usingCustomColor_ = true;
     if (customColor_.hsvHueF() >= 0)

--- a/editor.cpp
+++ b/editor.cpp
@@ -1642,6 +1642,11 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     return;
   }
 
+  // Clicking away from an in-progress text commits it like Return would,
+  // instead of leaving an orphaned editor or discarding what was typed.
+  if (textEditor_->isVisible())
+    acceptText();
+
   for (const ToolbarButton &button : toolbarButtons()) {
     if (button.rect.contains(cursor_)) {
       handleToolbar(button.action);

--- a/editor.cpp
+++ b/editor.cpp
@@ -40,6 +40,7 @@ constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
 constexpr qreal kToolbarWidth = 760;
 constexpr qreal kMinimumRedactionExtent = 5.0;
+constexpr int kBackdropDim = 143;
 
 qreal toolbarScale(qreal availableWidth) {
   constexpr qreal sideMargins = 16.0;
@@ -1982,14 +1983,81 @@ void CaptureEditor::updatePointerCursor() {
     setCursor(Qt::CrossCursor);
 }
 
+/** Scales the capture to the widget once instead of on every repaint. */
+void CaptureEditor::refreshBackdropCache() {
+  const qreal ratio = devicePixelRatioF();
+  const QSize device = (QSizeF(size()) * ratio).toSize();
+  const qint64 key = capture_.source.cacheKey();
+  if (device.isEmpty()) {
+    backdrop_ = {};
+    dimmedBackdrop_ = {};
+    backdropSize_ = {};
+    return;
+  }
+  if (!backdrop_.isNull() && backdropSize_ == device && backdropKey_ == key &&
+      qFuzzyCompare(backdropRatio_, ratio))
+    return;
+
+  backdropSize_ = device;
+  backdropRatio_ = ratio;
+  backdropKey_ = key;
+  backdrop_ = QPixmap(device);
+  backdrop_.setDevicePixelRatio(ratio);
+  backdrop_.fill(Qt::transparent);
+  {
+    QPainter cache(&backdrop_);
+    cache.setRenderHint(QPainter::SmoothPixmapTransform, true);
+    cache.drawImage(QRectF(QPointF(), QSizeF(device) / ratio), capture_.source);
+  }
+  dimmedBackdrop_ = backdrop_.copy();
+  {
+    QPainter cache(&dimmedBackdrop_);
+    cache.fillRect(QRectF(QPointF(), QSizeF(device) / ratio),
+                   QColor(0, 0, 0, kBackdropDim));
+  }
+}
+
+/** Scales the frozen crop the editor shows once per selection, size and
+ *  source image; sourceArea addresses the native pixels to show. */
+void CaptureEditor::refreshEditCropCache(const QRectF &image,
+                                         const QImage &source,
+                                         const QRectF &sourceArea) {
+  const qreal ratio = devicePixelRatioF();
+  const QSize device = (QSizeF(image.size()) * ratio).toSize();
+  const qint64 key = source.cacheKey();
+  if (device.isEmpty()) {
+    editCrop_ = {};
+    editCropSize_ = {};
+    return;
+  }
+  if (!editCrop_.isNull() && editCropSize_ == device && editCropKey_ == key &&
+      editCropArea_ == sourceArea && qFuzzyCompare(editCropRatio_, ratio))
+    return;
+
+  editCropSize_ = device;
+  editCropRatio_ = ratio;
+  editCropKey_ = key;
+  editCropArea_ = sourceArea;
+  editCrop_ = QPixmap(device);
+  editCrop_.setDevicePixelRatio(ratio);
+  editCrop_.fill(Qt::transparent);
+  QPainter cache(&editCrop_);
+  cache.setRenderHint(QPainter::SmoothPixmapTransform, true);
+  cache.drawImage(QRectF(QPointF(), QSizeF(device) / ratio), source,
+                  sourceArea);
+}
+
 void CaptureEditor::paintSelect(QPainter &painter) {
-  painter.drawImage(rect(), capture_.source);
-  painter.fillRect(rect(), QColor(0, 0, 0, 143));
+  refreshBackdropCache();
+  painter.drawPixmap(rect(), dimmedBackdrop_);
 
   if (windowMode_) {
     if (hoveredWindow_ >= 0 && hoveredWindow_ < capture_.windows.size()) {
       const QRect window = capture_.windows.at(hoveredWindow_).rect;
-      painter.drawImage(window, capture_.source, sourceRect(window));
+      painter.save();
+      painter.setClipRect(window);
+      painter.drawPixmap(rect(), backdrop_);
+      painter.restore();
     }
     for (int index = 0; index < capture_.windows.size(); ++index) {
       const WindowTarget &window = capture_.windows.at(index);
@@ -1999,7 +2067,10 @@ void CaptureEditor::paintSelect(QPainter &painter) {
       painter.drawRect(window.rect);
     }
   } else if (!selection_.isEmpty()) {
-    painter.drawImage(selection_, capture_.source, sourceRect(selection_));
+    painter.save();
+    painter.setClipRect(selection_);
+    painter.drawPixmap(rect(), backdrop_);
+    painter.restore();
     painter.setPen(QPen(Qt::white, 2));
     painter.setBrush(Qt::NoBrush);
     painter.drawRect(selection_);
@@ -2075,21 +2146,23 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     preview.redactionSeed = activeRedactionSeed_;
     redactions.push_back(std::move(preview));
   }
+  if (!redactions.isEmpty() && (redactionPreviewCache_.isNull() ||
+                                cachedRedactionSelection_ != selection_ ||
+                                cachedPreviewRedactions_ != redactions)) {
+    cachedRedactionSelection_ = selection_;
+    cachedPreviewRedactions_ = redactions;
+    redactionPreviewCache_ =
+        renderCapture(capture_, selection_, redactions, BackgroundStyle::None);
+  }
+  // Redactions replace the visible crop with their already redacted preview;
+  // either way the shown pixels are scaled to the canvas once, not per frame.
+  refreshEditCropCache(
+      image, redactions.isEmpty() ? capture_.source : redactionPreviewCache_,
+      redactions.isEmpty() ? sourceRect(selection_)
+                           : QRectF(redactionPreviewCache_.rect()));
   painter.save();
   painter.setClipPath(clip);
-  if (redactions.isEmpty()) {
-    painter.drawImage(image, capture_.source, sourceRect(selection_));
-  } else {
-    if (redactionPreviewCache_.isNull() ||
-        cachedRedactionSelection_ != selection_ ||
-        cachedPreviewRedactions_ != redactions) {
-      cachedRedactionSelection_ = selection_;
-      cachedPreviewRedactions_ = redactions;
-      redactionPreviewCache_ = renderCapture(capture_, selection_, redactions,
-                                             BackgroundStyle::None);
-    }
-    painter.drawImage(image, redactionPreviewCache_);
-  }
+  painter.drawPixmap(image, editCrop_, QRectF(editCrop_.rect()));
   painter.restore();
 
   painter.save();

--- a/editor.cpp
+++ b/editor.cpp
@@ -40,6 +40,10 @@ constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
 constexpr qreal kToolbarWidth = 760;
 constexpr qreal kMinimumRedactionExtent = 5.0;
+// Rapid adjustments (wheel scaling, color picking, style toggles) coalesce
+// into one working-snapshot write instead of one native-resolution PNG per
+// input event.
+constexpr int kSnapshotDebounceMs = 250;
 constexpr int kBackdropDim = 143;
 
 qreal toolbarScale(qreal availableWidth) {
@@ -261,6 +265,11 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     setGeometry(QGuiApplication::primaryScreen()->geometry());
   cursor_ = mapFromGlobal(QCursor::pos());
 
+  snapshotTimer_.setSingleShot(true);
+  snapshotTimer_.setInterval(kSnapshotDebounceMs);
+  connect(&snapshotTimer_, &QTimer::timeout, this,
+          [this] { persistSnapshot(); });
+
   textEditor_ = new QLineEdit(this);
   textEditor_->hide();
   textEditor_->setFrame(false);
@@ -314,6 +323,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
 }
 
 CaptureEditor::~CaptureEditor() {
+  flushPendingSnapshot();
   if (snapshotPath_.isEmpty() || !QFile::exists(snapshotPath_))
     return;
   const QString runtime = secureRuntimeDirectory();
@@ -456,7 +466,7 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
         std::clamp(annotation.magnification * factor, 1.0, 4.0);
     setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
                   .arg(annotation.magnification, 0, 'f', 1));
-    persistSnapshot();
+    schedulePersistSnapshot();
     return;
   }
   const QPointF center = annotationBounds(annotation).center();
@@ -492,7 +502,7 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
   }
   setStatus(QStringLiteral("Selected layer · wheel zoom %1%")
                 .arg(qRound(factor * 100)));
-  persistSnapshot();
+  schedulePersistSnapshot();
 }
 
 QRectF CaptureEditor::colorPaletteRect() const {
@@ -557,7 +567,7 @@ void CaptureEditor::applyCustomColor(const QPointF &position) {
           Annotation::Kind::Redaction) {
     recordEdit();
     annotations_[selectedAnnotation_].color = customColor_;
-    persistSnapshot();
+    schedulePersistSnapshot();
   }
   update();
 }
@@ -855,6 +865,8 @@ void CaptureEditor::redoEdit() {
 }
 
 void CaptureEditor::persistSnapshot() {
+  snapshotTimer_.stop();
+  snapshotPending_ = false;
   if (selection_.isEmpty())
     return;
   if (snapshotPath_.isEmpty())
@@ -866,9 +878,25 @@ void CaptureEditor::persistSnapshot() {
     qWarning().noquote() << error;
 }
 
+/** Queues the working snapshot so a burst of edits writes one PNG. */
+void CaptureEditor::schedulePersistSnapshot() {
+  if (selection_.isEmpty())
+    return;
+  snapshotPending_ = true;
+  snapshotTimer_.start();
+}
+
+/** Writes a queued snapshot immediately; every exit path calls this. */
+void CaptureEditor::flushPendingSnapshot() {
+  if (!snapshotPending_)
+    return;
+  persistSnapshot();
+}
+
 void CaptureEditor::pinSnapshot() {
   if (busy_ || selection_.isEmpty())
     return;
+  flushPendingSnapshot();
 
   prunePinnedSnapshots();
   const QString path = pinnedSnapshotPath(++pinCount_);
@@ -1107,6 +1135,7 @@ void CaptureEditor::finish(OutputMode mode) {
   busy_ = true;
   setStatus(QStringLiteral("Preparing screenshot…"));
   QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+  // Supersedes any debounced write: the output is this snapshot file.
   persistSnapshot();
   const QFileInfo snapshotFile(snapshotPath_);
   if (snapshotPath_.isEmpty() || !snapshotFile.exists() ||
@@ -1202,7 +1231,7 @@ void CaptureEditor::handleToolbar(const QString &action) {
             Annotation::Kind::Redaction) {
       recordEdit();
       annotations_[selectedAnnotation_].color = annotationColor();
-      persistSnapshot();
+      schedulePersistSnapshot();
     }
   } else if (action == QStringLiteral("custom-color")) {
     usingCustomColor_ = true;
@@ -1215,7 +1244,7 @@ void CaptureEditor::handleToolbar(const QString &action) {
         (static_cast<int>(backgroundStyle_) + 1) % 5);
     setStatus(QStringLiteral("Backdrop: %1 · B cycles")
                   .arg(backgroundName(backgroundStyle_)));
-    persistSnapshot();
+    schedulePersistSnapshot();
   } else if (action == QStringLiteral("undo")) {
     undoEdit();
   } else if (action == QStringLiteral("redo")) {
@@ -1350,7 +1379,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
               : RedactionStyle::Solid;
       setStatus(QStringLiteral("Selected redaction: %1 · D toggles")
                     .arg(redactionStyleName(redaction.redactionStyle)));
-      persistSnapshot();
+      schedulePersistSnapshot();
     } else {
       if (tool_ == Tool::Redact) {
         redactionStyle_ = redactionStyle_ == RedactionStyle::Solid
@@ -1379,7 +1408,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
         (static_cast<int>(backgroundStyle_) + 1) % 5);
     setStatus(QStringLiteral("Backdrop: %1 · B cycles")
                   .arg(backgroundName(backgroundStyle_)));
-    persistSnapshot();
+    schedulePersistSnapshot();
   } else if (event->key() >= Qt::Key_1 && event->key() <= Qt::Key_6) {
     colorIndex_ = event->key() - Qt::Key_1;
     usingCustomColor_ = false;
@@ -1388,7 +1417,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
             Annotation::Kind::Redaction) {
       recordEdit();
       annotations_[selectedAnnotation_].color = annotationColor();
-      persistSnapshot();
+      schedulePersistSnapshot();
     }
   } else {
     QWidget::keyPressEvent(event);
@@ -1688,7 +1717,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
             Annotation::Kind::Spotlight) {
       recordEdit();
       annotations_[selectedAnnotation_].color = customColor_;
-      persistSnapshot();
+      schedulePersistSnapshot();
     }
     QString clipboardError;
     static_cast<void>(copyTextToClipboard(

--- a/editor.cpp
+++ b/editor.cpp
@@ -269,6 +269,8 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
   snapshotTimer_.setInterval(kSnapshotDebounceMs);
   connect(&snapshotTimer_, &QTimer::timeout, this,
           [this] { persistSnapshot(); });
+  connect(&snapshotWatcher_, &QFutureWatcher<QString>::finished, this,
+          [this] { handleSnapshotWriteFinished(); });
 
   textEditor_ = new QLineEdit(this);
   textEditor_->hide();
@@ -864,6 +866,9 @@ void CaptureEditor::redoEdit() {
   setStatus(QStringLiteral("Redo · Ctrl+Z to undo"));
 }
 
+/** Hands the working snapshot to the thread pool: rendering and PNG encoding a
+ *  native-resolution selection costs far too much to run between input
+ *  events. */
 void CaptureEditor::persistSnapshot() {
   snapshotTimer_.stop();
   snapshotPending_ = false;
@@ -871,10 +876,55 @@ void CaptureEditor::persistSnapshot() {
     return;
   if (snapshotPath_.isEmpty())
     snapshotPath_ = temporarySnapshotPath();
-  const QImage image =
-      renderCapture(capture_, selection_, annotations_, backgroundStyle_);
-  QString error;
-  if (!saveTemporarySnapshot(image, snapshotPath_, error))
+  if (snapshotWriteActive_) {
+    snapshotWriteQueued_ = true;
+    return;
+  }
+  startSnapshotWrite();
+}
+
+/** Starts the one worker allowed to touch the snapshot file. Everything it
+ *  reads is copied here, on the GUI thread; the source image is copy-on-write
+ *  and nothing mutates it while the editor is in its Edit phase. */
+void CaptureEditor::startSnapshotWrite() {
+  snapshotWriteQueued_ = false;
+  snapshotWriteActive_ = true;
+  snapshotFuture_ = QtConcurrent::run(
+      [capture = capture_, selection = selection_, annotations = annotations_,
+       backgroundStyle = backgroundStyle_, path = snapshotPath_] {
+        const QImage image =
+            renderCapture(capture, selection, annotations, backgroundStyle);
+        QString error;
+        if (!saveTemporarySnapshot(image, path, error, SnapshotEncoding::Fast))
+          return error;
+        return QString();
+      });
+  snapshotWatcher_.setFuture(snapshotFuture_);
+}
+
+/** Collects a finished write and starts the request that arrived during it.
+ *  The watcher can also deliver a superseded future's signal, so only act once
+ *  the future actually held is done. */
+void CaptureEditor::handleSnapshotWriteFinished() {
+  if (!snapshotWriteActive_ || !snapshotFuture_.isFinished())
+    return;
+  const QString error = snapshotFuture_.result();
+  snapshotWriteActive_ = false;
+  if (!error.isEmpty())
+    qWarning().noquote() << error;
+  if (snapshotWriteQueued_)
+    startSnapshotWrite();
+}
+
+/** Blocks until no worker can write the snapshot file any more. */
+void CaptureEditor::awaitSnapshotWrite() {
+  if (!snapshotWriteActive_)
+    return;
+  snapshotFuture_.waitForFinished();
+  const QString error = snapshotFuture_.result();
+  snapshotWriteActive_ = false;
+  snapshotWriteQueued_ = false;
+  if (!error.isEmpty())
     qWarning().noquote() << error;
 }
 
@@ -886,11 +936,32 @@ void CaptureEditor::schedulePersistSnapshot() {
   snapshotTimer_.start();
 }
 
-/** Writes a queued snapshot immediately; every exit path calls this. */
-void CaptureEditor::flushPendingSnapshot() {
-  if (!snapshotPending_)
+/** Renders and writes the working snapshot here and now, at the default PNG
+ *  compression: finish() moves this very file into the user's screenshots. */
+void CaptureEditor::writeSnapshotNow() {
+  snapshotTimer_.stop();
+  snapshotPending_ = false;
+  awaitSnapshotWrite();
+  if (selection_.isEmpty())
     return;
-  persistSnapshot();
+  if (snapshotPath_.isEmpty())
+    snapshotPath_ = temporarySnapshotPath();
+  const QImage image =
+      renderCapture(capture_, selection_, annotations_, backgroundStyle_);
+  QString error;
+  if (!saveTemporarySnapshot(image, snapshotPath_, error))
+    qWarning().noquote() << error;
+}
+
+/** Leaves a complete, current snapshot on disk with no worker still running;
+ *  every exit path calls this. */
+void CaptureEditor::flushPendingSnapshot() {
+  const bool stale = snapshotPending_ || snapshotWriteQueued_;
+  snapshotTimer_.stop();
+  snapshotPending_ = false;
+  awaitSnapshotWrite();
+  if (stale)
+    writeSnapshotNow();
 }
 
 void CaptureEditor::pinSnapshot() {
@@ -983,6 +1054,11 @@ void CaptureEditor::handleEscape() {
 void CaptureEditor::chooseWindow(int index) {
   if (index < 0 || index >= capture_.windows.size())
     return;
+
+  // The capture source is replaced below, so no worker may still be rendering
+  // from the old one. Choosing a window happens before any selection exists,
+  // so this is a guard rather than a cost.
+  flushPendingSnapshot();
 
   const WindowTarget target = capture_.windows.at(index);
   setStatus(QStringLiteral("Capturing clean window surface…"));
@@ -1135,8 +1211,9 @@ void CaptureEditor::finish(OutputMode mode) {
   busy_ = true;
   setStatus(QStringLiteral("Preparing screenshot…"));
   QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-  // Supersedes any debounced write: the output is this snapshot file.
-  persistSnapshot();
+  // Supersedes any debounced or in-flight write: the output is this snapshot
+  // file, and the user keeps it, so it is worth the full compression.
+  writeSnapshotNow();
   const QFileInfo snapshotFile(snapshotPath_);
   if (snapshotPath_.isEmpty() || !snapshotFile.exists() ||
       snapshotFile.size() <= 0) {

--- a/editor.cpp
+++ b/editor.cpp
@@ -2108,8 +2108,16 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     preview.size = annotationSize_;
     liveAnnotations.push_back(std::move(preview));
   }
-  paintSpotlights(painter, capture_.source, QRectF(QPointF(), selection_.size()),
-                  sourceRect(selection_), liveAnnotations);
+  // Spotlights magnify what they sample, so a lens over a redaction must read
+  // the already redacted preview instead of the untouched source pixels.
+  const bool sampleRedacted =
+      !redactions.isEmpty() && !redactionPreviewCache_.isNull();
+  paintSpotlights(painter,
+                  sampleRedacted ? redactionPreviewCache_ : capture_.source,
+                  QRectF(QPointF(), selection_.size()),
+                  sampleRedacted ? QRectF(redactionPreviewCache_.rect())
+                                 : sourceRect(selection_),
+                  liveAnnotations);
   for (int index = 0; index < annotations_.size(); ++index) {
     if (index != editingAnnotation_ &&
         annotations_.at(index).kind != Annotation::Kind::Redaction)

--- a/editor.hpp
+++ b/editor.hpp
@@ -6,6 +6,7 @@
 #include <QFutureWatcher>
 #include <QLineEdit>
 #include <QPixmap>
+#include <QTimer>
 #include <QWidget>
 
 class QKeyEvent;
@@ -117,6 +118,8 @@ private:
   [[nodiscard]] EditState editState() const;
   void enterEdit(QString status);
   void persistSnapshot();
+  void schedulePersistSnapshot();
+  void flushPendingSnapshot();
   void pinSnapshot();
   void pushUndoState(const EditState &state);
   void recordEdit();
@@ -178,6 +181,8 @@ private:
   bool dragStartStateValid_ = false;
   bool dragChanged_ = false;
   QString snapshotPath_;
+  QTimer snapshotTimer_;
+  bool snapshotPending_ = false;
   // Preview-only scaling caches, keyed on the source image's cacheKey so a
   // replaced capture or re-rendered redaction preview rebuilds them. Export
   // paths keep rendering from capture_.source at native resolution.

--- a/editor.hpp
+++ b/editor.hpp
@@ -5,6 +5,7 @@
 #include <QElapsedTimer>
 #include <QFutureWatcher>
 #include <QLineEdit>
+#include <QPixmap>
 #include <QWidget>
 
 class QKeyEvent;
@@ -126,6 +127,9 @@ private:
   void handleToolbar(const QString &action);
   void paintEdit(QPainter &painter);
   void paintSelect(QPainter &painter);
+  void refreshBackdropCache();
+  void refreshEditCropCache(const QRectF &image, const QImage &source,
+                            const QRectF &sourceArea);
   void runOcr(const QRectF &localSelection = {});
   void setStatus(QString status);
   void scaleSelectedAnnotation(qreal factor);
@@ -174,6 +178,19 @@ private:
   bool dragStartStateValid_ = false;
   bool dragChanged_ = false;
   QString snapshotPath_;
+  // Preview-only scaling caches, keyed on the source image's cacheKey so a
+  // replaced capture or re-rendered redaction preview rebuilds them. Export
+  // paths keep rendering from capture_.source at native resolution.
+  QPixmap backdrop_;
+  QPixmap dimmedBackdrop_;
+  QSize backdropSize_;
+  qreal backdropRatio_ = 0.0;
+  qint64 backdropKey_ = 0;
+  QPixmap editCrop_;
+  QSize editCropSize_;
+  qreal editCropRatio_ = 0.0;
+  qint64 editCropKey_ = 0;
+  QRectF editCropArea_;
   QuickOutputMode quickOutputMode_ = QuickOutputMode::None;
   int pinCount_ = 0;
   QString status_ =

--- a/editor.hpp
+++ b/editor.hpp
@@ -3,6 +3,7 @@
 #include "capture.hpp"
 
 #include <QElapsedTimer>
+#include <QFuture>
 #include <QFutureWatcher>
 #include <QLineEdit>
 #include <QPixmap>
@@ -120,6 +121,10 @@ private:
   void persistSnapshot();
   void schedulePersistSnapshot();
   void flushPendingSnapshot();
+  void writeSnapshotNow();
+  void startSnapshotWrite();
+  void awaitSnapshotWrite();
+  void handleSnapshotWriteFinished();
   void pinSnapshot();
   void pushUndoState(const EditState &state);
   void recordEdit();
@@ -183,6 +188,13 @@ private:
   QString snapshotPath_;
   QTimer snapshotTimer_;
   bool snapshotPending_ = false;
+  // At most one worker writes the snapshot file. A request that arrives while
+  // one runs only sets snapshotWriteQueued_, and the finished worker restarts
+  // from the state as it stands then, so the last request always wins.
+  QFuture<QString> snapshotFuture_;
+  QFutureWatcher<QString> snapshotWatcher_;
+  bool snapshotWriteActive_ = false;
+  bool snapshotWriteQueued_ = false;
   // Preview-only scaling caches, keyed on the source image's cacheKey so a
   // replaced capture or re-rendered redaction preview rebuilds them. Export
   // paths keep rendering from capture_.source at native resolution.

--- a/instance-lock-smoke.cpp
+++ b/instance-lock-smoke.cpp
@@ -1,0 +1,249 @@
+/** @fileoverview Tests single-instance handover decisions and live SIGTERM. */
+#include "instance-lock-smoke.hpp"
+
+#include "instance-lock.hpp"
+
+#include <QCoreApplication>
+#include <QDeadlineTimer>
+#include <QDir>
+#include <QFile>
+#include <QLockFile>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QTemporaryDir>
+#include <QThread>
+
+#include <csignal>
+#include <unistd.h>
+
+namespace {
+volatile sig_atomic_t holderTerminated = 0;
+
+struct DecisionCase {
+  const char *name;
+  InstanceLockProbe probe;
+  InstanceHolder holder;
+  InstanceMode mode;
+  InstanceAction expected;
+};
+
+/** The full decision table; every row doubles as a named check. */
+constexpr DecisionCase kDecisionCases[] = {
+    {"free lock proceeds for capture", InstanceLockProbe::Acquired,
+     InstanceHolder::Unknown, InstanceMode::Capture, InstanceAction::Proceed},
+    {"free lock proceeds for file edit", InstanceLockProbe::Acquired,
+     InstanceHolder::Unknown, InstanceMode::EditFile, InstanceAction::Proceed},
+    {"live holder cancels a capture invocation", InstanceLockProbe::HeldByOther,
+     InstanceHolder::Alive, InstanceMode::Capture,
+     InstanceAction::CancelRunning},
+    {"live holder is replaced for a file edit", InstanceLockProbe::HeldByOther,
+     InstanceHolder::Alive, InstanceMode::EditFile,
+     InstanceAction::ReplaceRunning},
+    {"dead holder clears the stale lock for capture",
+     InstanceLockProbe::HeldByOther, InstanceHolder::Dead, InstanceMode::Capture,
+     InstanceAction::ClearStaleLock},
+    {"dead holder clears the stale lock for a file edit",
+     InstanceLockProbe::HeldByOther, InstanceHolder::Dead,
+     InstanceMode::EditFile, InstanceAction::ClearStaleLock},
+    {"unreadable lock info clears the stale lock",
+     InstanceLockProbe::HeldByOther, InstanceHolder::Unknown,
+     InstanceMode::Capture, InstanceAction::ClearStaleLock},
+    {"permission error fails instead of pretending to be a second instance",
+     InstanceLockProbe::PermissionError, InstanceHolder::Unknown,
+     InstanceMode::Capture, InstanceAction::Fail},
+    {"permission error fails for a file edit too",
+     InstanceLockProbe::PermissionError, InstanceHolder::Unknown,
+     InstanceMode::EditFile, InstanceAction::Fail},
+    {"unknown lock error fails", InstanceLockProbe::UnknownError,
+     InstanceHolder::Unknown, InstanceMode::Capture, InstanceAction::Fail},
+};
+
+bool runDecisionTableChecks(QString &error) {
+  for (const DecisionCase &check : kDecisionCases) {
+    if (decideInstanceAction(check.probe, check.holder, check.mode) !=
+        check.expected) {
+      error = QStringLiteral("Instance decision failed: %1")
+                  .arg(QString::fromLatin1(check.name));
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Starts this executable in lock-holder mode and waits until it owns it. */
+bool startLockHolder(QProcess &holder, const QString &lockPath, QString &error) {
+  QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+  environment.insert(QString::fromLatin1(kInstanceLockHolderVariable),
+                     lockPath);
+  holder.setProcessEnvironment(environment);
+  holder.setProgram(QCoreApplication::applicationFilePath());
+  holder.start();
+  if (!holder.waitForStarted(5000)) {
+    error = QStringLiteral("Could not start the lock-holder process");
+    return false;
+  }
+  QDeadlineTimer deadline(5000);
+  for (;;) {
+    qint64 pid = 0;
+    QString hostname;
+    QString application;
+    QLockFile probe(lockPath);
+    if (QFile::exists(lockPath) &&
+        probe.getLockInfo(&pid, &hostname, &application) &&
+        pid == holder.processId())
+      return true;
+    if (deadline.hasExpired()) {
+      error = QStringLiteral("Lock-holder process never took the lock");
+      return false;
+    }
+    QThread::msleep(10);
+  }
+}
+
+/** A file edit must terminate the overlay, wait for it, and still open. */
+bool runFileEditHandoverCheck(const QString &lockPath, QString &error) {
+  QProcess holder;
+  if (!startLockHolder(holder, lockPath, error))
+    return false;
+  const qint64 holderPid = holder.processId();
+
+  QLockFile lock(lockPath);
+  const InstanceLockResult result =
+      acquireInstanceLock(lock, InstanceMode::EditFile);
+  if (!result.proceed || !result.error.isEmpty() || !lock.isLocked() ||
+      result.signalledPid != holderPid) {
+    error = QStringLiteral("File edit did not take over the lock: %1")
+                .arg(result.error.isEmpty()
+                         ? QStringLiteral("no editor would have opened")
+                         : result.error);
+    holder.kill();
+    holder.waitForFinished(2000);
+    return false;
+  }
+  if (!holder.waitForFinished(2000) || holder.exitCode() != 0) {
+    error = QStringLiteral("Lock holder did not exit cleanly on SIGTERM");
+    return false;
+  }
+  lock.unlock();
+  return true;
+}
+
+/** A second capture invocation cancels the overlay without starting one. */
+bool runCaptureCancelCheck(const QString &lockPath, QString &error) {
+  QProcess holder;
+  if (!startLockHolder(holder, lockPath, error))
+    return false;
+  const qint64 holderPid = holder.processId();
+
+  QLockFile lock(lockPath);
+  const InstanceLockResult result =
+      acquireInstanceLock(lock, InstanceMode::Capture);
+  if (result.proceed || result.exitCode != kInstanceCancelledExitCode ||
+      !result.error.isEmpty() || result.signalledPid != holderPid) {
+    error = QStringLiteral("Second capture invocation did not cancel the "
+                           "running overlay");
+    holder.kill();
+    holder.waitForFinished(2000);
+    return false;
+  }
+  if (!holder.waitForFinished(2000) || holder.exitCode() != 0) {
+    error = QStringLiteral("Cancelled overlay did not shut down on SIGTERM");
+    return false;
+  }
+  QLockFile released(lockPath);
+  released.setStaleLockTime(0);
+  if (!released.tryLock(0)) {
+    error = QStringLiteral("SIGTERM did not release the single-instance lock");
+    return false;
+  }
+  released.unlock();
+  return true;
+}
+
+/** A killed instance leaves a lock file that the next launch must reclaim. */
+bool runStaleLockCheck(const QString &lockPath, QString &error) {
+  QProcess holder;
+  if (!startLockHolder(holder, lockPath, error))
+    return false;
+  holder.kill();
+  if (!holder.waitForFinished(2000)) {
+    error = QStringLiteral("Could not kill the lock-holder process");
+    return false;
+  }
+  if (!QFile::exists(lockPath)) {
+    error = QStringLiteral("Killed lock holder unexpectedly cleaned up");
+    return false;
+  }
+  QLockFile lock(lockPath);
+  const InstanceLockResult result =
+      acquireInstanceLock(lock, InstanceMode::Capture);
+  if (!result.proceed || !lock.isLocked() || result.signalledPid != 0) {
+    error = QStringLiteral("Stale lock was not reclaimed: %1").arg(result.error);
+    return false;
+  }
+  lock.unlock();
+  return true;
+}
+
+/** An unusable lock path must fail loudly, not look like a second instance. */
+bool runUnwritableLockCheck(const QString &root, QString &error) {
+  if (::geteuid() == 0)
+    return true; // Root ignores the permission bits this check relies on.
+  const QString locked = QDir(root).filePath(QStringLiteral("no-write"));
+  if (!QDir().mkdir(locked) ||
+      !QFile::setPermissions(locked, QFileDevice::ReadOwner |
+                                         QFileDevice::ExeOwner)) {
+    error = QStringLiteral("Could not create the read-only lock directory");
+    return false;
+  }
+  QLockFile lock(QDir(locked).filePath(QStringLiteral("omasnap.instance")));
+  const InstanceLockResult result =
+      acquireInstanceLock(lock, InstanceMode::Capture);
+  const bool ok = !result.proceed &&
+                  result.exitCode == kInstanceLockErrorExitCode &&
+                  !result.error.isEmpty();
+  static_cast<void>(QFile::setPermissions(locked, QFileDevice::ReadOwner |
+                                                      QFileDevice::WriteOwner |
+                                                      QFileDevice::ExeOwner));
+  if (!ok) {
+    error = QStringLiteral("Unwritable lock path did not fail loudly");
+    return false;
+  }
+  return true;
+}
+} // namespace
+
+bool runInstanceLockSmoke(QString &error) {
+  if (!runDecisionTableChecks(error))
+    return false;
+  QTemporaryDir lockRoot;
+  if (!lockRoot.isValid()) {
+    error = QStringLiteral("Could not create the instance-lock test directory");
+    return false;
+  }
+  const QString lockPath =
+      QDir(lockRoot.path()).filePath(QStringLiteral("omasnap.instance"));
+  return runFileEditHandoverCheck(lockPath, error) &&
+         runCaptureCancelCheck(lockPath, error) &&
+         runStaleLockCheck(lockPath, error) &&
+         runUnwritableLockCheck(lockRoot.path(), error);
+}
+
+int runInstanceLockHolder(const QString &lockPath) {
+  struct sigaction action{};
+  action.sa_handler = [](int) { holderTerminated = 1; };
+  sigemptyset(&action.sa_mask);
+  if (::sigaction(SIGTERM, &action, nullptr) != 0)
+    return 95;
+  QLockFile lock(lockPath);
+  lock.setStaleLockTime(0);
+  if (!lock.tryLock(0))
+    return 96;
+  QDeadlineTimer guard(30000);
+  while (holderTerminated == 0 && !guard.hasExpired())
+    QThread::msleep(5);
+  if (holderTerminated == 0)
+    return 97;
+  lock.unlock(); // Mirrors the overlay's clean Qt teardown.
+  return 0;
+}

--- a/instance-lock-smoke.hpp
+++ b/instance-lock-smoke.hpp
@@ -1,0 +1,14 @@
+/** @fileoverview Declares single-instance lock smoke checks. */
+#pragma once
+
+#include <QString>
+
+/** Environment variable that turns this executable into a lock holder. */
+inline constexpr char kInstanceLockHolderVariable[] =
+    "OMASNAP_SMOKE_HOLD_INSTANCE_LOCK";
+
+/** Checks the handover decision table and live SIGTERM handovers. */
+[[nodiscard]] bool runInstanceLockSmoke(QString &error);
+
+/** Holds the given lock file until SIGTERM, then releases it and exits. */
+[[nodiscard]] int runInstanceLockHolder(const QString &lockPath);

--- a/instance-lock.cpp
+++ b/instance-lock.cpp
@@ -1,0 +1,165 @@
+/** @fileoverview Hands the single-instance lock over to a starting process. */
+#include "instance-lock.hpp"
+
+#include <QDeadlineTimer>
+#include <QLockFile>
+#include <QThread>
+
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+
+namespace {
+/** How long a starting editor waits for the running instance to let go. */
+constexpr int kHandoverTimeoutMs = 2000;
+/** Poll interval while waiting for the lock file to disappear. */
+constexpr int kHandoverPollMs = 20;
+
+InstanceLockProbe probeLock(QLockFile &lock) {
+  if (lock.tryLock(0))
+    return InstanceLockProbe::Acquired;
+  switch (lock.error()) {
+  case QLockFile::LockFailedError:
+    return InstanceLockProbe::HeldByOther;
+  case QLockFile::PermissionError:
+    return InstanceLockProbe::PermissionError;
+  case QLockFile::NoError:
+  case QLockFile::UnknownError:
+    break;
+  }
+  return InstanceLockProbe::UnknownError;
+}
+
+/** Reads the lock holder's pid and whether that process still exists. */
+InstanceHolder readHolder(QLockFile &lock, qint64 &pid) {
+  qint64 lockPid = 0;
+  QString hostname;
+  QString application;
+  if (!lock.getLockInfo(&lockPid, &hostname, &application) || lockPid <= 0)
+    return InstanceHolder::Unknown;
+  pid = lockPid;
+  if (::kill(static_cast<pid_t>(lockPid), 0) != 0 && errno == ESRCH)
+    return InstanceHolder::Dead;
+  return InstanceHolder::Alive;
+}
+
+enum class SignalOutcome { Sent, AlreadyGone, Failed };
+
+SignalOutcome terminateHolder(qint64 pid, QString &error) {
+  if (::kill(static_cast<pid_t>(pid), SIGTERM) == 0)
+    return SignalOutcome::Sent;
+  if (errno == ESRCH)
+    return SignalOutcome::AlreadyGone;
+  error = QStringLiteral("Could not stop the running omasnap instance "
+                         "(pid %1): %2")
+              .arg(pid)
+              .arg(QString::fromLocal8Bit(std::strerror(errno)));
+  return SignalOutcome::Failed;
+}
+
+/** Claims a lock file whose owner is gone. */
+InstanceLockResult claimAbandonedLock(QLockFile &lock) {
+  lock.removeStaleLockFile();
+  if (lock.tryLock(0))
+    return {true, 0, {}, 0};
+  return {false, kInstanceLockErrorExitCode,
+          QStringLiteral("Could not claim the abandoned single-instance lock "
+                         "file %1")
+              .arg(lock.fileName()),
+          0};
+}
+
+/** Waits for the terminated instance to release the lock, then takes it. */
+bool waitForHandover(QLockFile &lock) {
+  QDeadlineTimer deadline(kHandoverTimeoutMs);
+  for (;;) {
+    if (lock.tryLock(0))
+      return true;
+    qint64 pid = 0;
+    if (lock.error() == QLockFile::LockFailedError &&
+        readHolder(lock, pid) != InstanceHolder::Alive) {
+      // The old process died without unlinking its lock file.
+      lock.removeStaleLockFile();
+      if (lock.tryLock(0))
+        return true;
+    }
+    if (deadline.hasExpired())
+      return false;
+    QThread::msleep(kHandoverPollMs);
+  }
+}
+} // namespace
+
+InstanceAction decideInstanceAction(InstanceLockProbe probe,
+                                    InstanceHolder holder, InstanceMode mode) {
+  switch (probe) {
+  case InstanceLockProbe::Acquired:
+    return InstanceAction::Proceed;
+  case InstanceLockProbe::PermissionError:
+  case InstanceLockProbe::UnknownError:
+    return InstanceAction::Fail;
+  case InstanceLockProbe::HeldByOther:
+    break;
+  }
+  if (holder != InstanceHolder::Alive)
+    return InstanceAction::ClearStaleLock;
+  return mode == InstanceMode::EditFile ? InstanceAction::ReplaceRunning
+                                        : InstanceAction::CancelRunning;
+}
+
+InstanceLockResult acquireInstanceLock(QLockFile &lock, InstanceMode mode) {
+  // Never expire a lock by age: a long annotation session is not stale.
+  lock.setStaleLockTime(0);
+  const InstanceLockProbe probe = probeLock(lock);
+  qint64 holderPid = 0;
+  const InstanceHolder holder = probe == InstanceLockProbe::HeldByOther
+                                    ? readHolder(lock, holderPid)
+                                    : InstanceHolder::Unknown;
+
+  QString error;
+  switch (decideInstanceAction(probe, holder, mode)) {
+  case InstanceAction::Proceed:
+    return {true, 0, {}, 0};
+  case InstanceAction::ClearStaleLock:
+    return claimAbandonedLock(lock);
+  case InstanceAction::CancelRunning:
+    switch (terminateHolder(holderPid, error)) {
+    case SignalOutcome::Sent:
+      return {false, kInstanceCancelledExitCode, {}, holderPid};
+    case SignalOutcome::AlreadyGone:
+      return claimAbandonedLock(lock); // Nothing to cancel; act as the first.
+    case SignalOutcome::Failed:
+      return {false, kInstanceLockErrorExitCode, error, 0};
+    }
+    break;
+  case InstanceAction::ReplaceRunning:
+    switch (terminateHolder(holderPid, error)) {
+    case SignalOutcome::Sent:
+      break;
+    case SignalOutcome::AlreadyGone:
+      return claimAbandonedLock(lock);
+    case SignalOutcome::Failed:
+      return {false, kInstanceLockErrorExitCode, error, 0};
+    }
+    if (waitForHandover(lock))
+      return {true, 0, {}, holderPid};
+    return {false, kInstanceLockErrorExitCode,
+            QStringLiteral("Timed out waiting for omasnap (pid %1) to release "
+                           "the single-instance lock")
+                .arg(holderPid),
+            holderPid};
+  case InstanceAction::Fail:
+    return {false, kInstanceLockErrorExitCode,
+            (probe == InstanceLockProbe::PermissionError
+                 ? QStringLiteral("No permission to use the single-instance "
+                                  "lock file %1")
+                 : QStringLiteral("Could not use the single-instance lock "
+                                  "file %1"))
+                .arg(lock.fileName()),
+            0};
+  }
+  return {false, kInstanceLockErrorExitCode,
+          QStringLiteral("Could not use the single-instance lock file %1")
+              .arg(lock.fileName()),
+          0};
+}

--- a/instance-lock.hpp
+++ b/instance-lock.hpp
@@ -1,0 +1,60 @@
+/** @fileoverview Declares single-instance lock handover decisions. */
+#pragma once
+
+#include <QString>
+
+class QLockFile;
+
+/** Exit code for a capture invocation that cancelled a running overlay. */
+inline constexpr int kInstanceCancelledExitCode = 0;
+/** Exit code for a lock that could neither be taken nor handed over. */
+inline constexpr int kInstanceLockErrorExitCode = 1;
+
+/** What the starting process wants to do, which decides how it treats a
+ * running instance. */
+enum class InstanceMode {
+  Capture,  // Screen-capture overlay: a second launch dismisses the first.
+  EditFile, // Editor for an existing image: it must always appear.
+};
+
+/** Result of a single non-blocking attempt to take the lock. */
+enum class InstanceLockProbe {
+  Acquired,        // The lock is ours; no other instance is running.
+  HeldByOther,     // Another process holds the lock.
+  PermissionError, // The lock path is not writable.
+  UnknownError,    // Anything else; never treat it as "already running".
+};
+
+/** Liveness of the process recorded in the lock file. */
+enum class InstanceHolder {
+  Alive,
+  Dead,
+  Unknown, // The lock info could not be read.
+};
+
+/** What the starting process should do about the lock. */
+enum class InstanceAction {
+  Proceed,        // Start normally.
+  ClearStaleLock, // Remove the abandoned lock file, then start normally.
+  CancelRunning,  // Terminate the running instance and exit without starting.
+  ReplaceRunning, // Terminate the running instance, wait, then start.
+  Fail,           // Report the lock error and exit non-zero.
+};
+
+/** Maps the observed lock state and the requested mode onto an action. */
+[[nodiscard]] InstanceAction decideInstanceAction(InstanceLockProbe probe,
+                                                  InstanceHolder holder,
+                                                  InstanceMode mode);
+
+/** Outcome of acting on the single-instance lock. */
+struct InstanceLockResult {
+  bool proceed = false; // Start the overlay or editor.
+  int exitCode = 0;     // Used when proceed is false.
+  QString error;        // Non-empty only for failures.
+  qint64 signalledPid = 0; // Instance that was asked to quit, if any.
+};
+
+/** Takes the lock, terminating and waiting for a running instance as the mode
+ * requires. */
+[[nodiscard]] InstanceLockResult acquireInstanceLock(QLockFile &lock,
+                                                     InstanceMode mode);

--- a/main.cpp
+++ b/main.cpp
@@ -246,10 +246,18 @@ int main(int argc, char **argv) {
                              .arg(localFile)
                              .arg(image.width())
                              .arg(image.height());
-  } else if (!captureFocusedMonitor(capture, error)) {
-    qCritical().noquote() << error;
-    sendCaptureNotification(QStringLiteral("Screenshot failed: %1").arg(error));
-    return 1;
+  } else {
+    // The quick fullscreen path never shows the overlay, so it never needs
+    // the window list that only window-mode hover consumes.
+    const bool quickFullscreen =
+        captureMode == CaptureEditor::CaptureMode::Fullscreen &&
+        quickOutputMode != QuickOutputMode::None;
+    if (!captureFocusedMonitor(capture, !quickFullscreen, error)) {
+      qCritical().noquote() << error;
+      sendCaptureNotification(
+          QStringLiteral("Screenshot failed: %1").arg(error));
+      return 1;
+    }
   }
 
   if (filePath.isEmpty())

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include "capture.hpp"
 #include "cli-path.hpp"
 #include "editor.hpp"
+#include "instance-lock.hpp"
 #include "pin.hpp"
 
 #include <LayerShellQt/Window>
@@ -97,9 +98,20 @@ int main(int argc, char **argv) {
   PosixSignalNotifier signalNotifier(&application);
 
   QCommandLineParser parser;
-  parser.setApplicationDescription(
-      QStringLiteral("Native Wayland screenshot and annotation overlay for "
-                     "Hyprland and Omarchy."));
+  parser.setApplicationDescription(QStringLiteral(
+      "Native Wayland screenshot and annotation overlay for Hyprland and "
+      "Omarchy.\n"
+      "\n"
+      "Only one capture overlay runs at a time. Starting omasnap again while "
+      "an\noverlay is open dismisses it: the running instance is asked to "
+      "quit and the\nnew process exits without capturing, so the same hotkey "
+      "opens and closes the\noverlay. Quick output (--copy, --save) dismisses "
+      "it the same way instead of\nscreenshotting the overlay. With --file (or "
+      "an image path) the running\ninstance is stopped and the editor opens on "
+      "that image instead.\n"
+      "\n"
+      "Exit codes: 0 success, including dismissing a running overlay; 1 "
+      "capture,\nimage, or single-instance lock failure; 2 usage error."));
   parser.addHelpOption();
   parser.addVersionOption();
   const QCommandLineOption fullscreenOption(
@@ -220,9 +232,21 @@ int main(int argc, char **argv) {
   }
   QLockFile instanceLock(
       QDir(runtime).filePath(QStringLiteral("omasnap.instance")));
-  instanceLock.setStaleLockTime(0);
-  if (!instanceLock.tryLock(0))
-    return 0;
+  // Every capture, quick output included, dismisses a running overlay instead
+  // of starting a second one: grim would otherwise photograph that overlay.
+  // filePath already covers --file and a positional image path or file URL.
+  const InstanceLockResult lockResult = acquireInstanceLock(
+      instanceLock,
+      filePath.isEmpty() ? InstanceMode::Capture : InstanceMode::EditFile);
+  if (lockResult.signalledPid != 0)
+    qInfo().noquote() << QStringLiteral("Asked the running omasnap (pid %1) to "
+                                        "quit")
+                             .arg(lockResult.signalledPid);
+  if (!lockResult.proceed) {
+    if (!lockResult.error.isEmpty())
+      qCritical().noquote() << lockResult.error;
+    return lockResult.exitCode;
+  }
 
   CaptureData capture;
   QString error;

--- a/main.cpp
+++ b/main.cpp
@@ -261,7 +261,7 @@ int main(int argc, char **argv) {
       return 1;
     }
     capture.source = image;
-    capture.preview = image;
+    capture.previewSize = image.size();
     capture.monitor.scale = 1.0;
     capture.monitor.pixelSize = image.size();
     capture.monitor.geometry = QRect(QPoint(0, 0), image.size());
@@ -297,8 +297,8 @@ int main(int argc, char **argv) {
       quickOutputMode != QuickOutputMode::None) {
     QString outputError;
     if (!quickOutput(renderCapture(capture,
-                                   QRectF(QPointF(), capture.preview.size()),
-                                   {}, BackgroundStyle::None),
+                                   QRectF(QPointF(), capture.previewSize), {},
+                                   BackgroundStyle::None),
                      quickOutputMode, outputError)) {
       qCritical().noquote() << outputError;
       return 1;

--- a/transform-smoke.cpp
+++ b/transform-smoke.cpp
@@ -101,7 +101,7 @@ bool runTransformSmoke(QString &error) {
     CaptureData rotatedCapture;
     if (!captureFocusedMonitor(rotatedCapture, true, error) ||
         rotatedCapture.monitor.geometry.size() != QSize(200, 300) ||
-        rotatedCapture.preview.size() != QSize(200, 300) ||
+        rotatedCapture.previewSize != QSize(200, 300) ||
         rotatedCapture.windows.size() != 1) {
       if (error.isEmpty())
         error = QStringLiteral("Quarter-turn monitor geometry was not swapped");
@@ -115,7 +115,7 @@ bool runTransformSmoke(QString &error) {
   CaptureData withoutWindows;
   if (!captureFocusedMonitor(withoutWindows, false, error) ||
       withoutWindows.source.size() != QSize(300, 200) ||
-      withoutWindows.preview.size() != QSize(300, 200) ||
+      withoutWindows.previewSize != QSize(300, 200) ||
       !withoutWindows.windows.isEmpty()) {
     if (error.isEmpty())
       error = QStringLiteral("Capture without window discovery was incorrect");

--- a/transform-smoke.cpp
+++ b/transform-smoke.cpp
@@ -60,12 +60,19 @@ bool runTransformSmoke(QString &error) {
       "\"x\":0,\"y\":0,\"activeWorkspace\":{\"id\":7}}]\\n' "
       "\"$OMASNAP_TEST_TRANSFORM\"\n"
       "else\n"
-      "  printf '[]\\n'\n"
+      "  printf '[{\"workspace\":{\"id\":7},\"at\":[0,0],\"size\":[100,100],"
+      "\"title\":\"Test window\",\"stableId\":\"w1\"}]\\n'\n"
       "fi\n");
-  const QByteArray grimScript =
-      QByteArrayLiteral("#!/usr/bin/env bash\n"
-                        "set -euo pipefail\n"
-                        "cp -- \"$OMASNAP_TEST_PPM\" \"${@: -1}\"\n");
+  // grim streams the capture on stdout; the garbage mode exits cleanly with
+  // undecodable bytes so the decode failure path can be checked.
+  const QByteArray grimScript = QByteArrayLiteral(
+      "#!/usr/bin/env bash\n"
+      "set -euo pipefail\n"
+      "if [[ -n \"${OMASNAP_TEST_GRIM_GARBAGE:-}\" ]]; then\n"
+      "  printf 'not-a-ppm'\n"
+      "  exit 0\n"
+      "fi\n"
+      "cat -- \"$OMASNAP_TEST_PPM\"\n");
   if (!writeExecutable(fakeHyprctl, hyprctlScript) ||
       !writeExecutable(fakeGrim, grimScript)) {
     error = QStringLiteral("Could not create transform-test commands");
@@ -83,23 +90,53 @@ bool runTransformSmoke(QString &error) {
   const QByteArray originalPath = qgetenv("PATH");
   qputenv("PATH", fakeCommands.path().toUtf8() + ':' + originalPath);
   qputenv("OMASNAP_TEST_PPM", ppmPath.toUtf8());
+  const auto restoreEnvironment = [&originalPath] {
+    qputenv("PATH", originalPath);
+    qunsetenv("OMASNAP_TEST_PPM");
+    qunsetenv("OMASNAP_TEST_TRANSFORM");
+    qunsetenv("OMASNAP_TEST_GRIM_GARBAGE");
+  };
   for (const int transform : {1, 3, 5, 7}) {
     qputenv("OMASNAP_TEST_TRANSFORM", QByteArray::number(transform));
     CaptureData rotatedCapture;
-    if (!captureFocusedMonitor(rotatedCapture, error) ||
+    if (!captureFocusedMonitor(rotatedCapture, true, error) ||
         rotatedCapture.monitor.geometry.size() != QSize(200, 300) ||
-        rotatedCapture.preview.size() != QSize(200, 300)) {
+        rotatedCapture.preview.size() != QSize(200, 300) ||
+        rotatedCapture.windows.size() != 1) {
       if (error.isEmpty())
         error = QStringLiteral("Quarter-turn monitor geometry was not swapped");
-      qputenv("PATH", originalPath);
-      qunsetenv("OMASNAP_TEST_PPM");
-      qunsetenv("OMASNAP_TEST_TRANSFORM");
+      restoreEnvironment();
       return false;
     }
   }
-  qputenv("PATH", originalPath);
-  qunsetenv("OMASNAP_TEST_PPM");
-  qunsetenv("OMASNAP_TEST_TRANSFORM");
+
+  // Callers that never show the overlay skip window discovery entirely.
+  qputenv("OMASNAP_TEST_TRANSFORM", QByteArrayLiteral("0"));
+  CaptureData withoutWindows;
+  if (!captureFocusedMonitor(withoutWindows, false, error) ||
+      withoutWindows.source.size() != QSize(300, 200) ||
+      withoutWindows.preview.size() != QSize(300, 200) ||
+      !withoutWindows.windows.isEmpty()) {
+    if (error.isEmpty())
+      error = QStringLiteral("Capture without window discovery was incorrect");
+    restoreEnvironment();
+    return false;
+  }
+
+  // A grim that exits cleanly but streams undecodable bytes must still explain
+  // itself instead of reporting an empty error.
+  qputenv("OMASNAP_TEST_GRIM_GARBAGE", QByteArrayLiteral("1"));
+  CaptureData undecodable;
+  QString decodeError;
+  const bool decoded = captureFocusedMonitor(undecodable, false, decodeError);
+  qunsetenv("OMASNAP_TEST_GRIM_GARBAGE");
+  if (decoded || decodeError.isEmpty()) {
+    error = QStringLiteral("Undecodable capture data did not report an error");
+    restoreEnvironment();
+    return false;
+  }
+
+  restoreEnvironment();
 
   const QImage upright = indexedImage({{1, 2}, {3, 4}, {5, 6}});
   const QVector<QPair<std::uint32_t, QImage>> transformedImages{


### PR DESCRIPTION
> **Depends on:** #41 (and via it #35–#40) — must merge first.
> **This layer alone:** 6 files, +392/−75. Everything else in the diff below is those pending PRs; draft until they merge, then I rebase (diff collapses to this layer) and mark ready.

| GUI-thread block (5K, Release) | before | after |
|---|---|---|
| select-all → editor responds | ~305 ms | **0.13–0.25 ms** |
| region-drag → editor responds | ~200 ms | **~5 ms** |
| saved screenshot bytes | — | byte-identical |

Entering edit froze the overlay for the duration of a synchronous full-resolution render + PNG encode + write of the working snapshot. Two changes:

- Intermediate crash-recovery writes run on the thread pool (`QtConcurrent`), one in flight, latest-wins; `finish()`, `pinSnapshot()`, `chooseWindow()`, and the destructor still flush synchronously, so the recovery guarantee and final-state ordering are unchanged.
- Intermediate writes use fast PNG encoding (quality 80 ≈ zlib level 1: 221 ms vs 295 ms at 5K, measured; qualities ≥90 hit stored/uncompressed and 40x the size, rejected). The finish-time write — the file that becomes the user's screenshot — keeps default compression; outputs verified byte-identical.

Smoke: `runSnapshotAsyncCheck` (exit 98) bounds the settle after enterEdit, asserts a burst + `finish(Save)` yields exactly the final state with no stale write and no snapshot resurrection after the move, and guards the saved-file size (≤1.5x a default-encoded reference — this catches fast encoding leaking into user files). ~30 existing snapshot reads moved to content-driven waits; 5 consecutive suite passes.

