### PR TITLE
feat(editor): Alt centers drag-created shapes, Alt+Shift centers a square/circle

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Install the corresponding Tesseract language data before adding a language to
 | `1`–`6` | Set annotation color |
 | Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size (`Alt`+wheel: rectangle corner radius) |
 | Hold `Shift` while dragging | Make rectangles, ellipses, and spotlights 1:1; snap lines and arrows to 45° |
+| Hold `Alt` while dragging | Center rectangles, ellipses, and spotlights on the press point; add `Shift` for a centered square/circle |
 | Double-click text | Reopen text editing |
 | `Delete` | Delete selected layer |
 | `Ctrl+Z` | Undo |

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -78,6 +78,11 @@ bool supportsCreationConstraint(CaptureEditor::Tool tool) {
          tool == CaptureEditor::Tool::Spotlight;
 }
 
+bool supportsCenteredCreation(CaptureEditor::Tool tool) {
+  return tool == CaptureEditor::Tool::Rectangle ||
+         tool == CaptureEditor::Tool::Ellipse ||
+         tool == CaptureEditor::Tool::Spotlight;
+}
 
 QString toolAction(CaptureEditor::Tool tool) {
   switch (tool) {
@@ -324,6 +329,13 @@ QPointF constrainedCreationEndpoint(CaptureEditor::Tool tool,
     return start + QPointF(std::cos(angle) * length, std::sin(angle) * length);
   }
   return end;
+}
+
+QPointF centeredCreationStart(CaptureEditor::Tool tool, const QPointF &center,
+                              const QPointF &end) {
+  if (!supportsCenteredCreation(tool))
+    return center;
+  return center * 2.0 - end;
 }
 
 CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
@@ -756,6 +768,17 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
   scheduleSnapshot();
 }
 
+QLineF CaptureEditor::creationSpan(const QPointF &rawEnd) const {
+  const QPointF end =
+      creationConstraintActive_
+          ? constrainedCreationEndpoint(tool_, dragStart_, rawEnd)
+          : rawEnd;
+  const QPointF start = creationCenteredActive_
+                            ? centeredCreationStart(tool_, dragStart_, end)
+                            : dragStart_;
+  return {start, end};
+}
+
 void CaptureEditor::toggleShapeFill() {
   fillShapes_ = !fillShapes_;
   selectedAnnotation_ = -1;
@@ -1078,13 +1101,13 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   const QString fillHint = fillShapes_ ? QStringLiteral("filled") : QString();
   add(36, QStringLiteral("tool-rectangle"), fillHint,
       QStringLiteral("Rectangle · R · %1 · R again toggles fill · Size %2 · "
-                     "Wheel · Alt+Wheel %3 · Shift makes square")
+                     "Wheel · Alt+Wheel %3 · Shift square · Alt centered")
           .arg(fillName(fillShapes_))
           .arg(qRound(annotationSize_))
           .arg(cornerName(cornerRadius_)));
   add(36, QStringLiteral("tool-ellipse"), fillHint,
       QStringLiteral("Ellipse · E · %1 · E again toggles fill · Size %2 · "
-                     "Wheel · Shift makes circle")
+                     "Wheel · Shift circle · Alt centered")
           .arg(fillName(fillShapes_))
           .arg(qRound(annotationSize_)));
   add(36, QStringLiteral("tool-redact"), {},
@@ -1178,6 +1201,7 @@ void CaptureEditor::cancelActiveDragForHistory() {
     applyEditState(dragStartState_);
   dragging_ = false;
   creationConstraintActive_ = false;
+  creationCenteredActive_ = false;
   interaction_ = Interaction::None;
   dragStartStateValid_ = false;
   dragChanged_ = false;
@@ -1377,6 +1401,7 @@ void CaptureEditor::handleEscape() {
   dragStartStateValid_ = false;
   dragChanged_ = false;
   creationConstraintActive_ = false;
+  creationCenteredActive_ = false;
   dragging_ = false;
   interaction_ = Interaction::None;
   colorPaletteOpen_ = false;
@@ -1696,6 +1721,13 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     update();
     return;
   }
+  if (event->key() == Qt::Key_Alt && phase_ == Phase::Edit && dragging_ &&
+      supportsCenteredCreation(tool_)) {
+    creationCenteredActive_ = true;
+    event->accept();
+    update();
+    return;
+  }
   if (event->key() == Qt::Key_Escape) {
     handleEscape();
     return;
@@ -1900,6 +1932,12 @@ void CaptureEditor::keyReleaseEvent(QKeyEvent *event) {
   modifiersSeen_ = true;
   if (event->key() == Qt::Key_Shift && creationConstraintActive_) {
     creationConstraintActive_ = false;
+    event->accept();
+    update();
+    return;
+  }
+  if (event->key() == Qt::Key_Alt && creationCenteredActive_) {
+    creationCenteredActive_ = false;
     event->accept();
     update();
     return;
@@ -2393,6 +2431,8 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     dragging_ = true;
     creationConstraintActive_ = supportsCreationConstraint(tool_) &&
                                 heldModifiers(event->modifiers()).testFlag(Qt::ShiftModifier);
+    creationCenteredActive_ = supportsCenteredCreation(tool_) &&
+                              heldModifiers(event->modifiers()).testFlag(Qt::AltModifier);
     if (tool_ == Tool::Redact) {
       activeRedactionSeed_ = QRandomGenerator::system()->generate();
       if (activeRedactionSeed_ == 0)
@@ -2526,11 +2566,11 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     return;
   }
 
-  const QPointF rawEnd = toAnnotationPoint(event->position());
-  const QPointF end = creationConstraintActive_
-                          ? constrainedCreationEndpoint(tool_, dragStart_, rawEnd)
-                          : rawEnd;
+  const QLineF span = creationSpan(toAnnotationPoint(event->position()));
+  const QPointF start = span.p1();
+  const QPointF end = span.p2();
   creationConstraintActive_ = false;
+  creationCenteredActive_ = false;
   if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
     if (freehandPoints_.isEmpty() ||
         QLineF(freehandPoints_.last(), end).length() >= 1.0)
@@ -2575,7 +2615,7 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     update();
     return;
   }
-  const QRectF draggedRect(dragStart_, end);
+  const QRectF draggedRect(start, end);
   const bool validRedaction =
       tool_ != Tool::Redact ||
       (draggedRect.normalized().width() >= kMinimumRedactionExtent &&
@@ -2598,7 +2638,7 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       if (tool_ == Tool::Rectangle)
         annotation.cornerRadius = cornerRadius_;
     }
-    annotation.start = dragStart_;
+    annotation.start = start;
     annotation.end = end;
     annotation.color = annotationColor();
     annotation.size = annotationSize_;
@@ -2942,26 +2982,21 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       preview.kind = tool_ == Tool::Highlighter ? Annotation::Kind::Highlighter
                                                 : Annotation::Kind::Freehand;
       preview.points = freehandPoints_;
-    } else if (tool_ == Tool::Spotlight) {
-      preview.kind = Annotation::Kind::Spotlight;
-      preview.start = dragStart_;
-      const QPointF end = toAnnotationPoint(cursor_);
-      preview.end = creationConstraintActive_
-                        ? constrainedCreationEndpoint(tool_, dragStart_, end)
-                        : end;
-      preview.magnification = spotlightMagnification_;
-      preview.spotlightShape = spotlightShape_;
     } else {
-      preview.kind = dragShapeKind(tool_);
-      if (tool_ == Tool::Rectangle || tool_ == Tool::Ellipse)
-        preview.filled = fillShapes_;
-      if (tool_ == Tool::Rectangle)
-        preview.cornerRadius = cornerRadius_;
-      preview.start = dragStart_;
-      const QPointF end = toAnnotationPoint(cursor_);
-      preview.end = creationConstraintActive_
-                        ? constrainedCreationEndpoint(tool_, dragStart_, end)
-                        : end;
+      if (tool_ == Tool::Spotlight) {
+        preview.kind = Annotation::Kind::Spotlight;
+        preview.magnification = spotlightMagnification_;
+        preview.spotlightShape = spotlightShape_;
+      } else {
+        preview.kind = dragShapeKind(tool_);
+        if (tool_ == Tool::Rectangle || tool_ == Tool::Ellipse)
+          preview.filled = fillShapes_;
+        if (tool_ == Tool::Rectangle)
+          preview.cornerRadius = cornerRadius_;
+      }
+      const QLineF span = creationSpan(toAnnotationPoint(cursor_));
+      preview.start = span.p1();
+      preview.end = span.p2();
     }
     preview.color = tool_ == Tool::Ocr ? QColor(Qt::white) : annotationColor();
     preview.size = tool_ == Tool::Ocr ? 2.0 : annotationSize_;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -8,6 +8,7 @@
 #include <QFutureWatcher>
 #include <QLineEdit>
 #include <QPixmap>
+#include <QLineF>
 #include <QWidget>
 
 class QKeyEvent;
@@ -181,6 +182,7 @@ private:
   [[nodiscard]] int windowInDirection(int current, int key) const;
   [[nodiscard]] QVector<ToolbarButton> toolbarButtons() const;
   [[nodiscard]] QColor annotationColor() const;
+  [[nodiscard]] QLineF creationSpan(const QPointF &rawEnd) const;
 
   void acceptText();
   void applyCustomColor(const QPointF &position);
@@ -235,6 +237,7 @@ private:
   bool creationConstraintActive_ = false;
   bool marqueeSelecting_ = false;
   bool marqueeAdditive_ = false;
+  bool creationCenteredActive_ = false;
   Interaction interaction_ = Interaction::None;
   QVector<QPointF> freehandPoints_;
   // Cut tool live-drag state. cutDragStart_/cutBandLo_/cutBandHi_ and
@@ -343,3 +346,7 @@ private:
 [[nodiscard]] QPointF constrainedCreationEndpoint(CaptureEditor::Tool tool,
                                                   const QPointF &start,
                                                   const QPointF &end);
+/** Start point that centers a drag-created shape on `center` given `end`. */
+[[nodiscard]] QPointF centeredCreationStart(CaptureEditor::Tool tool,
+                                            const QPointF &center,
+                                            const QPointF &end);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -909,6 +909,32 @@ bool runCreationConstraintCheck(QString &error) {
     error = QStringLiteral("Creation constraint changed an unrelated tool");
     return false;
   }
+
+
+  // Alt mirrors the end point through the press point so the shape is
+  // centered there; composed with Shift it yields a centered square/circle.
+  for (const CaptureEditor::Tool tool :
+       {CaptureEditor::Tool::Rectangle, CaptureEditor::Tool::Ellipse,
+        CaptureEditor::Tool::Spotlight}) {
+    if (centeredCreationStart(tool, start, QPointF(40, 30)) !=
+        QPointF(-20, -10)) {
+      error = QStringLiteral("Centered creation did not mirror the start");
+      return false;
+    }
+    if (centeredCreationStart(tool, start, square) != QPointF(-20, -20)) {
+      error = QStringLiteral(
+          "Centered creation did not compose with the 1:1 constraint");
+      return false;
+    }
+  }
+  for (const CaptureEditor::Tool tool :
+       {CaptureEditor::Tool::Arrow, CaptureEditor::Tool::Line,
+        CaptureEditor::Tool::Redact, CaptureEditor::Tool::Freehand}) {
+    if (centeredCreationStart(tool, start, QPointF(40, 30)) != start) {
+      error = QStringLiteral("Centered creation changed an unrelated tool");
+      return false;
+    }
+  }
   return true;
 }
 
@@ -2743,6 +2769,142 @@ bool runShapeFillToolSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+bool runCenteredCreationSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(700, 500));
+  application.processEvents();
+  const QRectF selection(100, 100, 600, 400);
+  const auto expected = [&](const QVector<Annotation> &annotations) {
+    return renderCapture(capture, selection, annotations,
+                         BackgroundStyle::None);
+  };
+  const auto snapshotMatches = [&](const QImage &image) {
+    return flushedSnapshot(editor, snapshotPath)
+                   .convertToFormat(image.format()) == image;
+  };
+  const auto shape = [](Annotation::Kind kind, const QPointF &start,
+                        const QPointF &end) {
+    Annotation annotation;
+    annotation.kind = kind;
+    annotation.start = start;
+    annotation.end = end;
+    annotation.color = QColor(QStringLiteral("#ff375f"));
+    annotation.size = 4;
+    return annotation;
+  };
+
+  // Alt held from the press: the ellipse is centered on the press point
+  // (widget (400,300) = annotation (300,195)) with the cursor on its corner.
+  QTest::keyClick(&editor, Qt::Key_E);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::AltModifier, QPoint(400, 300));
+  QTest::mouseMove(&editor, QPoint(500, 350), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::AltModifier,
+                      QPoint(500, 350));
+  application.processEvents();
+  const Annotation centeredEllipse =
+      shape(Annotation::Kind::Ellipse, {200, 145}, {400, 245});
+  if (!snapshotMatches(expected({centeredEllipse}))) {
+    error = QStringLiteral("Alt-drag did not center the ellipse");
+    return false;
+  }
+
+  // Alt+Shift: centered square whose half-extent is the longer drag axis.
+  QTest::keyClick(&editor, Qt::Key_R);
+  QTest::mousePress(&editor, Qt::LeftButton,
+                    Qt::AltModifier | Qt::ShiftModifier, QPoint(400, 300));
+  QTest::mouseMove(&editor, QPoint(460, 340), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton,
+                      Qt::AltModifier | Qt::ShiftModifier, QPoint(460, 340));
+  application.processEvents();
+  const Annotation centeredSquare =
+      shape(Annotation::Kind::Rectangle, {240, 135}, {360, 255});
+  if (!snapshotMatches(expected({centeredEllipse, centeredSquare}))) {
+    error = QStringLiteral("Alt+Shift-drag did not create a centered square");
+    return false;
+  }
+
+  // Alt pressed mid-drag applies; released before the mouse it does not.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 200));
+  QTest::mouseMove(&editor, QPoint(250, 230), 20);
+  QTest::keyPress(&editor, Qt::Key_Alt);
+  application.processEvents();
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::AltModifier,
+                      QPoint(250, 230));
+  QTest::keyRelease(&editor, Qt::Key_Alt);
+  application.processEvents();
+  const Annotation midDrag =
+      shape(Annotation::Kind::Rectangle, {50, 65}, {150, 125});
+  if (!snapshotMatches(expected({centeredEllipse, centeredSquare, midDrag}))) {
+    error = QStringLiteral("Alt pressed mid-drag did not center the shape");
+    return false;
+  }
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::AltModifier, QPoint(600, 200));
+  QTest::mouseMove(&editor, QPoint(650, 230), 20);
+  QTest::keyRelease(&editor, Qt::Key_Alt);
+  application.processEvents();
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(650, 230));
+  application.processEvents();
+  const Annotation released =
+      shape(Annotation::Kind::Rectangle, {500, 95}, {550, 125});
+  if (!snapshotMatches(
+          expected({centeredEllipse, centeredSquare, midDrag, released}))) {
+    error = QStringLiteral("Alt released before the mouse still centered");
+    return false;
+  }
+
+  // Spotlight (Omasnap's own drag-rectangle shape) centers the same way.
+  QTest::keyClick(&editor, Qt::Key_S);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::AltModifier, QPoint(600, 400));
+  QTest::mouseMove(&editor, QPoint(660, 440), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::AltModifier,
+                      QPoint(660, 440));
+  application.processEvents();
+  Annotation spotlight =
+      shape(Annotation::Kind::Spotlight, {440, 255}, {560, 335});
+  spotlight.magnification = 2.0;
+  spotlight.spotlightShape = SpotlightShape::Ellipse;
+  if (!snapshotMatches(expected(
+          {centeredEllipse, centeredSquare, midDrag, released, spotlight}))) {
+    error = QStringLiteral("Alt-drag did not center the spotlight");
+    return false;
+  }
+
+  // Alt leaves lines alone.
+  QTest::keyClick(&editor, Qt::Key_L);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::AltModifier, QPoint(200, 400));
+  QTest::mouseMove(&editor, QPoint(300, 450), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::AltModifier,
+                      QPoint(300, 450));
+  application.processEvents();
+  const Annotation line = shape(Annotation::Kind::Line, {100, 295}, {200, 345});
+  if (!snapshotMatches(expected({centeredEllipse, centeredSquare, midDrag,
+                                 released, spotlight, line}))) {
+    error = QStringLiteral("Alt changed a line's start point");
+    return false;
+  }
+
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -2833,6 +2995,10 @@ int main(int argc, char **argv) {
   if (!runSelectOutsideCanvasSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 106;
+  }
+  if (!runCenteredCreationSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 112;
   }
   if (!runShapeFillRenderingCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
> Stacked on #56, itself on #55. The diff below has both; only the last commit is this PR. I'll rebase as they land.

Hold Alt while you drag and the shape centers on the point you pressed instead of starting there. Shift's 1:1 constraint applies first, so Alt+Shift gives a square or circle centered on that point, and Alt can go down or come up mid-drag like Shift does.

Lines, arrows, redactions and OCR ignore it, since there's no sensible center for a stroke. The 4 px commit dead-zone still measures real mouse travel, so a centered drag doesn't commit early just because the shape grows twice as fast.

Four places were computing the live start/end separately; they share a `creationSpan()` now, which is what made toggling Alt mid-drag tractable at all.

Unit checks on `centeredCreationStart`, plus `runCenteredCreationSmoke` (exit 98) over Alt-drag, Alt+Shift, Alt pressed mid-drag, and a line correctly ignoring it.
