### PR TITLE
 Open clipboard images in the annotation editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ target_link_libraries(omasnap PRIVATE
 
 qt_add_executable(omasnap-smoke
   tests/editor-smoke.cpp
+  tests/clipboard-smoke.cpp
+  tests/clipboard-smoke.hpp
   src/icons.cpp
   src/icons.hpp
   src/instance-lock.cpp

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ LINT_SOURCES := \
 	src/cli-path.cpp src/icons.cpp src/pin.cpp src/pin-file.cpp \
 	src/pin-layout.cpp src/eyedropper.cpp src/instance-lock.cpp \
 	tests/editor-smoke.cpp tests/transform-smoke.cpp \
+	tests/clipboard-smoke.cpp \
 	tests/surface-capture-smoke.cpp tests/pin-layout-smoke.cpp \
 	tests/pin-lifecycle-smoke.cpp tests/instance-lock-smoke.cpp
 LINT_CHECKS ?= -*,clang-analyzer-*,bugprone-*,performance-*,misc-*

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   clipboard output streams the same PNG.
 - Verified PNG clipboard output through `wl-copy`/`wl-paste`, plus timestamped files
   under `~/Pictures/Screenshots` by default.
+- Open an image already on the clipboard directly in the annotation editor.
 - Correct native-pixel export on fractional or integer-scaled monitors.
 
 ## Platform scope
@@ -163,8 +164,8 @@ result is copied, saved, or both.
 
 Quick output skips the annotation editor. Add `--copy` to copy only, `--save` to save
 only, or both flags to copy and save. Region and window captures output after selection;
-fullscreen captures output immediately. Quick output cannot be combined with `--file` or
-`--pin`.
+fullscreen captures output immediately. Quick output cannot be combined with `--file`,
+`--clipboard`, or `--pin`.
 
 ### One instance, toggled by the same hotkey
 
@@ -177,9 +178,10 @@ Every capture invocation dismisses this way, quick output included: `--copy`/`--
 while an overlay is open closes the overlay and outputs nothing, rather than screenshotting
 the overlay that is still on screen.
 
-Editing an existing image is never cancelled this way: `--file` (or an image path) stops
-the running instance, waits up to two seconds for the lock, and opens the editor on that
-image. That is how a pin's Edit button and a notification click always land in the editor.
+Editing an existing image is never cancelled this way: `--file`, `--clipboard`, or an
+image path stops the running instance, waits up to two seconds for the lock, and opens the
+editor on that image. That is how a pin's Edit button and a notification click always land
+in the editor.
 
 A lock left behind by a crashed instance is removed and reclaimed. A lock file that cannot
 be read or written at all is reported on stderr instead of being mistaken for a running
@@ -193,7 +195,7 @@ Exit codes:
 | `1` | Capture, image, or single-instance lock failure |
 | `2` | Usage error |
 
-### Edit an existing image
+### Edit an existing or clipboard image
 
 Point omasnap at any readable image and it opens straight into the annotation editor
 with the whole image selected, skipping the screen-capture step:
@@ -204,9 +206,18 @@ omasnap ~/Pictures/Screenshots/screenshot-2026-08-11_10-00-00.png
 omasnap --file /path/to/capture.png
 ```
 
+To open the image currently on the Wayland clipboard:
+
+```bash
+omasnap --clipboard
+```
+
+The clipboard must offer readable image data. Text-only clipboard contents return an
+error instead of opening an empty editor.
+
 File URLs are accepted too. A saved capture notification's "Click to edit" action launches
-`omasnap` on the finished screenshot, so it can be reopened and re-annotated. Clipboard-only
-captures are not retained on disk and therefore have no delayed edit action.
+`omasnap` on the finished screenshot, so it can be reopened and re-annotated. Captures copied
+without saving are not retained on disk and therefore have no delayed edit action.
 
 Environment overrides:
 

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -921,6 +921,75 @@ QImage applyRedactionsScaled(QImage image, const QVector<Annotation> &redactions
   return image;
 }
 
+bool loadClipboardImage(QImage &image, QString &error) {
+  image = {};
+  error.clear();
+
+  const ProcessResult listed =
+      runProcess(QStringLiteral("wl-paste"), {QStringLiteral("--list-types")},
+                 {}, 5000);
+  if (!listed.finished || listed.exitCode != 0) {
+    const QString detail = QString::fromUtf8(listed.error).trimmed();
+    error = detail.isEmpty()
+                ? QStringLiteral("Could not read the Wayland clipboard")
+                : QStringLiteral("Could not read the Wayland clipboard: %1")
+                      .arg(detail);
+    return false;
+  }
+
+  const QStringList offered =
+      QString::fromUtf8(listed.output)
+          .split('\n', Qt::SkipEmptyParts, Qt::CaseSensitive);
+  QStringList imageTypes;
+  const QStringList preferred{QStringLiteral("image/png"),
+                              QStringLiteral("image/jpeg"),
+                              QStringLiteral("image/webp"),
+                              QStringLiteral("image/bmp")};
+  for (const QString &mimeType : preferred) {
+    if (offered.contains(mimeType))
+      imageTypes.append(mimeType);
+  }
+  for (const QString &mimeType : offered) {
+    const QString trimmed = mimeType.trimmed();
+    if (trimmed.startsWith(QStringLiteral("image/")) &&
+        !imageTypes.contains(trimmed))
+      imageTypes.append(trimmed);
+  }
+  if (imageTypes.isEmpty()) {
+    error = QStringLiteral("Clipboard does not contain an image");
+    return false;
+  }
+
+  bool receivedImageData = false;
+  QString readError;
+  for (const QString &mimeType : imageTypes) {
+    const ProcessResult pasted = runProcess(
+        QStringLiteral("wl-paste"),
+        {QStringLiteral("--no-newline"), QStringLiteral("--type"), mimeType},
+        {}, 5000);
+    if (!pasted.finished || pasted.exitCode != 0) {
+      const QString detail = QString::fromUtf8(pasted.error).trimmed();
+      if (!detail.isEmpty())
+        readError = detail;
+      continue;
+    }
+    receivedImageData = true;
+    image = QImage::fromData(pasted.output);
+    if (!image.isNull())
+      return true;
+  }
+
+  if (!receivedImageData) {
+    error = readError.isEmpty()
+                ? QStringLiteral("Could not read clipboard image")
+                : QStringLiteral("Could not read clipboard image: %1")
+                      .arg(readError);
+    return false;
+  }
+  error = QStringLiteral("Clipboard image could not be decoded");
+  return false;
+}
+
 bool copyPngFileToClipboard(const QString &path, QString &error) {
   QFile input(path);
   if (!input.open(QIODevice::ReadOnly)) {

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -106,6 +106,8 @@ enum class AnnotationLayer { Redaction, Default };
                                    const QRectF &selection,
                                    const QVector<Annotation> &annotations,
                                    BackgroundStyle backgroundStyle);
+/** Loads the current Wayland clipboard image. */
+[[nodiscard]] bool loadClipboardImage(QImage &image, QString &error);
 [[nodiscard]] bool copyPngFileToClipboard(const QString &path, QString &error);
 [[nodiscard]] bool quickOutput(const QImage &image, QuickOutputMode mode,
                                QString &error);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,8 +107,8 @@ int main(int argc, char **argv) {
       "quit and the\nnew process exits without capturing, so the same hotkey "
       "opens and closes the\noverlay. Quick output (--copy, --save) dismisses "
       "it the same way instead of\nscreenshotting the overlay. With --file (or "
-      "an image path) the running\ninstance is stopped and the editor opens on "
-      "that image instead.\n"
+      "an image path) or --clipboard, the running\ninstance is stopped and "
+      "the editor opens on that image instead.\n"
       "\n"
       "Exit codes: 0 success, including dismissing a running overlay; 1 "
       "capture,\nimage, or single-instance lock failure; 2 usage error."));
@@ -140,6 +140,11 @@ int main(int argc, char **argv) {
                      "instead of capturing the screen."),
       QStringLiteral("path"));
   parser.addOption(fileOption);
+  const QCommandLineOption clipboardOption(
+      QStringLiteral("clipboard"),
+      QStringLiteral("Open the current clipboard image in the annotation "
+                     "editor instead of capturing the screen."));
+  parser.addOption(clipboardOption);
   const QCommandLineOption pinOption(
       QStringLiteral("pin"),
       QStringLiteral("Show an image as a pinned always-visible layer."),
@@ -153,6 +158,7 @@ int main(int argc, char **argv) {
   parser.process(application);
 
   QString filePath = parser.value(fileOption);
+  const bool clipboardInput = parser.isSet(clipboardOption);
 
   QuickOutputMode quickOutputMode = QuickOutputMode::None;
   if (parser.isSet(copyOption) && parser.isSet(saveOption))
@@ -172,8 +178,8 @@ int main(int argc, char **argv) {
 
   const QStringList positional = parser.positionalArguments();
   if (parser.isSet(pinOption)) {
-    if (!filePath.isEmpty() || requestedModes > 0 || !positional.isEmpty() ||
-        quickOutputMode != QuickOutputMode::None) {
+    if (!filePath.isEmpty() || clipboardInput || requestedModes > 0 ||
+        !positional.isEmpty() || quickOutputMode != QuickOutputMode::None) {
       qCritical()
           << "Pinned mode cannot be combined with capture or edit targets";
       return 2;
@@ -217,8 +223,14 @@ int main(int argc, char **argv) {
     qCritical() << "An image file cannot be combined with a capture mode";
     return 2;
   }
-  if (!filePath.isEmpty() && quickOutputMode != QuickOutputMode::None) {
-    qCritical() << "Quick output options cannot be combined with an image file";
+  if (clipboardInput && (!filePath.isEmpty() || requestedModes > 0)) {
+    qCritical() << "Clipboard input cannot be combined with another target";
+    return 2;
+  }
+  const bool editingImage = clipboardInput || !filePath.isEmpty();
+  if (editingImage && quickOutputMode != QuickOutputMode::None) {
+    qCritical()
+        << "Quick output options cannot be combined with an image input";
     return 2;
   }
   if (!loadCaptureFonts())
@@ -234,10 +246,10 @@ int main(int argc, char **argv) {
       QDir(runtime).filePath(QStringLiteral("omasnap.instance")));
   // Every capture, quick output included, dismisses a running overlay instead
   // of starting a second one: grim would otherwise photograph that overlay.
-  // filePath already covers --file and a positional image path or file URL.
+  // Editing an image always takes over so the requested editor can open.
   const InstanceLockResult lockResult = acquireInstanceLock(
-      instanceLock,
-      filePath.isEmpty() ? InstanceMode::Capture : InstanceMode::EditFile);
+      instanceLock, editingImage ? InstanceMode::EditFile
+                                 : InstanceMode::Capture);
   if (lockResult.signalledPid != 0)
     qInfo().noquote() << QStringLiteral("Asked the running omasnap (pid %1) to "
                                         "quit")
@@ -250,15 +262,29 @@ int main(int argc, char **argv) {
 
   CaptureData capture;
   QString error;
-  if (!filePath.isEmpty()) {
-    QString localFile = QUrl(filePath).toLocalFile();
-    if (localFile.isEmpty())
-      localFile = filePath;
-    QImage image(localFile);
-    if (image.isNull()) {
-      qCritical().noquote()
-          << QStringLiteral("Could not load image: %1").arg(filePath);
-      return 1;
+  if (editingImage) {
+    QImage image;
+    QString inputName;
+    if (clipboardInput) {
+      if (!loadClipboardImage(image, error)) {
+        const QString message =
+            QStringLiteral("Could not load clipboard image: %1").arg(error);
+        qCritical().noquote() << message;
+        sendCaptureNotification(message);
+        return 1;
+      }
+      inputName = QStringLiteral("clipboard image");
+    } else {
+      QString localFile = QUrl(filePath).toLocalFile();
+      if (localFile.isEmpty())
+        localFile = filePath;
+      image.load(localFile);
+      if (image.isNull()) {
+        qCritical().noquote()
+            << QStringLiteral("Could not load image: %1").arg(filePath);
+        return 1;
+      }
+      inputName = localFile;
     }
     capture.source = image;
     capture.preview = image;
@@ -267,7 +293,7 @@ int main(int argc, char **argv) {
     capture.monitor.geometry = QRect(QPoint(0, 0), image.size());
     captureMode = CaptureEditor::CaptureMode::File;
     qInfo().noquote() << QStringLiteral("Opened %1 for annotation (%2x%3)")
-                             .arg(localFile)
+                             .arg(inputName)
                              .arg(image.width())
                              .arg(image.height());
   } else if (!probeFocusedMonitor(capture.monitor, error)) {
@@ -279,7 +305,7 @@ int main(int argc, char **argv) {
   // Fullscreen quick output never shows an overlay: the capture runs in the
   // background and the result is written out without opening the editor UI.
   const bool instantFullscreenOutput =
-      filePath.isEmpty() && captureMode == CaptureEditor::CaptureMode::Fullscreen &&
+      !editingImage && captureMode == CaptureEditor::CaptureMode::Fullscreen &&
       quickOutputMode != QuickOutputMode::None;
   const QuickOutputMode editorQuickOutput = instantFullscreenOutput
                                                 ? QuickOutputMode::None
@@ -355,7 +381,7 @@ int main(int argc, char **argv) {
     editor.setFocus(Qt::ActiveWindowFocusReason);
   }
 
-  if (filePath.isEmpty()) {
+  if (!editingImage) {
     // The quick fullscreen path never shows the overlay, so it never needs the
     // window list that only window-mode hover consumes.
     editor.startCapture(captureMode, !instantFullscreenOutput);

--- a/tests/clipboard-smoke.cpp
+++ b/tests/clipboard-smoke.cpp
@@ -1,0 +1,145 @@
+/** @fileoverview Tests clipboard image loading without a live compositor. */
+#include "clipboard-smoke.hpp"
+
+#include "capture.hpp"
+
+#include <QDir>
+#include <QFile>
+#include <QImage>
+#include <QScopeGuard>
+#include <QTemporaryDir>
+
+namespace {
+/** Writes an executable fake command. */
+bool writeExecutable(const QString &path, const QByteArray &contents) {
+  QFile file(path);
+  if (!file.open(QIODevice::WriteOnly) ||
+      file.write(contents) != contents.size())
+    return false;
+  file.close();
+  return QFile::setPermissions(path, QFileDevice::ReadOwner |
+                                         QFileDevice::WriteOwner |
+                                         QFileDevice::ExeOwner);
+}
+
+/** Checks that an offered PNG is decoded. */
+bool runImageCheck(QString &error) {
+  QImage image;
+  if (!loadClipboardImage(image, error))
+    return false;
+  if (image.size() != QSize(3, 2) ||
+      image.pixelColor(1, 0) != QColor(18, 52, 86) ||
+      image.pixelColor(2, 1) != QColor(171, 205, 239)) {
+    error = QStringLiteral("Clipboard image pixels were not preserved");
+    return false;
+  }
+  return true;
+}
+
+/** Checks that a text-only clipboard reports a clear failure. */
+bool runTextOnlyCheck(QString &error) {
+  qputenv("OMASNAP_TEST_CLIPBOARD_TEXT_ONLY", "1");
+  QImage image(1, 1, QImage::Format_ARGB32);
+  QString clipboardError;
+  if (loadClipboardImage(image, clipboardError) || !image.isNull() ||
+      !clipboardError.contains(QStringLiteral("image"),
+                               Qt::CaseInsensitive)) {
+    error = QStringLiteral("Text-only clipboard was not rejected clearly");
+    return false;
+  }
+  return true;
+}
+
+/** Checks that a failed image transfer keeps the wl-paste error. */
+bool runReadFailureCheck(QString &error) {
+  qunsetenv("OMASNAP_TEST_CLIPBOARD_TEXT_ONLY");
+  qputenv("OMASNAP_TEST_CLIPBOARD_READ_FAILURE", "1");
+  QImage image;
+  QString clipboardError;
+  if (loadClipboardImage(image, clipboardError) || !image.isNull() ||
+      !clipboardError.contains(QStringLiteral("clipboard changed"),
+                               Qt::CaseInsensitive)) {
+    error = QStringLiteral("Clipboard transfer failure lost its cause");
+    return false;
+  }
+  return true;
+}
+} // namespace
+
+bool runClipboardSmoke(QString &error) {
+  QTemporaryDir directory;
+  if (!directory.isValid()) {
+    error = QStringLiteral("Could not create clipboard-test directory");
+    return false;
+  }
+
+  const QString imagePath =
+      QDir(directory.path()).filePath(QStringLiteral("clipboard.png"));
+  QImage expected(3, 2, QImage::Format_ARGB32);
+  expected.fill(Qt::transparent);
+  expected.setPixelColor(1, 0, QColor(18, 52, 86));
+  expected.setPixelColor(2, 1, QColor(171, 205, 239));
+  if (!expected.save(imagePath, "PNG")) {
+    error = QStringLiteral("Could not create clipboard-test image");
+    return false;
+  }
+
+  const QString fakeWlPaste =
+      QDir(directory.path()).filePath(QStringLiteral("wl-paste"));
+  const QByteArray script = QByteArrayLiteral(
+      "#!/usr/bin/env bash\n"
+      "set -euo pipefail\n"
+      "if [[ \"${1:-}\" == \"--list-types\" ]]; then\n"
+      "  if [[ -n \"${OMASNAP_TEST_CLIPBOARD_TEXT_ONLY:-}\" ]]; then\n"
+      "    printf 'text/plain;charset=utf-8\\n'\n"
+      "  else\n"
+      "    printf 'text/plain\\nimage/png\\n'\n"
+      "  fi\n"
+      "  exit 0\n"
+      "fi\n"
+      "if [[ \"${1:-}\" == \"--no-newline\" && \"${2:-}\" == \"--type\" "
+      "&& \"${3:-}\" == \"image/png\" ]]; then\n"
+      "  if [[ -n \"${OMASNAP_TEST_CLIPBOARD_READ_FAILURE:-}\" ]]; then\n"
+      "    printf 'clipboard changed before image transfer\\n' >&2\n"
+      "    exit 1\n"
+      "  fi\n"
+      "  cat -- \"$OMASNAP_TEST_CLIPBOARD_IMAGE\"\n"
+      "  exit 0\n"
+      "fi\n"
+      "exit 1\n");
+  if (!writeExecutable(fakeWlPaste, script)) {
+    error = QStringLiteral("Could not create fake wl-paste command");
+    return false;
+  }
+
+  const bool pathWasSet = qEnvironmentVariableIsSet("PATH");
+  const QByteArray oldPath = qgetenv("PATH");
+  const bool imageWasSet =
+      qEnvironmentVariableIsSet("OMASNAP_TEST_CLIPBOARD_IMAGE");
+  const QByteArray oldImage = qgetenv("OMASNAP_TEST_CLIPBOARD_IMAGE");
+  const bool textOnlyWasSet =
+      qEnvironmentVariableIsSet("OMASNAP_TEST_CLIPBOARD_TEXT_ONLY");
+  const QByteArray oldTextOnly = qgetenv("OMASNAP_TEST_CLIPBOARD_TEXT_ONLY");
+  const bool readFailureWasSet =
+      qEnvironmentVariableIsSet("OMASNAP_TEST_CLIPBOARD_READ_FAILURE");
+  const QByteArray oldReadFailure =
+      qgetenv("OMASNAP_TEST_CLIPBOARD_READ_FAILURE");
+  const auto restoreEnvironment = qScopeGuard([=] {
+    pathWasSet ? qputenv("PATH", oldPath) : qunsetenv("PATH");
+    imageWasSet ? qputenv("OMASNAP_TEST_CLIPBOARD_IMAGE", oldImage)
+                : qunsetenv("OMASNAP_TEST_CLIPBOARD_IMAGE");
+    textOnlyWasSet
+        ? qputenv("OMASNAP_TEST_CLIPBOARD_TEXT_ONLY", oldTextOnly)
+        : qunsetenv("OMASNAP_TEST_CLIPBOARD_TEXT_ONLY");
+    readFailureWasSet
+        ? qputenv("OMASNAP_TEST_CLIPBOARD_READ_FAILURE", oldReadFailure)
+        : qunsetenv("OMASNAP_TEST_CLIPBOARD_READ_FAILURE");
+  });
+  qputenv("PATH", directory.path().toUtf8() + ':' + oldPath);
+  qputenv("OMASNAP_TEST_CLIPBOARD_IMAGE", imagePath.toUtf8());
+  qunsetenv("OMASNAP_TEST_CLIPBOARD_TEXT_ONLY");
+  qunsetenv("OMASNAP_TEST_CLIPBOARD_READ_FAILURE");
+
+  return runImageCheck(error) && runTextOnlyCheck(error) &&
+         runReadFailureCheck(error);
+}

--- a/tests/clipboard-smoke.hpp
+++ b/tests/clipboard-smoke.hpp
@@ -1,0 +1,7 @@
+/** @fileoverview Declares clipboard image loading smoke checks. */
+#pragma once
+
+#include <QString>
+
+/** Runs clipboard image loading checks with a fake wl-paste command. */
+[[nodiscard]] bool runClipboardSmoke(QString &error);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2,6 +2,7 @@
  */
 #include "capture.hpp"
 #include "cli-path.hpp"
+#include "clipboard-smoke.hpp"
 #include "editor.hpp"
 #include "instance-lock-smoke.hpp"
 #include "pin-layout-smoke.hpp"
@@ -2330,6 +2331,12 @@ int main(int argc, char **argv) {
       qWarning().noquote() << clipboardError;
       return 64;
     }
+  }
+
+  QString clipboardError;
+  if (!runClipboardSmoke(clipboardError)) {
+    qWarning().noquote() << clipboardError;
+    return 88;
   }
 
   QString transformError;


### PR DESCRIPTION
## Summary

  - Add `omasnap --clipboard` to open the current Wayland clipboard image directly in the annotation editor.
  - Read supported image data through `wl-paste`.
  - Show clear errors and a notification when the clipboard has no readable image or changes during loading.
  - Use the existing single-instance handover behavior for clipboard editing.
  - Reject incompatible capture, quick-output, file, and pin options.
  - Document the new option in `--help` and the README.
  - Add smoke coverage for valid images, text-only clipboards, and failed image transfers.

  ## Testing

  - `make check`
  - Fresh release build and offscreen smoke test
  - Verified `--help` output
  - Verified invalid option combinations return exit code `2`
  - Verified text-only clipboard input returns exit code `1`