### PR TITLE
fix(editor): sampling a color keeps the tool and the selection

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1556,6 +1556,8 @@ void CaptureEditor::handleToolbar(const QString &action) {
   } else if (action == QStringLiteral("tool-text"))
     tool_ = Tool::Text;
   else if (action == QStringLiteral("tool-eyedropper")) {
+    if (tool_ != Tool::Eyedropper)
+      toolBeforeEyedropper_ = tool_;
     tool_ = Tool::Eyedropper;
     customColorPickerOpen_ = false;
   }
@@ -1767,6 +1769,8 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if (event->key() == Qt::Key_T) {
     tool_ = Tool::Text;
   } else if (event->key() == Qt::Key_I) {
+    if (tool_ != Tool::Eyedropper)
+      toolBeforeEyedropper_ = tool_;
     tool_ = Tool::Eyedropper;
   } else if (event->key() == Qt::Key_O) {
     tool_ = Tool::Ocr;
@@ -2175,8 +2179,11 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     QString clipboardError;
     static_cast<void>(copyTextToClipboard(
         customColor_.name(QColor::HexRgb).toUpper(), clipboardError));
-    tool_ = Tool::Select;
-    selectedAnnotation_ = -1;
+    // Sampling a color is something you do in order to keep working: it
+    // hands back the tool that was in hand, and leaves the layer it just
+    // recolored selected so another color can be tried on it. Dropping both
+    // meant that taking a color cost you your place twice over.
+    tool_ = toolBeforeEyedropper_;
     setStatus(QStringLiteral("Sampled %1").arg(
         customColor_.name(QColor::HexRgb).toUpper()));
     updatePointerCursor();

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -212,6 +212,9 @@ private:
   Tool tool_ = Tool::Select;
   /// Set by the first key event, which carries a fresh modifier snapshot.
   bool modifiersSeen_ = false;
+  /// What to hand back to once a color has been sampled: taking a color is
+  /// not a change of tool.
+  Tool toolBeforeEyedropper_ = Tool::Select;
   QRectF selection_;
   QPointF dragStart_;
   QRectF originalSelection_;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1881,7 +1881,7 @@ bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
     }
     application.processEvents();
   };
-  // Widget centre of the spotlight drawn above, and a point clear of it.
+  // Widget center of the spotlight drawn above, and a point clear of it.
   const QPointF overSpotlight(400, 325);
   const QPointF awayFromSpotlight(160, 160);
 
@@ -1945,6 +1945,7 @@ bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
   return true;
 }
 } // namespace
+/** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
 /** Checks that a modifier left over from the launch binding is not believed.
@@ -2220,6 +2221,82 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Runs the interaction and rendering smoke checks. */
+/** Checks that sampling a color is not a change of tool: the eyedropper
+ *  hands back whatever was in hand, and recolors the layer that was selected
+ *  rather than dropping the selection with it. */
+bool runEyedropperSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  // A patch of a color nothing else uses, to sample from.
+  QPainter painter(&capture.source);
+  painter.fillRect(QRect(560, 380, 120, 120), QColor(QStringLiteral("#12b886")));
+  painter.fillRect(QRect(560, 140, 120, 120), QColor(QStringLiteral("#f59f00")));
+  painter.end();
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(700, 500));
+  application.processEvents();
+
+  // An arrow, selected, then a color sampled from the patch.
+  QTest::keyClick(&editor, Qt::Key_A);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 200));
+  QTest::mouseMove(&editor, QPoint(360, 300), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(360, 300));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(280, 250));
+  application.processEvents();
+  const QImage before = flushedSnapshot(editor, snapshotPath);
+  QTest::keyClick(&editor, Qt::Key_A); // back to the arrow tool
+  QTest::keyClick(&editor, Qt::Key_I); // eyedropper
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(620, 440));
+  application.processEvents();
+  const QImage recolored = flushedSnapshot(editor, snapshotPath);
+  if (recolored == before) {
+    error = QStringLiteral("Sampling a color did not recolor the selected "
+                           "layer");
+    return false;
+  }
+  // The layer is still the selected one, so a second color lands on it too.
+  // That is the half a cleared selection would break: the recolor reads the
+  // selected index, and dropping it makes every later sample a no-op.
+  QTest::keyClick(&editor, Qt::Key_I);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(620, 200));
+  application.processEvents();
+  const QImage twice = flushedSnapshot(editor, snapshotPath);
+  if (twice == recolored) {
+    error = QStringLiteral("Sampling a color dropped the selection");
+    return false;
+  }
+  // The tool that was in hand is still in hand: this drag draws a second
+  // arrow. With the tool dropped for the select tool it would only have
+  // marqueed, leaving the capture as it was.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 420));
+  QTest::mouseMove(&editor, QPoint(340, 470), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(340, 470));
+  application.processEvents();
+  if (flushedSnapshot(editor, snapshotPath) == twice) {
+    error = QStringLiteral("Sampling a color took the tool away");
+    return false;
+  }
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -2274,6 +2351,10 @@ int main(int argc, char **argv) {
   if (!runSpotlightHandleSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 98;
+  }
+  if (!runEyedropperSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 107;
   }
   if (!runAsyncCaptureRegionSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
Sampling a color with the eyedropper also arms the Select tool and clears whatever layer you had selected. Neither of those is what you asked it to do.

So matching the arrow you just drew to the button it's pointing at deselects the arrow and drops you back on Select. If the first red isn't right, you have to re-select the arrow before trying another.

Sampling now hands back whichever tool was in hand and leaves the layer selected, so you can keep sampling until it looks right.

`runEyedropperSmoke` (exit 94) checks both halves.
