### PR TITLE
feat(editor): shape fill toggle and rounded rectangle corners

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   capture stays in the window picker; Omasnap never substitutes a crop of the desktop.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
 - Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
-  rectangles, ellipses, numbered markers, editable Neucha text, and secure redaction with
-  opaque or randomized non-spatial mosaic output.
+  hollow or filled rectangles (optionally rounded) and ellipses, numbered markers,
+  editable Neucha text, and secure redaction with opaque or randomized non-spatial
+  mosaic output.
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
@@ -262,15 +263,15 @@ Install the corresponding Tesseract language data before adding a language to
 | `F` | Freehand stroke |
 | `I` | Eyedropper in the color popover · sample the image as the custom color |
 | `C` | Numbered marker |
-| `R` | Rectangle |
-| `E` | Ellipse |
+| `R` | Rectangle; press again to toggle filled/hollow; `Alt`+wheel rounds the corners |
+| `E` | Ellipse; press again to toggle filled/hollow |
 | `D` | Redact; press again to toggle randomized pixelation or solid redaction |
 | `X` | Cut out a band; drag across the image to remove and collapse a horizontal or vertical strip |
 | `T` | Neucha text |
 | `O` | Drag an OCR region and copy recognized text |
 | `B` | Cycle backdrop |
 | `1`–`6` | Set annotation color |
-| Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size |
+| Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size (`Alt`+wheel: rectangle corner radius) |
 | Hold `Shift` while dragging | Make rectangles, ellipses, and spotlights 1:1; snap lines and arrows to 45° |
 | Double-click text | Reopen text editing |
 | `Delete` | Delete selected layer |

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -309,15 +309,25 @@ void drawAnnotation(QPainter &painter, const Annotation &annotation) {
   painter.setPen(pen);
   painter.setBrush(annotation.color);
 
-  if (annotation.kind == Annotation::Kind::Rectangle) {
-    painter.setBrush(Qt::NoBrush);
-    painter.drawRect(QRectF(annotation.start, annotation.end).normalized());
-    return;
-  }
-
-  if (annotation.kind == Annotation::Kind::Ellipse) {
-    painter.setBrush(Qt::NoBrush);
-    painter.drawEllipse(QRectF(annotation.start, annotation.end).normalized());
+  if (annotation.kind == Annotation::Kind::Rectangle ||
+      annotation.kind == Annotation::Kind::Ellipse) {
+    // Filled shapes are a flat silhouette of the shape (no stroke), hollow
+    // ones a stroke band centered on its outline.
+    const QRectF bounds = QRectF(annotation.start, annotation.end).normalized();
+    if (annotation.filled)
+      painter.setPen(Qt::NoPen);
+    else
+      painter.setBrush(Qt::NoBrush);
+    if (annotation.kind == Annotation::Kind::Ellipse) {
+      painter.drawEllipse(bounds);
+    } else if (annotation.cornerRadius > 0.0) {
+      const qreal radius =
+          std::min({annotation.cornerRadius, bounds.width() / 2.0,
+                    bounds.height() / 2.0});
+      painter.drawRoundedRect(bounds, radius, radius);
+    } else {
+      painter.drawRect(bounds);
+    }
     return;
   }
 

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -64,6 +64,8 @@ struct Annotation {
   qreal size = 4.0;
   int number = 0;
   QVector<QPointF> points;
+  bool filled = false;
+  qreal cornerRadius = 0.0;
   RedactionStyle redactionStyle = RedactionStyle::Pixelate;
   qreal magnification = 2.0;
   SpotlightShape spotlightShape = SpotlightShape::Ellipse;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -130,6 +130,18 @@ Annotation::Kind dragShapeKind(CaptureEditor::Tool tool) {
   }
 }
 
+constexpr qreal kCornerRadiusStep = 2.0;
+constexpr qreal kMaximumCornerRadius = 24.0;
+
+QString fillName(bool filled) {
+  return filled ? QStringLiteral("Filled") : QStringLiteral("Hollow");
+}
+
+QString cornerName(qreal radius) {
+  return radius > 0.0 ? QStringLiteral("%1 px corners").arg(qRound(radius))
+                      : QStringLiteral("square corners");
+}
+
 QString redactionStyleName(RedactionStyle style) {
   return style == RedactionStyle::Solid ? QStringLiteral("Solid")
                                         : QStringLiteral("Pixelate");
@@ -636,23 +648,28 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
     } else {
       const QRectF bounds = annotationBounds(annotation);
       if (annotation.kind == Annotation::Kind::Rectangle) {
+        // Filled rectangles hit anywhere inside; hollow ones only on the
+        // stroke band.
         const qreal tolerance = std::max<qreal>(7.0, annotation.size + 3.0);
         const QRectF outer =
             bounds.adjusted(-tolerance, -tolerance, tolerance, tolerance);
+        if (annotation.filled)
+          return outer.contains(point);
         const QRectF inner =
             bounds.adjusted(tolerance, tolerance, -tolerance, -tolerance);
         return outer.contains(point) &&
                (inner.isEmpty() || !inner.contains(point));
       }
       if (annotation.kind == Annotation::Kind::Ellipse) {
-        // Hollow ellipse: only a band around the outline is a hit, like the
-        // rectangle ring above.
+        // Same rule for ellipses: filled hits the silhouette, hollow only a
+        // band around the outline.
         const qreal tolerance = std::max<qreal>(7.0, annotation.size + 3.0);
         QPainterPath outline;
         outline.addEllipse(bounds);
         QPainterPathStroker band;
         band.setWidth(tolerance * 2.0);
-        return band.createStroke(outline).contains(point);
+        return band.createStroke(outline).contains(point) ||
+               (annotation.filled && outline.contains(point));
       }
       if (bounds.adjusted(-7, -7, 7, 7).contains(point))
         return true;
@@ -737,6 +754,15 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
   setStatus(QStringLiteral("Selected layer · wheel zoom %1%")
                 .arg(qRound(factor * 100)));
   scheduleSnapshot();
+}
+
+void CaptureEditor::toggleShapeFill() {
+  fillShapes_ = !fillShapes_;
+  selectedAnnotation_ = -1;
+  setStatus(QStringLiteral("%1 shapes · %2 again toggles fill")
+                .arg(fillName(fillShapes_))
+                .arg(tool_ == Tool::Ellipse ? QStringLiteral("E")
+                                            : QStringLiteral("R")));
 }
 
 QRectF CaptureEditor::colorPaletteRect() const {
@@ -1049,10 +1075,18 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(36, QStringLiteral("tool-marker"), {},
       QStringLiteral("Number marker · C · Size %1 · Wheel")
           .arg(qRound(annotationSize_)));
-  add(36, QStringLiteral("tool-rectangle"), {},
-      QStringLiteral("Rectangle · R · Shift makes square"));
-  add(36, QStringLiteral("tool-ellipse"), {},
-      QStringLiteral("Ellipse · E · Shift makes circle"));
+  const QString fillHint = fillShapes_ ? QStringLiteral("filled") : QString();
+  add(36, QStringLiteral("tool-rectangle"), fillHint,
+      QStringLiteral("Rectangle · R · %1 · R again toggles fill · Size %2 · "
+                     "Wheel · Alt+Wheel %3 · Shift makes square")
+          .arg(fillName(fillShapes_))
+          .arg(qRound(annotationSize_))
+          .arg(cornerName(cornerRadius_)));
+  add(36, QStringLiteral("tool-ellipse"), fillHint,
+      QStringLiteral("Ellipse · E · %1 · E again toggles fill · Size %2 · "
+                     "Wheel · Shift makes circle")
+          .arg(fillName(fillShapes_))
+          .arg(qRound(annotationSize_)));
   add(36, QStringLiteral("tool-redact"), {},
       QStringLiteral("Redact · D · %1 · D again toggles")
           .arg(redactionStyleName(redactionStyle_)));
@@ -1558,11 +1592,16 @@ void CaptureEditor::handleToolbar(const QString &action) {
     tool_ = Tool::Highlighter;
   else if (action == QStringLiteral("tool-marker"))
     tool_ = Tool::Marker;
-  else if (action == QStringLiteral("tool-rectangle"))
-    tool_ = Tool::Rectangle;
-  else if (action == QStringLiteral("tool-ellipse"))
-    tool_ = Tool::Ellipse;
-  else if (action == QStringLiteral("tool-spotlight")) {
+  else if (action == QStringLiteral("tool-rectangle") ||
+           action == QStringLiteral("tool-ellipse")) {
+    const Tool shape = action == QStringLiteral("tool-rectangle")
+                           ? Tool::Rectangle
+                           : Tool::Ellipse;
+    if (tool_ == shape)
+      toggleShapeFill();
+    else
+      tool_ = shape;
+  } else if (action == QStringLiteral("tool-spotlight")) {
     if (tool_ == Tool::Spotlight) {
       spotlightShape_ = spotlightShape_ == SpotlightShape::Ellipse
                             ? SpotlightShape::Rectangle
@@ -1760,10 +1799,27 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Highlighter;
   } else if (event->key() == Qt::Key_C || event->key() == Qt::Key_M) {
     tool_ = Tool::Marker;
-  } else if (event->key() == Qt::Key_R) {
-    tool_ = Tool::Rectangle;
-  } else if (event->key() == Qt::Key_E) {
-    tool_ = Tool::Ellipse;
+  } else if (event->key() == Qt::Key_R || event->key() == Qt::Key_E) {
+    const bool rectangle = event->key() == Qt::Key_R;
+    const Tool shape = rectangle ? Tool::Rectangle : Tool::Ellipse;
+    if (!dragging_ && selectedAnnotation_ >= 0 &&
+        selectedAnnotation_ < annotations_.size() &&
+        annotations_.at(selectedAnnotation_).kind == dragShapeKind(shape)) {
+      recordEdit();
+      Annotation &selected = annotations_[selectedAnnotation_];
+      selected.filled = !selected.filled;
+      setStatus(
+          QStringLiteral("Selected %1: %2 · %3 again toggles fill")
+              .arg(rectangle ? QStringLiteral("rectangle")
+                             : QStringLiteral("ellipse"))
+              .arg(fillName(selected.filled).toLower())
+              .arg(rectangle ? QStringLiteral("R") : QStringLiteral("E")));
+      scheduleSnapshot();
+    } else if (tool_ == shape) {
+      toggleShapeFill();
+    } else {
+      tool_ = shape;
+    }
   } else if (event->key() == Qt::Key_S) {
     if (tool_ == Tool::Spotlight) {
       spotlightShape_ = spotlightShape_ == SpotlightShape::Ellipse
@@ -2537,6 +2593,10 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       annotation.spotlightShape = spotlightShape_;
     } else {
       annotation.kind = dragShapeKind(tool_);
+      if (tool_ == Tool::Rectangle || tool_ == Tool::Ellipse)
+        annotation.filled = fillShapes_;
+      if (tool_ == Tool::Rectangle)
+        annotation.cornerRadius = cornerRadius_;
     }
     annotation.start = dragStart_;
     annotation.end = end;
@@ -2564,7 +2624,10 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
     QWidget::wheelEvent(event);
     return;
   }
-  const int step = event->angleDelta().y() > 0 ? 1 : -1;
+  // Some stacks report a modified wheel on the horizontal axis; read
+  // whichever axis moved.
+  const QPoint delta = event->angleDelta();
+  const int step = (delta.y() != 0 ? delta.y() : delta.x()) > 0 ? 1 : -1;
   if (tool_ == Tool::Select && selectedAnnotation_ >= 0 &&
       selectedAnnotation_ < annotations_.size()) {
     scaleSelectedAnnotation(step > 0 ? 1.1 : 1.0 / 1.1);
@@ -2591,9 +2654,17 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
       setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
                     .arg(spotlightMagnification_, 0, 'f', 1));
     }
+  } else if (tool_ == Tool::Rectangle &&
+             event->modifiers().testFlag(Qt::AltModifier)) {
+    // Alt+wheel is the rectangle's secondary control: corner rounding.
+    cornerRadius_ = std::clamp(cornerRadius_ + step * kCornerRadiusStep, 0.0,
+                               kMaximumCornerRadius);
+    setStatus(QStringLiteral("Rectangle · %1 · Alt+wheel adjusts")
+                  .arg(cornerName(cornerRadius_)));
   } else if (tool_ == Tool::Arrow || tool_ == Tool::Line ||
              tool_ == Tool::Freehand || tool_ == Tool::Highlighter ||
-             tool_ == Tool::Marker) {
+             tool_ == Tool::Marker || tool_ == Tool::Rectangle ||
+             tool_ == Tool::Ellipse) {
     annotationSize_ = std::clamp(annotationSize_ + step, 2.0, 12.0);
     setStatus(QStringLiteral("Size %1 · mouse wheel changes size")
                   .arg(qRound(annotationSize_)));
@@ -2764,6 +2835,14 @@ void CaptureEditor::paintSelect(QPainter &painter) {
   drawMeasureBadge(painter, rect(), cursor_, measurementText());
 }
 
+qreal selectionBoundsRadius(const Annotation &annotation, qreal inset) {
+  if (annotation.kind != Annotation::Kind::Rectangle || annotation.cornerRadius <= 0.0)
+    return 0.0;
+  // Concentric with the shape: a rounded rect offset outward by `inset` keeps
+  // the same centres, so its radius grows by the same amount.
+  return annotation.cornerRadius + inset;
+}
+
 void CaptureEditor::paintEdit(QPainter &painter) {
   painter.setCompositionMode(QPainter::CompositionMode_Source);
   painter.fillRect(rect(), QColor(0, 0, 0, 160));
@@ -2874,6 +2953,10 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       preview.spotlightShape = spotlightShape_;
     } else {
       preview.kind = dragShapeKind(tool_);
+      if (tool_ == Tool::Rectangle || tool_ == Tool::Ellipse)
+        preview.filled = fillShapes_;
+      if (tool_ == Tool::Rectangle)
+        preview.cornerRadius = cornerRadius_;
       preview.start = dragStart_;
       const QPointF end = toAnnotationPoint(cursor_);
       preview.end = creationConstraintActive_
@@ -2940,7 +3023,14 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       painter.setPen(
           QPen(QColor(255, 255, 255, 220), 1.0 / scale, Qt::DashLine));
       painter.setBrush(Qt::NoBrush);
-      painter.drawRect(bounds);
+      const qreal boxRadius =
+          multiple ? 0.0
+                   : selectionBoundsRadius(
+                         annotations_.at(selectedAnnotation_), 4.0);
+      if (boxRadius > 0.0)
+        painter.drawRoundedRect(bounds, boxRadius, boxRadius);
+      else
+        painter.drawRect(bounds);
     }
     if (!multiple) {
       const Annotation &selected = annotations_.at(selectedAnnotation_);
@@ -3104,6 +3194,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   } else if (tool_ == Tool::Arrow || tool_ == Tool::Line ||
              tool_ == Tool::Freehand || tool_ == Tool::Highlighter ||
              tool_ == Tool::Marker || tool_ == Tool::Redact ||
+             tool_ == Tool::Rectangle || tool_ == Tool::Ellipse ||
              tool_ == Tool::Text) {
     const QString selectedAction = toolAction(tool_);
     for (const ToolbarButton &button : buttons) {
@@ -3117,6 +3208,16 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         } else if (tool_ == Tool::Redact) {
           tooltip = QStringLiteral("Redact · %1 · D toggles style")
                         .arg(redactionStyleName(redactionStyle_));
+        } else if (tool_ == Tool::Rectangle) {
+          tooltip = QStringLiteral("Rectangle · %1 · Size %2 · Scroll wheel · "
+                                   "Alt+Wheel %3")
+                        .arg(fillName(fillShapes_))
+                        .arg(qRound(annotationSize_))
+                        .arg(cornerName(cornerRadius_));
+        } else if (tool_ == Tool::Ellipse) {
+          tooltip = QStringLiteral("Ellipse · %1 · Size %2 · Scroll wheel")
+                        .arg(fillName(fillShapes_))
+                        .arg(qRound(annotationSize_));
         } else {
           tooltip = QStringLiteral("Size %1 · Scroll wheel")
                         .arg(qRound(annotationSize_));

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -16,6 +16,14 @@ class QPaintEvent;
 class QWheelEvent;
 
 class QPainter;
+
+/// Corner radius for the dashed selection box around `annotation`, drawn
+/// `inset` px outside its bounds. A rounded rectangle inside a square box
+/// reads as a mistake, and while the radius is being set the box is the only
+/// thing large enough to see it change on. 0 for every other kind.
+[[nodiscard]] qreal selectionBoundsRadius(const Annotation &annotation,
+                                          qreal inset);
+
 class CaptureEditor final : public QWidget {
   Q_OBJECT
 public:
@@ -200,6 +208,7 @@ private:
   void runOcr(const QRectF &localSelection = {});
   void setStatus(QString status);
   void scaleSelectedAnnotation(qreal factor);
+  void toggleShapeFill();
   void undoEdit();
   void updatePointerCursor();
 
@@ -253,6 +262,8 @@ private:
   qreal customHue_ = 0.98;
   int nextMarker_ = 1;
   qreal annotationSize_ = 4.0;
+  bool fillShapes_ = false;
+  qreal cornerRadius_ = 0.0;
   int textSizeIndex_ = 1;
   qreal spotlightMagnification_ = 2.0;
   SpotlightShape spotlightShape_ = SpotlightShape::Ellipse;

--- a/src/icons.cpp
+++ b/src/icons.cpp
@@ -61,8 +61,12 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     painter.drawText(QRectF(4, 4, 16, 16), Qt::AlignCenter,
                      QStringLiteral("1"));
   } else if (action == QStringLiteral("tool-rectangle")) {
+    if (label == QStringLiteral("filled"))
+      painter.setBrush(color);
     painter.drawRoundedRect(QRectF(4, 4, 16, 16), 2, 2);
   } else if (action == QStringLiteral("tool-ellipse")) {
+    if (label == QStringLiteral("filled"))
+      painter.setBrush(color);
     painter.drawEllipse(QRectF(3, 6, 18, 12));
   } else if (action == QStringLiteral("tool-redact")) {
     QPainterPath shield;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2483,6 +2483,266 @@ bool runEllipseToolSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+bool runShapeFillRenderingCheck(QString &error) {
+  error = QStringLiteral("Shape fill rendering check failed");
+  CaptureData capture;
+  capture.monitor.scale = 1.0;
+  capture.monitor.pixelSize = {200, 100};
+  capture.source = QImage(200, 100, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(Qt::transparent);
+  capture.previewSize = capture.source.size();
+  const auto render = [&](Annotation shape) {
+    shape.color = QColor(QStringLiteral("#ff375f"));
+    shape.size = 4;
+    shape.start = {20, 20};
+    shape.end = {180, 80};
+    return renderCapture(capture, QRectF(0, 0, 200, 100), {shape},
+                         BackgroundStyle::None);
+  };
+
+  Annotation filledRectangle;
+  filledRectangle.kind = Annotation::Kind::Rectangle;
+  filledRectangle.filled = true;
+  const QImage filled = render(filledRectangle);
+  if (filled.pixelColor(100, 50).alpha() != 255 ||
+      filled.pixelColor(21, 21).alpha() != 255 ||
+      filled.pixelColor(10, 50).alpha() != 0) {
+    error = QStringLiteral("Filled rectangle did not paint a flat silhouette");
+    return false;
+  }
+
+  Annotation roundedRectangle;
+  roundedRectangle.kind = Annotation::Kind::Rectangle;
+  roundedRectangle.cornerRadius = 12;
+  const QImage rounded = render(roundedRectangle);
+  if (rounded.pixelColor(21, 21).alpha() != 0 ||
+      rounded.pixelColor(100, 20).alpha() < 200 ||
+      rounded.pixelColor(20, 50).alpha() < 200 ||
+      rounded.pixelColor(100, 50).alpha() != 0) {
+    error = QStringLiteral("Rounded rectangle did not clip its corners");
+    return false;
+  }
+
+  Annotation filledEllipse;
+  filledEllipse.kind = Annotation::Kind::Ellipse;
+  filledEllipse.filled = true;
+  const QImage ellipse = render(filledEllipse);
+  if (ellipse.pixelColor(100, 50).alpha() != 255 ||
+      ellipse.pixelColor(22, 22).alpha() != 0) {
+    error = QStringLiteral("Filled ellipse did not fill its silhouette only");
+    return false;
+  }
+
+  // The selection box follows the corners, so the radius can be seen while it
+  // is being set rather than judged against a square frame around it.
+  Annotation roundedBox;
+  roundedBox.kind = Annotation::Kind::Rectangle;
+  roundedBox.cornerRadius = 8.0;
+  if (selectionBoundsRadius(roundedBox, 4.0) != 12.0) {
+    error = QStringLiteral("Selection box did not stay concentric with a "
+                           "rounded rectangle");
+    return false;
+  }
+  Annotation squareBox;
+  squareBox.kind = Annotation::Kind::Rectangle;
+  if (selectionBoundsRadius(squareBox, 4.0) != 0.0) {
+    error = QStringLiteral("Selection box rounded a square rectangle");
+    return false;
+  }
+  Annotation ellipseBox;
+  ellipseBox.kind = Annotation::Kind::Ellipse;
+  ellipseBox.cornerRadius = 8.0;
+  if (selectionBoundsRadius(ellipseBox, 4.0) != 0.0) {
+    error = QStringLiteral("Selection box rounded a kind that has no corners");
+    return false;
+  }
+  return true;
+}
+
+bool runShapeFillToolSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(700, 500));
+  application.processEvents();
+  const QRectF selection(100, 100, 600, 400);
+  const auto expected = [&](const QVector<Annotation> &annotations) {
+    return renderCapture(capture, selection, annotations,
+                         BackgroundStyle::None);
+  };
+  const auto snapshotMatches = [&](const QImage &image) {
+    return flushedSnapshot(editor, snapshotPath)
+                   .convertToFormat(image.format()) == image;
+  };
+  const auto shape = [](Annotation::Kind kind, const QPointF &start,
+                        const QPointF &end, bool filled, qreal radius = 0) {
+    Annotation annotation;
+    annotation.kind = kind;
+    annotation.start = start;
+    annotation.end = end;
+    annotation.filled = filled;
+    annotation.cornerRadius = radius;
+    annotation.color = QColor(QStringLiteral("#ff375f"));
+    annotation.size = 4;
+    return annotation;
+  };
+  const auto drag = [&](const QPoint &from, const QPoint &to) {
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, from);
+    QTest::mouseMove(&editor, to, 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, to);
+    application.processEvents();
+  };
+  const auto wheel = [&](int steps,
+                         Qt::KeyboardModifiers modifiers = Qt::NoModifier) {
+    for (int step = 0; step < std::abs(steps); ++step) {
+      QWheelEvent event(QPointF(400, 300), QPointF(400, 300), {},
+                        {0, steps > 0 ? 120 : -120}, Qt::NoButton, modifiers,
+                        Qt::NoScrollPhase, false);
+      QApplication::sendEvent(&editor, &event);
+    }
+    application.processEvents();
+  };
+  const auto shapeSized = [&shape](Annotation::Kind kind, const QPointF &start,
+                                   const QPointF &end, bool filled,
+                                   qreal radius, qreal size) {
+    Annotation annotation = shape(kind, start, end, filled, radius);
+    annotation.size = size;
+    return annotation;
+  };
+
+  // R arms a hollow rectangle; the wheel sets its stroke size like every
+  // other tool; R again toggles fill for the next shapes.
+  QTest::keyClick(&editor, Qt::Key_R);
+  wheel(1);
+  drag(QPoint(200, 200), QPoint(400, 300));
+  const Annotation hollow = shapeSized(Annotation::Kind::Rectangle, {100, 95},
+                                       {300, 195}, false, 0, 5);
+  if (!snapshotMatches(expected({hollow}))) {
+    error = QStringLiteral("Rectangle did not start hollow at wheel size 5");
+    return false;
+  }
+  wheel(-1);
+  QTest::keyClick(&editor, Qt::Key_R);
+  drag(QPoint(200, 350), QPoint(400, 450));
+  const Annotation filled =
+      shape(Annotation::Kind::Rectangle, {100, 245}, {300, 345}, true);
+  if (!snapshotMatches(expected({hollow, filled}))) {
+    error = QStringLiteral("R again did not fill the next rectangle");
+    return false;
+  }
+
+  // Alt+wheel rounds the corners of new rectangles (2 px per notch, 0–24);
+  // the plain wheel keeps meaning stroke size, as for every other tool.
+  wheel(6, Qt::AltModifier);
+  drag(QPoint(450, 200), QPoint(650, 300));
+  const Annotation rounded =
+      shape(Annotation::Kind::Rectangle, {350, 95}, {550, 195}, true, 12);
+  if (!snapshotMatches(expected({hollow, filled, rounded}))) {
+    error = QStringLiteral("Alt+wheel did not round the next rectangle");
+    return false;
+  }
+  wheel(-20, Qt::AltModifier);
+  drag(QPoint(450, 350), QPoint(650, 450));
+  const Annotation squareAgain =
+      shape(Annotation::Kind::Rectangle, {350, 245}, {550, 345}, true, 0);
+  if (!snapshotMatches(expected({hollow, filled, rounded, squareAgain}))) {
+    error = QStringLiteral("Alt+wheel did not clamp the corner radius to 0");
+    return false;
+  }
+
+  // Ellipses share the fill flag; E again toggles it back to hollow.
+  QTest::keyClick(&editor, Qt::Key_E);
+  QTest::keyClick(&editor, Qt::Key_E);
+  drag(QPoint(200, 480), QPoint(300, 500));
+  const Annotation ellipse =
+      shape(Annotation::Kind::Ellipse, {100, 375}, {200, 395}, false);
+  if (!snapshotMatches(
+          expected({hollow, filled, rounded, squareAgain, ellipse}))) {
+    error = QStringLiteral("E again did not toggle the shared fill off");
+    return false;
+  }
+
+  // Filled shapes hit anywhere inside; hollow ones still only on the band.
+  QTest::keyClick(&editor, Qt::Key_V);
+  application.processEvents();
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 250));
+  QTest::keyClick(&editor, Qt::Key_Delete);
+  application.processEvents();
+  if (!snapshotMatches(
+          expected({hollow, filled, rounded, squareAgain, ellipse}))) {
+    error = QStringLiteral("Hollow rectangle interior selected a layer");
+    return false;
+  }
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 400));
+  QTest::keyClick(&editor, Qt::Key_Delete);
+  application.processEvents();
+  if (!snapshotMatches(expected({hollow, rounded, squareAgain, ellipse}))) {
+    error = QStringLiteral("Filled rectangle interior did not select it");
+    return false;
+  }
+
+  // R with a selected rectangle toggles that layer's fill (undoable).
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 200));
+  QTest::keyClick(&editor, Qt::Key_R);
+  application.processEvents();
+  Annotation hollowNowFilled = hollow;
+  hollowNowFilled.filled = true;
+  if (!snapshotMatches(
+          expected({hollowNowFilled, rounded, squareAgain, ellipse}))) {
+    error = QStringLiteral("R did not fill the selected rectangle");
+    return false;
+  }
+  if (editor.cursor().shape() != Qt::ArrowCursor) {
+    error = QStringLiteral("Toggling a selected rectangle switched tools");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(expected({hollow, rounded, squareAgain, ellipse}))) {
+    error = QStringLiteral("Undo did not restore the hollow rectangle");
+    return false;
+  }
+
+  // Clicking the armed rectangle's toolbar button toggles fill as well
+  // (deselect first: R with a rectangle selected targets that layer).
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(680, 480));
+  QTest::keyClick(&editor, Qt::Key_R);
+  application.processEvents();
+  constexpr qreal toolbarWidth = 840.0; // kToolbarWidth in editor.cpp
+  const qreal scale = std::min<qreal>(1.0, (800.0 - 16.0) / toolbarWidth);
+  const qreal toolbarX = (800.0 - toolbarWidth * scale) / 2.0;
+  const QPointF button(toolbarX + (7 * 40 + 18) * scale,
+                       105 - 36 * scale - 10 + 18 * scale);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, button.toPoint());
+  application.processEvents();
+  drag(QPoint(500, 480), QPoint(600, 500));
+  const Annotation viaButton =
+      shape(Annotation::Kind::Rectangle, {400, 375}, {500, 395}, true);
+  if (!snapshotMatches(
+          expected({hollow, rounded, squareAgain, ellipse, viaButton}))) {
+    error = QStringLiteral("Toolbar re-click did not toggle fill");
+    return false;
+  }
+
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -2573,6 +2833,14 @@ int main(int argc, char **argv) {
   if (!runSelectOutsideCanvasSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 106;
+  }
+  if (!runShapeFillRenderingCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 110;
+  }
+  if (!runShapeFillToolSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 111;
   }
   if (!runEllipseRenderingCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
@@ -2666,8 +2934,9 @@ int main(int argc, char **argv) {
       return renderCapture(capture, QRectF(100, 100, 550, 370), {rectangle},
                            BackgroundStyle::None);
     };
+    // Arm once: pressing R again would toggle the fill instead.
+    QTest::keyClick(&constraintEditor, Qt::Key_R);
     const auto dragRectangle = [&](bool releaseShiftBeforeMouse) {
-      QTest::keyClick(&constraintEditor, Qt::Key_R);
       QTest::mousePress(&constraintEditor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(300, 220));
       QTest::mouseMove(&constraintEditor, QPoint(420, 280), 20);


### PR DESCRIPTION
> Stacked on #55. The diff below has that commit in it too; only the second one is this PR. I'll rebase once it lands.

Fill for rectangles and ellipses, rounded corners for rectangles.

A filled shape draws as a flat silhouette and is grabbable anywhere inside; hollow ones keep the outline-band hit test. The radius clamps to half the shorter edge, so a small rectangle still looks like a rectangle.

Controls follow the existing idiom of pressing the tool key again for its variant. `R` or `E` again (or re-clicking the armed button) flips fill for the shapes you draw next, and with a shape selected it toggles that layer instead, as an undoable edit. The wheel sets stroke size for rectangles and ellipses now like it does everywhere else, and Alt+wheel rounds corners at 2 px a notch, up to 24.

I also made the dashed selection box follow the corners, staying concentric with the shape. A rounded rectangle sitting inside a square box looks like a rendering bug, and the box is what you judge the radius against while setting it.

`runShapeFillRenderingCheck` (exit 96) covers filled, rounded and filled-ellipse rendering plus the selection box radius; `runShapeFillToolSmoke` (exit 97) drives the toggles, both wheel bindings and the fill-aware hit testing.
