### PR TITLE
Put redactions under the default annotation layer

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -636,6 +636,15 @@ void paintSpotlights(QPainter &painter, const QImage &source,
   painter.restore();
 }
 
+void paintDefaultLayer(QPainter &painter, const QImage &redacted,
+                       const QRectF &logicalBounds,
+                       const QVector<Annotation> &annotations) {
+  paintSpotlights(painter, redacted, logicalBounds, QRectF(redacted.rect()),
+                  annotations);
+  for (const Annotation &annotation : annotations)
+    paintAnnotation(painter, annotation);
+}
+
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
                             BackgroundStyle backgroundStyle) {
   if (backgroundStyle == BackgroundStyle::None)
@@ -879,10 +888,8 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   painter.translate(marginX, marginY);
   painter.scale(scaleX, scaleY);
   painter.setClipRect(QRectF(QPointF(), selection.size()));
-  paintSpotlights(painter, cropped, QRectF(QPointF(), selection.size()),
-                  QRectF(cropped.rect()), annotations);
-  for (const Annotation &annotation : annotations)
-    drawAnnotation(painter, annotation);
+  paintDefaultLayer(painter, cropped, QRectF(QPointF(), selection.size()),
+                    annotations);
   painter.restore();
   painter.end();
   return output;
@@ -908,9 +915,9 @@ QImage applyRedactionsScaled(QImage image, const QVector<Annotation> &redactions
     return image;
   const qreal scaleX = targetSize.width() / selection.width();
   const qreal scaleY = targetSize.height() / selection.height();
-  applyRedactions(image, redactions, scaleX, scaleY,
-                  QPointF(-selection.left() * scaleX,
-                          -selection.top() * scaleY));
+  // The image already starts at the selection origin and redactions are
+  // selection-relative, so scaling alone maps them onto the layer.
+  applyRedactions(image, redactions, scaleX, scaleY);
   return image;
 }
 

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -70,6 +70,13 @@ struct Annotation {
   bool operator==(const Annotation &) const = default;
 };
 
+enum class AnnotationLayer { Redaction, Default };
+
+[[nodiscard]] constexpr AnnotationLayer annotationLayer(Annotation::Kind kind) {
+  return kind == Annotation::Kind::Redaction ? AnnotationLayer::Redaction
+                                             : AnnotationLayer::Default;
+}
+
 [[nodiscard]] bool loadCaptureFonts();
 [[nodiscard]] QFont annotationTextFont(qreal size);
 /**
@@ -108,10 +115,18 @@ void paintAnnotation(QPainter &painter, const Annotation &annotation);
 void paintSpotlights(QPainter &painter, const QImage &source,
                      const QRectF &targetBounds, const QRectF &sourceRect,
                      const QVector<Annotation> &annotations);
+/**
+ * Paints the default annotation layer (spotlights, then vectors) in selection
+ * space. Spotlights sample `redacted`, which must already include the
+ * redaction layer so a loupe cannot magnify source pixels.
+ */
+void paintDefaultLayer(QPainter &painter, const QImage &redacted,
+                       const QRectF &logicalBounds,
+                       const QVector<Annotation> &annotations);
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
                             BackgroundStyle backgroundStyle);
 /**
- * Renders the selection region at `targetSize` for redaction previews. The
+ * Renders the selection region at `targetSize` for the redaction layer. The
  * result carries no annotations; callers overlay redactions with
  * applyRedactionsScaled and cache it while the selection is unchanged.
  */
@@ -121,7 +136,7 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
 /**
  * Paints redaction annotations over a display-resolution selection image. The
  * source image MUST be the exact selection region scaled to `targetSize`;
- * annotations live in the same logical coordinate space as `selection`.
+ * annotations are selection-relative, spanning 0..`selection` size.
  */
 QImage applyRedactionsScaled(QImage image, const QVector<Annotation> &redactions,
                              const QRectF &selection, const QSizeF &targetSize);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2383,11 +2383,36 @@ void CaptureEditor::paintEdit(QPainter &painter) {
 
   QPainterPath clip;
   clip.addRoundedRect(image, hasBackground ? 10 : 0, hasBackground ? 10 : 0);
-  QVector<Annotation> redactions;
-  for (const Annotation &annotation : annotations_) {
-    if (annotation.kind == Annotation::Kind::Redaction)
-      redactions.push_back(annotation);
+  const QSize targetSize(qRound(image.width() * devicePixelRatioF()),
+                         qRound(image.height() * devicePixelRatioF()));
+  // Cache the un-annotated selection at display resolution. Rebuilding it
+  // from the native source every pointer move would stall large captures.
+  if (redactionBaseStale_ || redactionBaseSize_ != targetSize ||
+      cachedRedactionSelection_ != selection_) {
+    redactionBase_ = renderSelectionBase(capture_, selection_, targetSize);
+    redactionBaseSize_ = targetSize;
+    cachedRedactionSelection_ = selection_;
+    redactionLayerCache_ = {};
+    cachedCommittedRedactions_.clear();
+    redactionBaseStale_ = false;
   }
+
+  QVector<Annotation> committedRedactions;
+  for (const Annotation &annotation : annotations_) {
+    if (annotationLayer(annotation.kind) == AnnotationLayer::Redaction)
+      committedRedactions.push_back(annotation);
+  }
+  if (redactionLayerCache_.isNull() ||
+      cachedCommittedRedactions_ != committedRedactions) {
+    cachedCommittedRedactions_ = committedRedactions;
+    redactionLayerCache_ =
+        committedRedactions.isEmpty()
+            ? redactionBase_
+            : applyRedactionsScaled(redactionBase_, committedRedactions,
+                                    selection_, QSizeF(targetSize));
+  }
+
+  QImage redactionLayer = redactionLayerCache_;
   if (dragging_ && tool_ == Tool::Redact) {
     Annotation preview;
     preview.kind = Annotation::Kind::Redaction;
@@ -2395,34 +2420,16 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     preview.end = toAnnotationPoint(cursor_);
     preview.redactionStyle = redactionStyle_;
     preview.redactionSeed = activeRedactionSeed_;
-    redactions.push_back(std::move(preview));
+    redactionLayer = applyRedactionsScaled(redactionLayerCache_, {preview},
+                                           selection_, QSizeF(targetSize));
   }
+
   painter.save();
   painter.setClipPath(clip);
-  if (redactions.isEmpty()) {
+  if (!redactionLayer.isNull())
+    painter.drawImage(image, redactionLayer);
+  else
     painter.drawImage(image, capture_.source, sourceRect(selection_));
-  } else {
-    // Redact against a cached display-resolution base: rebuilding it from the
-    // native source every drag frame would stall the overlay on large
-    // captures. Only the redaction blocks change while dragging.
-    const QSize targetSize(qRound(image.width() * devicePixelRatioF()),
-                           qRound(image.height() * devicePixelRatioF()));
-    if (redactionBaseStale_ || redactionBaseSize_ != targetSize ||
-        cachedRedactionSelection_ != selection_) {
-      redactionBase_ = renderSelectionBase(capture_, selection_, targetSize);
-      redactionBaseSize_ = targetSize;
-      cachedRedactionSelection_ = selection_;
-      redactionPreviewCache_ = {};
-      redactionBaseStale_ = false;
-    }
-    if (redactionPreviewCache_.isNull() ||
-        cachedPreviewRedactions_ != redactions) {
-      cachedPreviewRedactions_ = redactions;
-      redactionPreviewCache_ = applyRedactionsScaled(
-          redactionBase_, redactions, selection_, QSizeF(targetSize));
-    }
-    painter.drawImage(image, redactionPreviewCache_);
-  }
   painter.restore();
 
   painter.save();
@@ -2430,27 +2437,14 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   painter.scale(editScale(), editScale());
   painter.save();
   painter.setClipRect(QRectF(QPointF(), selection_.size()));
-  QVector<Annotation> liveAnnotations = annotations_;
-  if (dragging_ && tool_ == Tool::Spotlight) {
-    Annotation preview;
-    preview.kind = Annotation::Kind::Spotlight;
-    preview.start = dragStart_;
-    const QPointF end = toAnnotationPoint(cursor_);
-    preview.end = creationConstraintActive_
-                      ? constrainedCreationEndpoint(tool_, dragStart_, end)
-                      : end;
-    preview.magnification = spotlightMagnification_;
-    preview.spotlightShape = spotlightShape_;
-    preview.color = annotationColor();
-    preview.size = annotationSize_;
-    liveAnnotations.push_back(std::move(preview));
-  }
-  paintSpotlights(painter, capture_.source, QRectF(QPointF(), selection_.size()),
-                  sourceRect(selection_), liveAnnotations);
+  QVector<Annotation> defaultAnnotations;
+  defaultAnnotations.reserve(annotations_.size() + 1);
   for (int index = 0; index < annotations_.size(); ++index) {
-    if (index != editingAnnotation_ &&
-        annotations_.at(index).kind != Annotation::Kind::Redaction)
-      paintAnnotation(painter, annotations_.at(index));
+    if (index == editingAnnotation_)
+      continue;
+    if (annotationLayer(annotations_.at(index).kind) ==
+        AnnotationLayer::Default)
+      defaultAnnotations.push_back(annotations_.at(index));
   }
   if (dragging_ && tool_ != Tool::Select && tool_ != Tool::Redact) {
     Annotation preview;
@@ -2480,7 +2474,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     }
     preview.color = tool_ == Tool::Ocr ? QColor(Qt::white) : annotationColor();
     preview.size = tool_ == Tool::Ocr ? 2.0 : annotationSize_;
-    paintAnnotation(painter, preview);
+    defaultAnnotations.push_back(std::move(preview));
   } else if (tool_ == Tool::Marker && image.contains(cursor_)) {
     Annotation preview;
     preview.kind = Annotation::Kind::Marker;
@@ -2489,7 +2483,16 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     preview.color = annotationColor();
     preview.color.setAlpha(185);
     preview.size = annotationSize_;
-    paintAnnotation(painter, preview);
+    defaultAnnotations.push_back(std::move(preview));
+  }
+  // Default-layer tools (including spotlight) sample the redaction layer,
+  // never the raw capture. The layer image is already the selection crop.
+  if (!redactionLayer.isNull()) {
+    paintDefaultLayer(painter, redactionLayer,
+                      QRectF(QPointF(), selection_.size()), defaultAnnotations);
+  } else {
+    for (const Annotation &annotation : defaultAnnotations)
+      paintAnnotation(painter, annotation);
   }
   painter.restore();
   if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -203,8 +203,10 @@ private:
   RedactionStyle redactionStyle_ = RedactionStyle::Pixelate;
   quint32 activeRedactionSeed_ = 0;
   QRectF cachedRedactionSelection_;
-  QVector<Annotation> cachedPreviewRedactions_;
-  QImage redactionPreviewCache_;
+  QVector<Annotation> cachedCommittedRedactions_;
+  // Committed redaction layer at display resolution. Live drag paints the
+  // in-progress rect on a copy so committed blocks are not rebuilt per move.
+  QImage redactionLayerCache_;
   // Display-resolution selection image reused across redaction drag frames.
   QImage redactionBase_;
   QSize redactionBaseSize_;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -741,6 +741,256 @@ bool runTextClickAwayCommitCheck(QApplication &application, QString &error) {
   return true;
 }
 
+bool showsSecretRed(const QColor &color) {
+  return color.red() > 180 && color.green() < 70 && color.blue() < 70;
+}
+
+/** Redaction sits under every other tool in both preview and export. */
+bool runAnnotationLayerChecks(QApplication &application, QString &error) {
+  const QColor solid(QStringLiteral("#121216"));
+  const QColor secret(QStringLiteral("#ff0000"));
+  const QColor backdrop(QStringLiteral("#182030"));
+
+  if (annotationLayer(Annotation::Kind::Redaction) !=
+          AnnotationLayer::Redaction ||
+      annotationLayer(Annotation::Kind::Arrow) != AnnotationLayer::Default ||
+      annotationLayer(Annotation::Kind::Spotlight) !=
+          AnnotationLayer::Default ||
+      annotationLayer(Annotation::Kind::Text) != AnnotationLayer::Default) {
+    error = QStringLiteral("Annotation kinds did not map onto two layers");
+    return false;
+  }
+
+  // Selection-relative redactions must stay put when the crop is not at the
+  // origin. The old applyRedactionsScaled offset subtracted selection.topLeft()
+  // and slid the block off the secret.
+  QImage scaledBase(100, 80, QImage::Format_ARGB32_Premultiplied);
+  scaledBase.fill(secret);
+  Annotation scaledRedaction;
+  scaledRedaction.kind = Annotation::Kind::Redaction;
+  scaledRedaction.start = {10, 10};
+  scaledRedaction.end = {40, 40};
+  scaledRedaction.redactionStyle = RedactionStyle::Solid;
+  const QImage scaled = applyRedactionsScaled(
+      scaledBase, {scaledRedaction}, QRectF(200, 150, 100, 80), QSizeF(100, 80));
+  if (scaled.pixelColor(20, 20) != solid ||
+      scaled.pixelColor(2, 2) != secret) {
+    error = QStringLiteral(
+        "Scaled redaction layer used capture coordinates instead of "
+        "selection-relative ones");
+    return false;
+  }
+
+  CaptureData capture;
+  capture.monitor.scale = 1.0;
+  capture.monitor.pixelSize = {80, 40};
+  capture.source = QImage(80, 40, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(backdrop);
+  for (int y = 10; y < 30; ++y) {
+    for (int x = 20; x < 40; ++x)
+      capture.source.setPixelColor(x, y, secret);
+  }
+  capture.preview = capture.source;
+
+  Annotation redaction;
+  redaction.kind = Annotation::Kind::Redaction;
+  redaction.start = {20, 10};
+  redaction.end = {40, 30};
+  redaction.redactionStyle = RedactionStyle::Solid;
+
+  Annotation lens;
+  lens.kind = Annotation::Kind::Spotlight;
+  lens.start = {16, 6};
+  lens.end = {44, 34};
+  lens.magnification = 2.0;
+  lens.color = Qt::white;
+  lens.size = 2;
+
+  const QImage spotlightExport =
+      renderCapture(capture, QRectF(0, 0, 80, 40), {redaction, lens},
+                    BackgroundStyle::None);
+  if (spotlightExport.isNull() ||
+      showsSecretRed(spotlightExport.pixelColor(30, 20)) ||
+      spotlightExport.pixelColor(30, 20) != solid) {
+    error = QStringLiteral("Export spotlight sampled un-redacted source pixels");
+    return false;
+  }
+
+  Annotation arrow;
+  arrow.kind = Annotation::Kind::Arrow;
+  arrow.start = {22, 20};
+  arrow.end = {38, 20};
+  arrow.color = QColor(QStringLiteral("#0a84ff"));
+  arrow.size = 4;
+  Annotation label;
+  label.kind = Annotation::Kind::Text;
+  label.start = {24, 26};
+  label.text = QStringLiteral("X");
+  label.color = Qt::white;
+  label.size = 8;
+  const QImage redactionOnly =
+      renderCapture(capture, QRectF(0, 0, 80, 40), {redaction},
+                    BackgroundStyle::None);
+  const QImage overlayExport =
+      renderCapture(capture, QRectF(0, 0, 80, 40), {redaction, arrow, label},
+                    BackgroundStyle::None);
+  const QColor overlayFill = overlayExport.pixelColor(22, 12);
+  const QColor overlayStroke = overlayExport.pixelColor(26, 20);
+  if (overlayExport.isNull() || redactionOnly.isNull() ||
+      redactionOnly.pixelColor(22, 12) != solid || showsSecretRed(overlayFill) ||
+      overlayStroke.blue() <= overlayStroke.red() + 20) {
+    error = QStringLiteral(
+        "Export did not keep redaction under arrow and text");
+    return false;
+  }
+
+  CaptureData editorCapture;
+  editorCapture.monitor.name = QStringLiteral("TEST");
+  editorCapture.monitor.geometry = {0, 0, 800, 600};
+  editorCapture.monitor.pixelSize = {800, 600};
+  editorCapture.monitor.scale = 1.0;
+  editorCapture.source =
+      QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  editorCapture.source.fill(backdrop);
+  {
+    QPainter painter(&editorCapture.source);
+    painter.fillRect(QRect(200, 200, 100, 60), secret);
+  }
+  editorCapture.preview = editorCapture.source;
+
+  // Fullscreen draws the 800x600 capture at 84,68 scaled by 0.79. The secret
+  // then covers 242,226 to 321,273, centered on 281,250. A loupe smaller than
+  // the redaction can only show redacted pixels if it samples the redaction
+  // layer.
+  const auto spotlightPreviewColor = [&](bool redact) {
+    CaptureEditor editor(editorCapture, CaptureEditor::CaptureMode::Fullscreen);
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    if (redact) {
+      QTest::keyClick(&editor, Qt::Key_D);
+      QTest::keyClick(&editor, Qt::Key_D);
+      QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(230, 214));
+      QTest::mouseMove(&editor, QPoint(333, 285), 20);
+      QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                          QPoint(333, 285));
+      application.processEvents();
+    }
+    QTest::keyClick(&editor, Qt::Key_S);
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(251, 230));
+    QTest::mouseMove(&editor, QPoint(311, 270), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(311, 270));
+    application.processEvents();
+    const QColor color = editor.grab().toImage().pixelColor(QPoint(281, 250));
+    editor.close();
+    return color;
+  };
+  if (!showsSecretRed(spotlightPreviewColor(false))) {
+    error = QStringLiteral("Spotlight preview did not magnify the capture");
+    return false;
+  }
+  if (showsSecretRed(spotlightPreviewColor(true))) {
+    error = QStringLiteral("Spotlight preview magnified un-redacted pixels");
+    return false;
+  }
+
+  {
+    CaptureEditor editor(editorCapture, CaptureEditor::CaptureMode::Fullscreen);
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::keyClick(&editor, Qt::Key_D);
+    QTest::keyClick(&editor, Qt::Key_D);
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(230, 214));
+    QTest::mouseMove(&editor, QPoint(333, 285), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(333, 285));
+    QTest::keyClick(&editor, Qt::Key_5);
+    QTest::keyClick(&editor, Qt::Key_A);
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(250, 250));
+    QTest::mouseMove(&editor, QPoint(312, 250), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(312, 250));
+    application.processEvents();
+    const QImage preview = editor.grab().toImage();
+    const QImage exported = editor.renderCurrentOutput();
+    editor.close();
+    const QColor arrowColor(QStringLiteral("#0a84ff"));
+    if (preview.pixelColor(250, 226) != solid ||
+        showsSecretRed(preview.pixelColor(250, 226)) ||
+        preview.pixelColor(260, 250) != arrowColor) {
+      error = QStringLiteral("Preview did not keep redaction under the arrow");
+      return false;
+    }
+    if (exported.pixelColor(210, 202) != solid ||
+        showsSecretRed(exported.pixelColor(210, 202)) ||
+        exported.pixelColor(220, 230) != arrowColor) {
+      error = QStringLiteral("Export did not keep redaction under the arrow");
+      return false;
+    }
+  }
+
+  {
+    CaptureData offsetCapture = editorCapture;
+    {
+      QPainter painter(&offsetCapture.source);
+      painter.fillRect(QRect(450, 350, 80, 60), secret);
+    }
+    offsetCapture.preview = offsetCapture.source;
+    CaptureEditor editor(offsetCapture);
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+
+    // Region 200,150 400x300 draws at 200,155 with edit scale 1. The secret
+    // is then at 450,355 to 530,415. A preview that subtracts the selection
+    // origin lands the block around 250,205 instead.
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 150));
+    QTest::mouseMove(&editor, QPoint(600, 450), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(600, 450));
+    application.processEvents();
+    const QPoint secretCenter(490, 385);
+    const QPoint displacedCenter(250, 205);
+    if (!showsSecretRed(editor.grab().toImage().pixelColor(secretCenter))) {
+      error = QStringLiteral("Editor did not show the secret before redacting");
+      return false;
+    }
+
+    QTest::keyClick(&editor, Qt::Key_D);
+    QTest::keyClick(&editor, Qt::Key_D);
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(450, 355));
+    QTest::mouseMove(&editor, QPoint(530, 415), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(530, 415));
+    application.processEvents();
+    const QImage preview = editor.grab().toImage();
+    const QImage exported = editor.renderCurrentOutput();
+    editor.close();
+    if (showsSecretRed(preview.pixelColor(secretCenter)) ||
+        preview.pixelColor(secretCenter) != solid) {
+      error = QStringLiteral("Redaction preview left the secret visible");
+      return false;
+    }
+    if (preview.pixelColor(displacedCenter) == solid) {
+      error = QStringLiteral(
+          "Redaction preview drew the block at the selection offset");
+      return false;
+    }
+    if (exported.size() != QSize(400, 300) ||
+        exported.pixelColor(290, 230) != solid ||
+        showsSecretRed(exported.pixelColor(290, 230)) ||
+        exported.pixelColor(10, 10) != backdrop) {
+      error = QStringLiteral(
+          "Export redaction did not stay on the off-origin secret");
+      return false;
+    }
+  }
+  return true;
+}
+
 bool runContinuousAnnotationToolsSmoke(QApplication &application,
                                        QString &error) {
   CaptureData capture;
@@ -1174,6 +1424,10 @@ int main(int argc, char **argv) {
   if (!runTextClickAwayCommitCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 87;
+  }
+  if (!runAnnotationLayerChecks(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 86;
   }
   if (!runContinuousAnnotationToolsSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
## Summary
- Split compositing into two layers: redaction on the bottom, every other tool (arrow, line, freehand, highlighter, marker, rectangle, text, spotlight) on a default layer above. Eyedropper is not a layer.
- `renderCapture` and `paintEdit` share that order. Spotlight samples the already-redacted selection image in both preview and export, so a loupe cannot magnify source pixels.
- `applyRedactionsScaled` no longer subtracts `selection.topLeft()`. Annotations are selection-relative, so region crops keep the block on the secret (fixes #44).
- The committed redaction layer is cached at display resolution; a live redact drag paints only the in-progress rect on a copy of that cache.

## Test plan
- [x] `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- [x] `cmake --build build --parallel --target omasnap-smoke` (Debian LayerShellQt 6.3.4 cannot build the `omasnap` binary; smoke does not link it)
- [x] `QT_QPA_PLATFORM=offscreen ./build/omasnap-smoke /tmp/omasnap-smoke` (exit 0)
- New `runAnnotationLayerChecks` covers:
  - redaction under spotlight (preview + export, no source leak)
  - redaction under arrow/text
  - non-origin region selection (redaction stays on the secret)
- [ ] Visual check on Hyprland: region away from origin, redact, then spotlight over the block