### PR TITLE
feat(editor): draw text on a cream readability pill, T again toggles it

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
 - Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
   hollow or filled rectangles (optionally rounded) and ellipses, numbered markers,
-  editable Neucha text, and secure redaction with opaque or randomized non-spatial
-  mosaic output.
+  editable Neucha text (on a readability pill), and secure redaction with opaque or
+  randomized non-spatial mosaic output.
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
@@ -267,7 +267,7 @@ Install the corresponding Tesseract language data before adding a language to
 | `E` | Ellipse; press again to toggle filled/hollow |
 | `D` | Redact; press again to toggle randomized pixelation or solid redaction |
 | `X` | Cut out a band; drag across the image to remove and collapse a horizontal or vertical strip |
-| `T` | Neucha text |
+| `T` | Neucha text on a cream readability pill; press again to toggle the pill (with a text layer selected, toggles that layer) |
 | `O` | Drag an OCR region and copy recognized text |
 | `B` | Cycle backdrop |
 | `1`–`6` | Set annotation color |

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -44,6 +44,20 @@ QFont annotationTextFont(qreal size) {
   return font;
 }
 
+QRectF annotationTextBounds(const Annotation &annotation) {
+  const QFontMetricsF metrics(annotationTextFont(annotation.size));
+  const QRectF glyphs(
+      annotation.start.x(), annotation.start.y() - metrics.ascent(),
+      metrics.horizontalAdvance(annotation.text), metrics.height());
+  if (annotation.textBackground != TextBackground::Pill)
+    return glyphs;
+  // The pill has even side/top padding and a bottom pad that grows with the
+  // descender, so commas and tails stay inside the cream.
+  const qreal pad = std::max<qreal>(4.0, metrics.height() * 0.18);
+  const qreal bottom = std::max(pad, metrics.descent() + 2.0);
+  return glyphs.adjusted(-pad, -pad, pad, bottom - metrics.descent());
+}
+
 bool ensurePrivateDirectory(const QString &path) {
   if (path.isEmpty())
     return false;
@@ -401,6 +415,15 @@ void drawAnnotation(QPainter &painter, const Annotation &annotation) {
   }
 
   const QFont font = annotationTextFont(annotation.size);
+  if (annotation.textBackground == TextBackground::Pill) {
+    // A cream pill under the glyphs keeps text readable on any capture or
+    // shape beneath it (the default text background).
+    const QRectF pill = annotationTextBounds(annotation);
+    const qreal radius = std::min(pill.height() / 4.0, 6.0);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor(248, 245, 235));
+    painter.drawRoundedRect(pill, radius, radius);
+  }
   painter.setFont(font);
   painter.setPen(annotation.color);
   painter.setBrush(Qt::NoBrush);

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -41,6 +41,7 @@ enum class QuickOutputMode { None, Copy, Save, Both };
 
 enum class SpotlightShape { Ellipse, Rectangle, RoundedRectangle };
 enum class RedactionStyle { Solid, Pixelate };
+enum class TextBackground { Plain, Pill };
 
 struct Annotation {
   enum class Kind {
@@ -70,6 +71,7 @@ struct Annotation {
   qreal magnification = 2.0;
   SpotlightShape spotlightShape = SpotlightShape::Ellipse;
   quint32 redactionSeed = 0;
+  TextBackground textBackground = TextBackground::Pill;
 
   bool operator==(const Annotation &) const = default;
 };
@@ -101,6 +103,9 @@ enum class AnnotationLayer { Redaction, Default };
 /** Convenience: probes the focused monitor, then captures its pixels. */
 [[nodiscard]] bool captureFocusedMonitor(CaptureData &capture,
                                          bool includeWindows, QString &error);
+/** Bounds of a text layer's glyph box, or of its readability pill when it
+ *  has one; `start` is the baseline origin. */
+[[nodiscard]] QRectF annotationTextBounds(const Annotation &annotation);
 [[nodiscard]] bool captureWindowSurface(const WindowTarget &window,
                                         QImage &image, QString &error);
 /** Returns an upright image for captured Wayland buffer contents. */

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -23,6 +23,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QProcess>
+#include <QProxyStyle>
 #include <QRandomGenerator>
 #include <QScreen>
 #include <QThread>
@@ -34,6 +35,29 @@
 #include <limits>
 #include <utility>
 #include <numbers>
+
+/// The inline text editor: a QLineEdit whose native caret is hidden (the
+/// editor paints a shorter one over Neucha's tall line box) and whose caret
+/// rectangle is exposed for that.
+class InlineTextEdit final : public QLineEdit {
+public:
+  explicit InlineTextEdit(QWidget *parent) : QLineEdit(parent) {
+    setStyle(&caretlessStyle_);
+  }
+  using QLineEdit::cursorRect;
+
+private:
+  class CaretlessStyle final : public QProxyStyle {
+  public:
+    int pixelMetric(PixelMetric metric, const QStyleOption *option,
+                    const QWidget *widget) const override {
+      return metric == PM_TextCursorWidth
+                 ? 0
+                 : QProxyStyle::pixelMetric(metric, option, widget);
+    }
+  };
+  CaretlessStyle caretlessStyle_;
+};
 
 namespace {
 constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
@@ -145,6 +169,11 @@ QString fillName(bool filled) {
 QString cornerName(qreal radius) {
   return radius > 0.0 ? QStringLiteral("%1 px corners").arg(qRound(radius))
                       : QStringLiteral("square corners");
+}
+
+QString textBackgroundName(TextBackground background) {
+  return background == TextBackground::Pill ? QStringLiteral("Pill")
+                                            : QStringLiteral("Plain");
 }
 
 QString redactionStyleName(RedactionStyle style) {
@@ -363,7 +392,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     setGeometry(QGuiApplication::primaryScreen()->geometry());
   cursor_ = mapFromGlobal(QCursor::pos());
 
-  textEditor_ = new QLineEdit(this);
+  textEditor_ = new InlineTextEdit(this);
   textEditor_->hide();
   textEditor_->setFrame(false);
   textEditor_->setTextMargins(0, 0, 0, 0);
@@ -372,11 +401,24 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
                      "border: none; padding: 0;"
                      " selection-background-color: #0a84ff; }"));
   textEditor_->installEventFilter(this);
+  // The editor paints its own, shorter caret (see paintEdit); blink it.
+  textCaretTimer_.setInterval(530);
+  connect(&textCaretTimer_, &QTimer::timeout, this, [this] {
+    textCaretOn_ = !textCaretOn_;
+    update(textEditor_->geometry().adjusted(-4, -4, 4, 4));
+  });
+  connect(textEditor_, &QLineEdit::cursorPositionChanged, this, [this] {
+    textCaretOn_ = true;
+    textCaretTimer_.start();
+    update();
+  });
   connect(
       textEditor_, &QLineEdit::textChanged, this, [this](const QString &text) {
         const QFontMetrics metrics(textEditor_->font());
+        const QMargins margins = textEditor_->textMargins();
         const int desiredWidth = std::max(
-            48, metrics.horizontalAdvance(text + QStringLiteral("  ")));
+            48, metrics.horizontalAdvance(text + QStringLiteral("  ")) +
+                    margins.left() + margins.right());
         const int availableWidth =
             std::max(48, qRound(editImageRect().right() - textEditor_->x()));
         textEditor_->resize(std::min(desiredWidth, availableWidth),
@@ -556,11 +598,8 @@ QRectF CaptureEditor::annotationBounds(const Annotation &annotation) const {
     return {annotation.start.x() - diameter / 2.0,
             annotation.start.y() - diameter / 2.0, diameter, diameter};
   }
-  if (annotation.kind == Annotation::Kind::Text) {
-    const QFontMetricsF metrics(annotationTextFont(annotation.size));
-    return {annotation.start.x(), annotation.start.y() - metrics.ascent(),
-            metrics.horizontalAdvance(annotation.text), metrics.height()};
-  }
+  if (annotation.kind == Annotation::Kind::Text)
+    return annotationTextBounds(annotation);
   if (isStrokeKind(annotation.kind)) {
     if (annotation.points.isEmpty())
       return {};
@@ -786,6 +825,27 @@ void CaptureEditor::toggleShapeFill() {
                 .arg(fillName(fillShapes_))
                 .arg(tool_ == Tool::Ellipse ? QStringLiteral("E")
                                             : QStringLiteral("R")));
+}
+
+void CaptureEditor::toggleTextBackground() {
+  if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+      annotations_.at(selectedAnnotation_).kind == Annotation::Kind::Text) {
+    recordEdit();
+    Annotation &text = annotations_[selectedAnnotation_];
+    text.textBackground = text.textBackground == TextBackground::Pill
+                              ? TextBackground::Plain
+                              : TextBackground::Pill;
+    setStatus(QStringLiteral("Selected text: %1 · T again toggles")
+                  .arg(textBackgroundName(text.textBackground).toLower()));
+    scheduleSnapshot();
+    return;
+  }
+  textBackground_ = textBackground_ == TextBackground::Pill
+                        ? TextBackground::Plain
+                        : TextBackground::Pill;
+  selectedAnnotation_ = -1;
+  setStatus(QStringLiteral("Text: %1 · T again toggles")
+                .arg(textBackgroundName(textBackground_).toLower()));
 }
 
 QRectF CaptureEditor::colorPaletteRect() const {
@@ -1116,9 +1176,10 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(36, QStringLiteral("tool-cut"), {},
       QStringLiteral("Cut out a band · X · drag across"));
   add(36, QStringLiteral("tool-text"), {},
-      QStringLiteral("Neucha text · T · %1 · Wheel")
+      QStringLiteral("Neucha text · T · %1 · %2 · T again toggles pill · Wheel")
           .arg(QString::fromLatin1(
-              kTextSizeNames.at(static_cast<std::size_t>(textSizeIndex_)))));
+              kTextSizeNames.at(static_cast<std::size_t>(textSizeIndex_))))
+          .arg(textBackgroundName(textBackground_)));
   add(36, QStringLiteral("palette"), {}, QStringLiteral("Annotation color"),
       annotationColor());
   add(36, QStringLiteral("tool-ocr"), {},
@@ -1191,6 +1252,7 @@ void CaptureEditor::applyEditState(const EditState &state) {
   freehandPoints_.clear();
   textEditor_->clear();
   textEditor_->hide();
+  textCaretTimer_.stop();
   setFocus(Qt::OtherFocusReason);
   updatePointerCursor();
   update();
@@ -1393,6 +1455,7 @@ void CaptureEditor::handleEscape() {
   escapeTimer_.restart();
   textEditor_->clear();
   textEditor_->hide();
+  textCaretTimer_.stop();
   editingAnnotation_ = -1;
   if (dragStartStateValid_) {
     applyEditState(dragStartState_);
@@ -1451,19 +1514,30 @@ void CaptureEditor::beginText(const QPointF &point, int annotationIndex) {
       std::max(12, qRound(displayFont.pixelSize() * scale)));
   const QFontMetrics metrics(displayFont);
   textEditor_->setFont(displayFont);
+  // While typing, show the same cream pill the committed text will have.
+  const TextBackground background =
+      annotationIndex >= 0 && annotationIndex < annotations_.size()
+          ? annotations_.at(annotationIndex).textBackground
+          : textBackground_;
+  const bool pill = background == TextBackground::Pill;
+  textEditPill_ = pill;
+  const int pillPad = pill ? qRound(std::max(4.0, metrics.height() * 0.18)) : 0;
   textEditor_->setStyleSheet(
-      QStringLiteral(
-          "QLineEdit { color: %1; background: transparent; border: none;"
-          " margin: 0; padding: 0; selection-background-color: #0a84ff; }")
+      QStringLiteral("QLineEdit { color: %1; background: transparent; "
+                     "border: none; margin: 0; padding: 0;"
+                     " selection-background-color: #0a84ff; }")
           .arg(textColor_.name()));
-  textEditor_->setGeometry(qRound(position.x()), qRound(position.y()), 72,
-                           metrics.height());
+  textEditor_->setTextMargins(pillPad, 0, pillPad, 0);
+  textEditor_->setGeometry(qRound(position.x()) - pillPad, qRound(position.y()),
+                           72 + 2 * pillPad, metrics.height());
   textEditor_->setText(existingText);
   textEditor_->show();
   textEditor_->raise();
   textEditor_->setFocus(Qt::MouseFocusReason);
   if (!existingText.isEmpty())
     textEditor_->selectAll();
+  textCaretOn_ = true;
+  textCaretTimer_.start();
 }
 
 void CaptureEditor::acceptText() {
@@ -1478,6 +1552,10 @@ void CaptureEditor::acceptText() {
     annotation.text = text;
     annotation.color = textColor_;
     annotation.size = textSize_;
+    annotation.textBackground =
+        editingAnnotation_ >= 0 && editingAnnotation_ < annotations_.size()
+            ? annotations_.at(editingAnnotation_).textBackground
+            : textBackground_;
     if (editingAnnotation_ >= 0 && editingAnnotation_ < annotations_.size()) {
       annotations_[editingAnnotation_] = std::move(annotation);
       selectedAnnotation_ = editingAnnotation_;
@@ -1495,6 +1573,7 @@ void CaptureEditor::acceptText() {
   editingAnnotation_ = -1;
   textEditor_->clear();
   textEditor_->hide();
+  textCaretTimer_.stop();
   setFocus(Qt::OtherFocusReason);
   updatePointerCursor();
   update();
@@ -1653,9 +1732,12 @@ void CaptureEditor::handleToolbar(const QString &action) {
     tool_ = Tool::Cut;
     selectedAnnotation_ = -1;
     setStatus(QStringLiteral("Cut: drag across a band to remove it"));
-  } else if (action == QStringLiteral("tool-text"))
-    tool_ = Tool::Text;
-  else if (action == QStringLiteral("tool-eyedropper")) {
+  } else if (action == QStringLiteral("tool-text")) {
+    if (tool_ == Tool::Text)
+      toggleTextBackground();
+    else
+      tool_ = Tool::Text;
+  } else if (action == QStringLiteral("tool-eyedropper")) {
     if (tool_ != Tool::Eyedropper)
       toolBeforeEyedropper_ = tool_;
     tool_ = Tool::Eyedropper;
@@ -1893,7 +1975,13 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     tool_ = Tool::Cut;
     setStatus(QStringLiteral("Cut: drag across a band to remove it"));
   } else if (event->key() == Qt::Key_T) {
-    tool_ = Tool::Text;
+    const bool textSelected =
+        selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+        annotations_.at(selectedAnnotation_).kind == Annotation::Kind::Text;
+    if (tool_ == Tool::Text || textSelected)
+      toggleTextBackground();
+    else
+      tool_ = Tool::Text;
   } else if (event->key() == Qt::Key_I) {
     if (tool_ != Tool::Eyedropper)
       toolBeforeEyedropper_ = tool_;
@@ -2876,11 +2964,15 @@ void CaptureEditor::paintSelect(QPainter &painter) {
 }
 
 qreal selectionBoundsRadius(const Annotation &annotation, qreal inset) {
-  if (annotation.kind != Annotation::Kind::Rectangle || annotation.cornerRadius <= 0.0)
-    return 0.0;
-  // Concentric with the shape: a rounded rect offset outward by `inset` keeps
-  // the same centres, so its radius grows by the same amount.
-  return annotation.cornerRadius + inset;
+  if (annotation.kind == Annotation::Kind::Rectangle &&
+      annotation.cornerRadius > 0.0)
+    return annotation.cornerRadius + inset;
+  if (annotation.kind == Annotation::Kind::Text &&
+      annotation.textBackground == TextBackground::Pill) {
+    const QRectF pill = annotationTextBounds(annotation);
+    return std::min(pill.height() / 4.0, 6.0) + inset;
+  }
+  return 0.0;
 }
 
 void CaptureEditor::paintEdit(QPainter &painter) {
@@ -3141,6 +3233,29 @@ void CaptureEditor::paintEdit(QPainter &painter) {
                      QPointF(hue.right() + 2, hueY));
   }
 
+  if (textEditor_->isVisible()) {
+    // Cream pill under the inline editor (the QLineEdit is transparent), and
+    // a caret spanning the glyph box rather than Neucha's whole line height.
+    const QRectF box = textEditor_->geometry();
+    if (textEditPill_) {
+      const qreal radius = std::min(box.height() / 4.0, 6.0);
+      painter.setPen(Qt::NoPen);
+      painter.setBrush(QColor(248, 245, 235));
+      painter.drawRoundedRect(box, radius, radius);
+    }
+    if (textCaretOn_ && textEditor_->hasFocus()) {
+      const QFontMetricsF metrics(textEditor_->font());
+      const QRectF cursor =
+          QRectF(textEditor_->cursorRect()).translated(box.topLeft());
+      const qreal baseline = box.top() + metrics.ascent();
+      const qreal top = baseline - metrics.capHeight() * 1.15;
+      const qreal bottom = baseline + metrics.descent() * 0.35;
+      painter.setPen(QPen(textColor_, std::max(1.0, box.height() / 18.0)));
+      painter.drawLine(QPointF(cursor.center().x(), top),
+                       QPointF(cursor.center().x(), bottom));
+    }
+  }
+
   const QString currentTool = toolAction(tool_);
   QFont buttonFont = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
   buttonFont.setPixelSize(11);
@@ -3236,10 +3351,12 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       if (button.action == selectedAction) {
         QString tooltip;
         if (tool_ == Tool::Text) {
-          tooltip =
-              QStringLiteral("Neucha · S  M  L · current %1 · Scroll wheel")
-                  .arg(QString::fromLatin1(kTextSizeNames.at(
-                      static_cast<std::size_t>(textSizeIndex_))));
+          tooltip = QStringLiteral(
+                        "Neucha · S  M  L · current %1 · Scroll wheel · %2 · T "
+                        "again toggles pill")
+                        .arg(QString::fromLatin1(kTextSizeNames.at(
+                            static_cast<std::size_t>(textSizeIndex_))))
+                        .arg(textBackgroundName(textBackground_));
         } else if (tool_ == Tool::Redact) {
           tooltip = QStringLiteral("Redact · %1 · D toggles style")
                         .arg(redactionStyleName(redactionStyle_));

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -9,6 +9,7 @@
 #include <QLineEdit>
 #include <QPixmap>
 #include <QLineF>
+#include <QTimer>
 #include <QWidget>
 
 class QKeyEvent;
@@ -18,10 +19,11 @@ class QWheelEvent;
 
 class QPainter;
 
+class InlineTextEdit;
 /// Corner radius for the dashed selection box around `annotation`, drawn
-/// `inset` px outside its bounds. A rounded rectangle inside a square box
-/// reads as a mistake, and while the radius is being set the box is the only
-/// thing large enough to see it change on. 0 for every other kind.
+/// `inset` px outside its bounds. A rounded rectangle or text pill inside a
+/// square box reads as a mistake, and while the radius is being set the box
+/// is the only thing large enough to see it change on. 0 for every other kind.
 [[nodiscard]] qreal selectionBoundsRadius(const Annotation &annotation,
                                           qreal inset);
 
@@ -211,6 +213,7 @@ private:
   void setStatus(QString status);
   void scaleSelectedAnnotation(qreal factor);
   void toggleShapeFill();
+  void toggleTextBackground();
   void undoEdit();
   void updatePointerCursor();
 
@@ -268,6 +271,7 @@ private:
   bool fillShapes_ = false;
   qreal cornerRadius_ = 0.0;
   int textSizeIndex_ = 1;
+  TextBackground textBackground_ = TextBackground::Pill;
   qreal spotlightMagnification_ = 2.0;
   SpotlightShape spotlightShape_ = SpotlightShape::Ellipse;
   RedactionStyle redactionStyle_ = RedactionStyle::Pixelate;
@@ -333,12 +337,18 @@ private:
   int pinCount_ = 0;
   QString status_ =
       QStringLiteral("Drag to select an area · Space selects a window");
-  QLineEdit *textEditor_ = nullptr;
+  InlineTextEdit *textEditor_ = nullptr;
   QPointF textPoint_;
   QVector<Annotation> originalSelectedAnnotations_;
   QVector<int> selectedAnnotations_;
   qreal textSize_ = 4.0;
   QElapsedTimer escapeTimer_;
+  /// The inline editor's pill and caret are painted by the editor itself
+  /// (the QLineEdit stays transparent with its own caret hidden) so the
+  /// caret can be shorter than Neucha's tall line box.
+  bool textEditPill_ = false;
+  bool textCaretOn_ = true;
+  QTimer textCaretTimer_;
   QColor textColor_;
   QFutureWatcher<OcrResult> ocrWatcher_;
 };

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1281,6 +1281,9 @@ bool runAnnotationLayerChecks(QApplication &application, QString &error) {
   label.text = QStringLiteral("X");
   label.color = Qt::white;
   label.size = 8;
+  // Plain, so this stays a layer-order check: a readability pill would cover
+  // the arrow beneath it by design, which runTextPillSmoke covers instead.
+  label.textBackground = TextBackground::Plain;
   const QImage redactionOnly =
       renderCapture(capture, QRectF(0, 0, 80, 40), {redaction},
                     BackgroundStyle::None);
@@ -1972,6 +1975,7 @@ bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
   return true;
 }
 } // namespace
+/** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
@@ -2905,6 +2909,182 @@ bool runCenteredCreationSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Runs the interaction and rendering smoke checks. */
+bool runTextPillRenderingCheck(QString &error) {
+  error = QStringLiteral("Text pill rendering check failed");
+  CaptureData capture;
+  capture.monitor.scale = 1.0;
+  capture.monitor.pixelSize = {300, 100};
+  capture.source = QImage(300, 100, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(Qt::transparent);
+  capture.previewSize = capture.source.size();
+  Annotation text;
+  text.kind = Annotation::Kind::Text;
+  text.text = QStringLiteral("Readable");
+  text.color = QColor(QStringLiteral("#ff375f"));
+  text.size = 5;
+  text.start = {40, 60};
+  const QRectF pill = annotationTextBounds(text);
+  const QImage withPill = renderCapture(capture, QRectF(0, 0, 300, 100), {text},
+                                        BackgroundStyle::None);
+  // Cream just left of the first glyph and just above the ascent, inside
+  // the pill but away from any ink.
+  const QPoint beside(qRound(pill.left() + 2), 55);
+  const QPoint above(60, qRound(pill.top() + 2));
+  for (const QPoint &probe : {beside, above}) {
+    if (withPill.pixelColor(probe) != QColor(248, 245, 235)) {
+      error = QStringLiteral("Text pill was not painted around the glyphs");
+      return false;
+    }
+  }
+  if (withPill.pixelColor(pill.left() - 3, 55).alpha() != 0) {
+    error = QStringLiteral("Text pill spilled outside its bounds");
+    return false;
+  }
+  text.textBackground = TextBackground::Plain;
+  const QImage plain = renderCapture(capture, QRectF(0, 0, 300, 100), {text},
+                                     BackgroundStyle::None);
+  if (plain.pixelColor(beside).alpha() != 0 ||
+      plain.pixelColor(above).alpha() != 0) {
+    error = QStringLiteral("Plain text still painted a pill");
+    return false;
+  }
+
+  // The selection box follows the pill, so a rounded background does not sit
+  // inside a square dashed frame.
+  Annotation pilled = text;
+  pilled.textBackground = TextBackground::Pill;
+  const qreal pillHeight = annotationTextBounds(pilled).height();
+  const qreal want = std::min(pillHeight / 4.0, 6.0) + 4.0;
+  if (selectionBoundsRadius(pilled, 4.0) != want) {
+    error = QStringLiteral("Selection box did not follow the text pill");
+    return false;
+  }
+  Annotation bare = text;
+  bare.textBackground = TextBackground::Plain;
+  if (selectionBoundsRadius(bare, 4.0) != 0.0) {
+    error = QStringLiteral("Selection box rounded text that has no pill");
+    return false;
+  }
+  Annotation rect;
+  rect.kind = Annotation::Kind::Rectangle;
+  if (selectionBoundsRadius(rect, 4.0) != 0.0) {
+    error = QStringLiteral("Selection box rounded a kind with no pill");
+    return false;
+  }
+  return true;
+}
+
+bool runTextPillSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(700, 500));
+  application.processEvents();
+  const QRectF selection(100, 100, 600, 400);
+  const auto expected = [&](const QVector<Annotation> &annotations) {
+    return renderCapture(capture, selection, annotations,
+                         BackgroundStyle::None);
+  };
+  const auto snapshotMatches = [&](const QImage &image) {
+    return flushedSnapshot(editor, snapshotPath)
+                   .convertToFormat(image.format()) == image;
+  };
+  const qreal ascent = QFontMetricsF(annotationTextFont(5.0)).ascent();
+  const auto text = [&](const QPointF &clicked, const QString &content,
+                        TextBackground background) {
+    Annotation annotation;
+    annotation.kind = Annotation::Kind::Text;
+    annotation.start = clicked + QPointF(0, ascent);
+    annotation.text = content;
+    annotation.color = QColor(QStringLiteral("#ff375f"));
+    annotation.size = 5;
+    annotation.textBackground = background;
+    return annotation;
+  };
+  const auto typeText = [&](const QPoint &at, const QString &content) {
+    QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, at);
+    application.processEvents();
+    QTest::keyClicks(QApplication::focusWidget(), content);
+    QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+    application.processEvents();
+  };
+
+  // New text gets the pill by default.
+  QTest::keyClick(&editor, Qt::Key_T);
+  typeText(QPoint(300, 300), QStringLiteral("Pill"));
+  const Annotation pill =
+      text({200, 195}, QStringLiteral("Pill"), TextBackground::Pill);
+  if (!snapshotMatches(expected({pill}))) {
+    error = QStringLiteral("New text did not get a readability pill");
+    return false;
+  }
+
+  // T again (tool still armed) switches the next text to plain.
+  QTest::keyClick(&editor, Qt::Key_T);
+  typeText(QPoint(300, 400), QStringLiteral("Plain"));
+  const Annotation plain =
+      text({200, 295}, QStringLiteral("Plain"), TextBackground::Plain);
+  if (!snapshotMatches(expected({pill, plain}))) {
+    error = QStringLiteral("T again did not switch new text to plain");
+    return false;
+  }
+
+  // T with a text layer selected toggles that layer, undoably.
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(310, 290));
+  QTest::keyClick(&editor, Qt::Key_T);
+  application.processEvents();
+  Annotation pillNowPlain = pill;
+  pillNowPlain.textBackground = TextBackground::Plain;
+  if (!snapshotMatches(expected({pillNowPlain, plain}))) {
+    error = QStringLiteral("T did not toggle the selected text's pill");
+    return false;
+  }
+  if (editor.cursor().shape() != Qt::ArrowCursor) {
+    error = QStringLiteral("Toggling a selected text switched tools");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(expected({pill, plain}))) {
+    error = QStringLiteral("Undo did not restore the text pill");
+    return false;
+  }
+
+  // Re-editing keeps the layer's own background.
+  QTest::mouseDClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(310, 410));
+  application.processEvents();
+  QTest::keyClick(QApplication::focusWidget(), Qt::Key_End); // text is selected
+  QTest::keyClicks(QApplication::focusWidget(), QStringLiteral(" text"));
+  QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+  application.processEvents();
+  const Annotation plainEdited =
+      text({200, 295}, QStringLiteral("Plain text"), TextBackground::Plain);
+  if (!snapshotMatches(expected({pill, plainEdited}))) {
+    error = QStringLiteral("Re-editing changed the text's background");
+    return false;
+  }
+
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -3015,6 +3195,14 @@ int main(int argc, char **argv) {
   if (!runEllipseToolSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 109;
+  }
+  if (!runTextPillRenderingCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 102;
+  }
+  if (!runTextPillSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 103;
   }
   if (!runSpotlightWheelSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
Text drew bare in the annotation color, so a label sitting on the shape it belongs to, in the same color as that shape, came out hard to read. That's the case you want text for most.

Text layers carry a `TextBackground` now, `Pill` by default, a cream rounded rectangle under the glyphs. Its bounds double as the layer's hit target, and short text is much easier to grab by a pill than by the glyph runs.

The inline editor shows the same pill while you type, so the draft looks like the result. It paints its own caret spanning the glyphs' cap height (530 ms blink, reset on move), with the `QLineEdit` transparent and its native caret suppressed through a `QProxyStyle`, because that one is sized to Neucha's tall line box and read as a stray vertical rule beside the text.

`T` again flips the default for new text, and with a text layer selected it restyles that layer instead, as an undoable edit. Same idiom the other tools use.

The dashed selection box follows the pill's corners, since a rounded background sitting in a square frame reads as a rendering bug.

`runTextPillRenderingCheck` (exit 102) checks the pill hugs the glyphs rather than the editor's box; `runTextPillSmoke` (exit 103) covers the default, the toggle, undo and re-editing.
