### PR TITLE
feat(editor): Alt+D duplicates the selected layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Install the corresponding Tesseract language data before adding a language to
 | Hold `Alt` while dragging | Center rectangles, ellipses, and spotlights on the press point; add `Shift` for a centered square/circle |
 | Double-click text | Reopen text editing |
 | `Delete` | Delete selected layer |
+| `Alt+D` | Duplicate selected layer (offset down-left, or away from a nearby edge); the copy becomes the selection |
 | `Ctrl+Z` | Undo |
 | `Ctrl+Shift+Z`, `Ctrl+Y` | Redo |
 | `Ctrl+C` | Copy PNG only |

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1957,7 +1957,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     finish(OutputMode::Both);
     return;
   } else if (event->key() == Qt::Key_D &&
-             heldModifiers(event->modifiers()) == Qt::AltModifier) {
+             event->modifiers() == Qt::AltModifier) {
     duplicateSelectedAnnotation();
   } else if ((event->key() == Qt::Key_Delete ||
               event->key() == Qt::Key_Backspace) &&

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -94,6 +94,35 @@ qreal strokeHitTolerance(const Annotation &annotation) {
     return std::max<qreal>(8.0, annotation.size * 3.0 + 4.0);
   return std::max<qreal>(8.0, annotation.size + 4.0);
 }
+void translateAnnotation(Annotation &annotation, const QPointF &delta) {
+  annotation.start += delta;
+  if (hasEndpointHandles(annotation.kind))
+    annotation.end += delta;
+  if (isStrokeKind(annotation.kind)) {
+    for (QPointF &point : annotation.points)
+      point += delta;
+  }
+}
+
+/// A redaction's mosaic seed; zero is reserved for "not yet seeded".
+quint32 freshRedactionSeed() {
+  const quint32 seed = QRandomGenerator::system()->generate();
+  return seed == 0 ? 1 : seed;
+}
+
+/// Offset for a duplicated layer: down-left by default, flipped per axis
+/// when that would push the copy off the canvas and the other way fits.
+QPointF duplicateOffset(const QRectF &bounds, const QSizeF &canvas) {
+  constexpr qreal step = 100.0;
+  qreal dx = -step;
+  qreal dy = step;
+  if (bounds.left() + dx < 0 && bounds.right() - dx <= canvas.width())
+    dx = -dx;
+  if (bounds.bottom() + dy > canvas.height() && bounds.top() - dy >= 0)
+    dy = -dy;
+  return {dx, dy};
+}
+
 bool supportsCreationConstraint(CaptureEditor::Tool tool) {
   return tool == CaptureEditor::Tool::Arrow ||
          tool == CaptureEditor::Tool::Line ||
@@ -777,6 +806,26 @@ int CaptureEditor::hoveredSpotlightAt(const QPointF &position) const {
   if (index < 0 || annotations_.at(index).kind != Annotation::Kind::Spotlight)
     return -1;
   return index;
+}
+void CaptureEditor::duplicateSelectedAnnotation() {
+  if (dragging_ || textEditor_->isVisible() || selectedAnnotation_ < 0 ||
+      selectedAnnotation_ >= annotations_.size())
+    return;
+  recordEdit();
+  Annotation copy = annotations_.at(selectedAnnotation_);
+  translateAnnotation(
+      copy, duplicateOffset(annotationBounds(copy), selection_.size()));
+  if (copy.kind == Annotation::Kind::Marker)
+    copy.number = nextMarker_++;
+  if (copy.kind == Annotation::Kind::Redaction) {
+    // A copy must not share the original's mosaic; give it its own seed.
+    copy.redactionSeed = freshRedactionSeed();
+  }
+  annotations_.push_back(std::move(copy));
+  selectedAnnotation_ = annotations_.size() - 1;
+  selectedAnnotations_ = {selectedAnnotation_};
+  setStatus(QStringLiteral("Duplicated · Alt+D again offsets further"));
+  scheduleSnapshot();
 }
 
 void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
@@ -1907,6 +1956,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
     finish(OutputMode::Both);
     return;
+  } else if (event->key() == Qt::Key_D &&
+             heldModifiers(event->modifiers()) == Qt::AltModifier) {
+    duplicateSelectedAnnotation();
   } else if ((event->key() == Qt::Key_Delete ||
               event->key() == Qt::Key_Backspace) &&
              !selectedAnnotations_.isEmpty()) {
@@ -2159,14 +2211,7 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
         Annotation &annotation = annotations_[selectedAnnotation_];
         annotation = originalAnnotation_;
       if (interaction_ == Interaction::Move) {
-        const QPointF delta = point - dragStart_;
-        annotation.start += delta;
-        if (hasEndpointHandles(annotation.kind))
-          annotation.end += delta;
-        if (isStrokeKind(annotation.kind)) {
-          for (QPointF &strokePoint : annotation.points)
-            strokePoint += delta;
-        }
+        translateAnnotation(annotation, point - dragStart_);
       } else if (interaction_ == Interaction::ResizeStart) {
         if (hasEndpointHandles(annotation.kind)) {
           annotation.start =
@@ -2546,11 +2591,8 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
                                 heldModifiers(event->modifiers()).testFlag(Qt::ShiftModifier);
     creationCenteredActive_ = supportsCenteredCreation(tool_) &&
                               heldModifiers(event->modifiers()).testFlag(Qt::AltModifier);
-    if (tool_ == Tool::Redact) {
-      activeRedactionSeed_ = QRandomGenerator::system()->generate();
-      if (activeRedactionSeed_ == 0)
-        activeRedactionSeed_ = 1;
-    }
+    if (tool_ == Tool::Redact)
+      activeRedactionSeed_ = freshRedactionSeed();
     if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
       freehandPoints_.clear();
       freehandPoints_.reserve(256);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -193,6 +193,7 @@ private:
   void cancelActiveDragForHistory();
   void beginText(const QPointF &point, int annotationIndex = -1);
   void chooseWindow(int index);
+  void duplicateSelectedAnnotation();
   [[nodiscard]] EditState editState() const;
   void enterEdit(QString status);
   void scheduleSnapshot();

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1981,6 +1981,7 @@ bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
+/** Runs the interaction and rendering smoke checks. */
 /** Checks that a modifier left over from the launch binding is not believed.
  *  A binding with a modifier in it, such as the README's ALT + SHIFT + 4,
  *  leaves that modifier held as the overlay takes keyboard focus. Its release
@@ -3221,6 +3222,143 @@ bool runSelectAllDeleteSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Runs the interaction and rendering smoke checks. */
+bool runDuplicateLayerSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+
+  // 600x400 selection shown 1:1 at widget offset (100, 105).
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(700, 500));
+  application.processEvents();
+  const QRectF selection(100, 100, 600, 400);
+  const auto expected = [&](const QVector<Annotation> &annotations) {
+    return renderCapture(capture, selection, annotations,
+                         BackgroundStyle::None);
+  };
+  const auto snapshotMatches = [&](const QImage &image) {
+    return flushedSnapshot(editor, snapshotPath)
+                   .convertToFormat(image.format()) == image;
+  };
+  const auto rectangle = [](const QPointF &start, const QPointF &end) {
+    Annotation annotation;
+    annotation.kind = Annotation::Kind::Rectangle;
+    annotation.start = start;
+    annotation.end = end;
+    annotation.color = QColor(QStringLiteral("#ff375f"));
+    annotation.size = 4;
+    return annotation;
+  };
+  const auto marker = [](const QPointF &at, int number) {
+    Annotation annotation;
+    annotation.kind = Annotation::Kind::Marker;
+    annotation.start = at;
+    annotation.number = number;
+    annotation.color = QColor(QStringLiteral("#ff375f"));
+    annotation.size = 4;
+    return annotation;
+  };
+  const auto drag = [&](const QPoint &from, const QPoint &to) {
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, from);
+    QTest::mouseMove(&editor, to, 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, to);
+    application.processEvents();
+  };
+
+  // A rectangle hugging the left edge: the default down-left offset would
+  // leave the canvas, so the copy goes down-right instead.
+  QTest::keyClick(&editor, Qt::Key_R);
+  drag(QPoint(120, 200), QPoint(220, 260));
+  const Annotation left = rectangle({20, 95}, {120, 155});
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(170, 200));
+  QTest::keyClick(&editor, Qt::Key_D, Qt::AltModifier);
+  application.processEvents();
+  const Annotation leftCopy = rectangle({120, 195}, {220, 255});
+  if (!snapshotMatches(expected({left, leftCopy}))) {
+    error = QStringLiteral("Alt+D did not flip the offset away from the edge");
+    return false;
+  }
+
+  // Mid-canvas: down-left, and chained Alt+D keeps stepping from the copy.
+  QTest::keyClick(&editor, Qt::Key_R);
+  drag(QPoint(400, 250), QPoint(500, 300));
+  const Annotation middle = rectangle({300, 145}, {400, 195});
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(450, 250));
+  QTest::keyClick(&editor, Qt::Key_D, Qt::AltModifier);
+  QTest::keyClick(&editor, Qt::Key_D, Qt::AltModifier);
+  application.processEvents();
+  const Annotation middleCopy = rectangle({200, 245}, {300, 295});
+  const Annotation middleCopyCopy = rectangle({100, 345}, {200, 395});
+  if (!snapshotMatches(
+          expected({left, leftCopy, middle, middleCopy, middleCopyCopy}))) {
+    error = QStringLiteral("Chained Alt+D did not offset down-left twice");
+    return false;
+  }
+
+  // A duplicated marker takes the next number.
+  QTest::keyClick(&editor, Qt::Key_C);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(600, 200));
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(600, 200));
+  QTest::keyClick(&editor, Qt::Key_D, Qt::AltModifier);
+  application.processEvents();
+  const Annotation first = marker({500, 95}, 1);
+  const Annotation second = marker({400, 195}, 2);
+  const QVector<Annotation> withMarkers = {
+      left, leftCopy, middle, middleCopy, middleCopyCopy, first, second};
+  if (!snapshotMatches(expected(withMarkers))) {
+    error = QStringLiteral("Duplicated marker did not take the next number");
+    return false;
+  }
+
+  // Delete removes the selected copy; undo brings it back.
+  QTest::keyClick(&editor, Qt::Key_Delete);
+  application.processEvents();
+  if (!snapshotMatches(expected(
+          {left, leftCopy, middle, middleCopy, middleCopyCopy, first}))) {
+    error = QStringLiteral("Delete did not remove the selected copy");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(expected(withMarkers))) {
+    error = QStringLiteral("Undo did not restore the deleted layer");
+    return false;
+  }
+
+  // Plain D still arms the Redact tool.
+  QTest::keyClick(&editor, Qt::Key_D);
+  application.processEvents();
+  if (editor.cursor().shape() != Qt::CrossCursor) {
+    error = QStringLiteral("Plain D no longer arms the Redact tool");
+    return false;
+  }
+  if (!snapshotMatches(expected(withMarkers))) {
+    error = QStringLiteral("Plain D changed the layers");
+    return false;
+  }
+
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -3343,6 +3481,10 @@ int main(int argc, char **argv) {
   if (!runSelectAllDeleteSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 101;
+  }
+  if (!runDuplicateLayerSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 100;
   }
   if (!runSpotlightWheelSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -3295,6 +3295,10 @@ bool runDuplicateLayerSmoke(QApplication &application, QString &error) {
   }
 
   // Mid-canvas: down-left, and chained Alt+D keeps stepping from the copy.
+  // R with a rectangle selected toggles that layer's fill (#56), so drop the
+  // selection before arming the tool.
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(150, 450));
+  application.processEvents();
   QTest::keyClick(&editor, Qt::Key_R);
   drag(QPoint(400, 250), QPoint(500, 300));
   const Annotation middle = rectangle({300, 145}, {400, 195});


### PR DESCRIPTION
`Alt+D` copies the selected layer and offsets it by (-100, +100) px: far enough to read as "another one over here", close enough that a run of them stays on the canvas. If the default direction would push the copy off an edge and the opposite way has room, that axis flips.

The copy lands on top and takes the selection, so you can drag it where you want it immediately; undo removes it. A duplicated counter takes the next number, and a duplicated redaction gets a fresh mosaic seed, since two redactions with the same seed produce identical noise, which defeats the point of the mosaic.

The chord requires exactly Alt and sits ahead of the plain-`D` redact branch, so `D` still arms Redact.

`runDuplicateLayerSmoke` (exit 100) covers the edge-aware flip, chaining, counter renumbering, delete, undo, and `D` still arming Redact.
