### PR TITLE
fix: make check work with clean and absolute builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,14 @@ all: build
 configure:
 	$(CMAKE) -S . -B $(BUILD_DIR) -G $(GENERATOR) \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
 		-DCMAKE_INSTALL_PREFIX=$(PREFIX)
 
 build: configure
 	$(CMAKE) --build $(BUILD_DIR) --parallel
 
 smoke: build
-	QT_QPA_PLATFORM=offscreen ./$(BUILD_DIR)/omasnap-smoke \
+	QT_QPA_PLATFORM=offscreen $(BUILD_DIR)/omasnap-smoke \
 		$(BUILD_DIR)/omasnap-smoke-output
 
 lint: build


### PR DESCRIPTION
 ## Summary

  - Generate `compile_commands.json` so `make check` can run `clang-tidy` on a clean build.
  - Support absolute `BUILD_DIR` paths when running the smoke executable.

  ## Testing

  - `make check`
  - `make smoke BUILD_DIR=/tmp/omasnap-make-check-build`