### PR TITLE
fix(editor): let a selected layer's handles and body work outside the canvas

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -844,6 +844,30 @@ QPointF CaptureEditor::toAnnotationPoint(const QPointF &position) const {
                      selection_.height())};
 }
 
+QPointF
+CaptureEditor::toUnclampedAnnotationPoint(const QPointF &position) const {
+  const QRectF image = editImageRect();
+  const qreal scale = std::max<qreal>(editScale(), 0.001);
+  return {(position.x() - image.left()) / scale,
+          (position.y() - image.top()) / scale};
+}
+
+bool CaptureEditor::selectedLayerAcceptsPoint(const QPointF &point) const {
+  if (selectedAnnotation_ < 0 || selectedAnnotation_ >= annotations_.size())
+    return false;
+  const Annotation &selected = annotations_.at(selectedAnnotation_);
+  const qreal tolerance = 9.0 / std::max<qreal>(editScale(), 0.01);
+  const QRectF bounds = annotationBounds(selected);
+  const bool endpoints = hasEndpointHandles(selected.kind);
+  const QPointF first = endpoints ? selected.start : bounds.topLeft();
+  const QPointF last = endpoints ? selected.end : bounds.bottomRight();
+  if (endpoints && QLineF(point, first).length() <= tolerance)
+    return true;
+  if (QLineF(point, last).length() <= tolerance)
+    return true;
+  return annotationAt(point) == selectedAnnotation_;
+}
+
 QRectF CaptureEditor::sourceRect(const QRectF &logicalRect) const {
   if (capture_.source.isNull() || capture_.previewSize.isEmpty())
     return {};
@@ -2123,10 +2147,16 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       return;
     }
   }
-  if (!editImageRect().contains(cursor_))
+  // A layer that ran off the capture keeps its handles and body live outside
+  // the canvas, so it can be resized or dragged back in instead of being
+  // stranded. Drags still follow the clamped pointer, so this only ever pulls
+  // layers back; anything else outside the canvas stays inert.
+  const bool insideImage = editImageRect().contains(cursor_);
+  const QPointF point = insideImage ? toAnnotationPoint(cursor_)
+                                    : toUnclampedAnnotationPoint(cursor_);
+  if (!insideImage &&
+      (tool_ != Tool::Select || !selectedLayerAcceptsPoint(point)))
     return;
-
-  const QPointF point = toAnnotationPoint(cursor_);
   if (tool_ == Tool::Eyedropper) {
     customColor_ = sampleSourceColor(capture_.source, capture_.previewSize,
                                      selection_, editImageRect(), cursor_);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -162,6 +162,8 @@ private:
   [[nodiscard]] QRectF editImageRect() const;
   [[nodiscard]] qreal editScale() const;
   [[nodiscard]] QPointF toAnnotationPoint(const QPointF &position) const;
+  [[nodiscard]] QPointF toUnclampedAnnotationPoint(const QPointF &position) const;
+  [[nodiscard]] bool selectedLayerAcceptsPoint(const QPointF &point) const;
   [[nodiscard]] QRectF sourceRect(const QRectF &logicalRect) const;
   [[nodiscard]] QPointF sourcePoint(const QPointF &logicalPoint) const;
   [[nodiscard]] QRectF mapWidgetToPreview(const QRectF &widgetRect) const;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1946,6 +1946,7 @@ bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
 }
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
+/** Runs the interaction and rendering smoke checks. */
 /** Checks that a modifier left over from the launch binding is not believed.
  *  A binding with a modifier in it, such as the README's ALT + SHIFT + 4,
  *  leaves that modifier held as the overlay takes keyboard focus. Its release
@@ -2111,6 +2112,114 @@ bool runSpotlightHandleSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Runs the interaction and rendering smoke checks. */
+bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(700, 500));
+  application.processEvents();
+  const QRectF selection(100, 100, 600, 400);
+  const auto expected = [&](const QVector<Annotation> &annotations) {
+    return renderCapture(capture, selection, annotations,
+                         BackgroundStyle::None);
+  };
+  const auto snapshotMatches = [&](const QImage &image) {
+    return flushedSnapshot(editor, snapshotPath)
+                   .convertToFormat(image.format()) == image;
+  };
+  const auto drag = [&](const QPoint &from, const QPoint &to) {
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, from);
+    QTest::mouseMove(&editor, to, 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, to);
+    application.processEvents();
+  };
+
+  // A rectangle at annotation (400,195)-(550,345); the widget offset is
+  // (100,105). Drag it 100 px right so its right side leaves the canvas.
+  QTest::keyClick(&editor, Qt::Key_R);
+  drag(QPoint(500, 300), QPoint(650, 450));
+  Annotation rectangle;
+  rectangle.kind = Annotation::Kind::Rectangle;
+  rectangle.start = {400, 195};
+  rectangle.end = {550, 345};
+  rectangle.color = QColor(QStringLiteral("#ff375f"));
+  rectangle.size = 4;
+  if (!snapshotMatches(expected({rectangle}))) {
+    error = QStringLiteral("Outside-canvas smoke: rectangle did not render");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_V);
+  // Press the top edge, clear of the corner handles, so this is a move.
+  drag(QPoint(575, 300), QPoint(675, 300));
+  Annotation shifted = rectangle;
+  shifted.start.rx() += 100;
+  shifted.end.rx() += 100;
+  if (!snapshotMatches(expected({shifted}))) {
+    error = QStringLiteral("Outside-canvas smoke: rectangle did not move");
+    return false;
+  }
+
+  // Its bottom-right handle now sits outside the canvas (widget (750,450));
+  // dragging it back in resizes the layer.
+  drag(QPoint(750, 450), QPoint(650, 400));
+  Annotation resized = shifted;
+  resized.end = {550, 295};
+  if (!snapshotMatches(expected({resized}))) {
+    error = QStringLiteral(
+        "Dragging a handle that lies outside the canvas did not resize");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(expected({shifted}))) {
+    error = QStringLiteral("Undo did not restore the outside-handle resize");
+    return false;
+  }
+
+  // Its right edge is outside the canvas too (widget x 750); grabbing the
+  // layer there drags it back in.
+  drag(QPoint(750, 375), QPoint(650, 375));
+  if (!snapshotMatches(expected({rectangle}))) {
+    error = QStringLiteral(
+        "Grabbing a selected layer outside the canvas did not move it");
+    return false;
+  }
+
+  // Outside the canvas, anything but the selected layer stays inert: a
+  // click on the surround neither deselects nor changes anything, so
+  // Delete still removes the layer.
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(760, 150));
+  application.processEvents();
+  if (!snapshotMatches(expected({rectangle}))) {
+    error = QStringLiteral("A click outside the canvas changed the capture");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Delete);
+  application.processEvents();
+  if (!snapshotMatches(expected({}))) {
+    error = QStringLiteral("A click outside the canvas deselected the layer");
+    return false;
+  }
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -2193,6 +2302,10 @@ int main(int argc, char **argv) {
   if (!runContinuousAnnotationToolsSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 80;
+  }
+  if (!runSelectOutsideCanvasSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 106;
   }
   if (!runSpotlightWheelSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
Drag a layer half off the capture and you can't get it back. `mousePressEvent` refuses every press outside the image, so the handle just past the edge is dead and the body out there isn't grabbable either.

A press outside the image now still reaches the *selected* layer, handles and body, hit-tested with an unclamped point so the geometry out there is real. Drags still follow the clamped pointer, so this can only pull a layer back toward the canvas, never further out. Everything else outside stays inert: no marquee, no new shape, no change of selection.

Draw a rectangle, drag it half off the right edge, grab it in the gray surround and pull it back. `runSelectOutsideCanvasSmoke` (exit 106).
