### PR TITLE
feat(editor): Ctrl+A selects every layer so Delete clears the canvas

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -623,13 +623,34 @@ QRectF CaptureEditor::selectedAnnotationsBounds() const {
   for (const int index : selectedAnnotations_) {
     if (index < 0 || index >= annotations_.size())
       continue;
-    const QRectF annotation = annotationBounds(annotations_.at(index));
-    if (annotation.isEmpty())
+    QRectF annotation = annotationBounds(annotations_.at(index));
+    if (annotation.isNull())
       continue;
+    // A horizontal arrow or line has zero height, which isEmpty() reports as
+    // nothing at all; give it an extent so the group still covers it.
+    annotation = annotation.normalized();
+    if (annotation.width() <= 0.0)
+      annotation.setWidth(1.0);
+    if (annotation.height() <= 0.0)
+      annotation.setHeight(1.0);
     bounds = initialized ? bounds.united(annotation) : annotation;
     initialized = true;
   }
   return initialized ? bounds : QRectF();
+}
+
+void CaptureEditor::selectAllAnnotations() {
+  if (annotations_.isEmpty()) {
+    setStatus(QStringLiteral("No layers to select"));
+    return;
+  }
+  selectedAnnotations_.clear();
+  for (int index = 0; index < annotations_.size(); ++index)
+    selectedAnnotations_.push_back(index);
+  selectedAnnotation_ = annotations_.size() - 1;
+  tool_ = Tool::Select;
+  setStatus(QStringLiteral("All %1 layers selected · Delete removes them")
+                .arg(annotations_.size()));
 }
 
 bool CaptureEditor::annotationSelected(int index) const {
@@ -1900,9 +1921,13 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     }
     selectedAnnotations_.clear();
     selectedAnnotation_ = -1;
+    if (annotations_.isEmpty())
+      nextMarker_ = 1;
     scheduleSnapshot();
   } else if (event->key() == Qt::Key_V) {
     tool_ = Tool::Select;
+  } else if (event->matches(QKeySequence::SelectAll)) {
+    selectAllAnnotations();
   } else if (event->key() == Qt::Key_A) {
     tool_ = Tool::Arrow;
   } else if (event->key() == Qt::Key_L) {
@@ -3147,8 +3172,11 @@ void CaptureEditor::paintEdit(QPainter &painter) {
             .adjusted(-4, -4, 4, 4);
     if (multiple ||
         showsSelectionBounds(annotations_.at(selectedAnnotation_).kind)) {
-      painter.setPen(
-          QPen(QColor(255, 255, 255, 220), 1.0 / scale, Qt::DashLine));
+      // The union reads as the group's extent, so draw it faintly and outline
+      // each member on top: otherwise a select-all looks like one box with no
+      // way to tell what is in it, and a flat arrow shows nothing at all.
+      painter.setPen(QPen(QColor(255, 255, 255, multiple ? 110 : 220),
+                          1.0 / scale, Qt::DashLine));
       painter.setBrush(Qt::NoBrush);
       const qreal boxRadius =
           multiple ? 0.0
@@ -3158,6 +3186,23 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         painter.drawRoundedRect(bounds, boxRadius, boxRadius);
       else
         painter.drawRect(bounds);
+    }
+    if (multiple) {
+      painter.setPen(
+          QPen(QColor(255, 255, 255, 220), 1.0 / scale, Qt::DashLine));
+      painter.setBrush(Qt::NoBrush);
+      for (const int index : selectedAnnotations_) {
+        if (index < 0 || index >= annotations_.size() ||
+            index == editingAnnotation_)
+          continue;
+        QRectF member = annotationBounds(annotations_.at(index));
+        if (member.isNull())
+          continue;
+        member = member.normalized();
+        // Flat arrows and lines have no extent across; the inset gives every
+        // member a visible outline whatever its shape.
+        painter.drawRect(member.adjusted(-3, -3, 3, 3));
+      }
     }
     if (!multiple) {
       const Annotation &selected = annotations_.at(selectedAnnotation_);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -148,6 +148,7 @@ private:
 
   [[nodiscard]] QRectF annotationBounds(const Annotation &annotation) const;
   [[nodiscard]] QRectF selectedAnnotationsBounds() const;
+  void selectAllAnnotations();
   [[nodiscard]] bool annotationSelected(int index) const;
   /// What a pointer event reports, or nothing until a key event has confirmed
   /// it. A binding with a modifier in it, such as the README's ALT + SHIFT + 4,

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1980,6 +1980,7 @@ bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
+/** Runs the interaction and rendering smoke checks. */
 /** Checks that a modifier left over from the launch binding is not believed.
  *  A binding with a modifier in it, such as the README's ALT + SHIFT + 4,
  *  leaves that modifier held as the overlay takes keyboard focus. Its release
@@ -3085,6 +3086,141 @@ bool runTextPillSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Runs the interaction and rendering smoke checks. */
+bool runSelectAllDeleteSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(700, 500));
+  application.processEvents();
+  const QRectF selection(100, 100, 600, 400);
+  const auto expected = [&](const QVector<Annotation> &annotations) {
+    return renderCapture(capture, selection, annotations,
+                         BackgroundStyle::None);
+  };
+  const auto snapshotMatches = [&](const QImage &image) {
+    // Snapshots are written off the UI thread, so flush before reading.
+    return flushedSnapshot(editor, snapshotPath).convertToFormat(image.format()) ==
+           image;
+  };
+  const auto drag = [&](const QPoint &from, const QPoint &to) {
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, from);
+    QTest::mouseMove(&editor, to, 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, to);
+    application.processEvents();
+  };
+  const auto layer = [](Annotation::Kind kind, const QPointF &start,
+                        const QPointF &end, int number = 0) {
+    Annotation annotation;
+    annotation.kind = kind;
+    annotation.start = start;
+    annotation.end = end;
+    annotation.number = number;
+    annotation.color = QColor(QStringLiteral("#ff375f"));
+    annotation.size = 4;
+    return annotation;
+  };
+
+  // A rectangle, an arrow and two markers.
+  QTest::keyClick(&editor, Qt::Key_R);
+  drag(QPoint(200, 200), QPoint(400, 300));
+  QTest::keyClick(&editor, Qt::Key_A);
+  drag(QPoint(450, 200), QPoint(650, 300));
+  QTest::keyClick(&editor, Qt::Key_M);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(250, 400));
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(350, 400));
+  application.processEvents();
+  const QVector<Annotation> all = {
+      layer(Annotation::Kind::Rectangle, {100, 95}, {300, 195}),
+      layer(Annotation::Kind::Arrow, {350, 95}, {550, 195}),
+      layer(Annotation::Kind::Marker, {150, 295}, {}, 1),
+      layer(Annotation::Kind::Marker, {250, 295}, {}, 2)};
+  if (!snapshotMatches(expected(all))) {
+    error = QStringLiteral("Select-all smoke could not draw its four layers");
+    return false;
+  }
+
+  // Delete with nothing selected leaves everything alone.
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(680, 480));
+  QTest::keyClick(&editor, Qt::Key_Delete);
+  application.processEvents();
+  if (!snapshotMatches(expected(all))) {
+    error = QStringLiteral("Delete with nothing selected removed layers");
+    return false;
+  }
+
+  // Every member of a select-all is outlined, including a flat arrow whose
+  // bounds have no height: the group must look selected, not just delete.
+  QTest::keyClick(&editor, Qt::Key_A, Qt::ControlModifier);
+  application.processEvents();
+  const QImage grouped = editor.grab().toImage();
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(680, 480));
+  application.processEvents();
+  if (grouped == editor.grab().toImage()) {
+    error = QStringLiteral("Select-all drew no selection indicator");
+    return false;
+  }
+
+  // Clicking empty canvas drops the group selection again, so a following
+  // Delete is a no-op.
+  QTest::keyClick(&editor, Qt::Key_A, Qt::ControlModifier);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(680, 480));
+  QTest::keyClick(&editor, Qt::Key_Backspace);
+  application.processEvents();
+  if (!snapshotMatches(expected(all))) {
+    error = QStringLiteral("Delete after leaving select-all removed layers");
+    return false;
+  }
+
+  // Ctrl+A then Delete removes every layer as one undo step, even with a
+  // single layer selected beforehand.
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 200));
+  QTest::keyClick(&editor, Qt::Key_A, Qt::ControlModifier);
+  QTest::keyClick(&editor, Qt::Key_Delete);
+  application.processEvents();
+  if (!snapshotMatches(expected({}))) {
+    error = QStringLiteral("Ctrl+A then Delete did not remove every layer");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(expected(all))) {
+    error = QStringLiteral("Undo did not restore all deleted layers");
+    return false;
+  }
+
+  // After clearing, marker numbering restarts at 1.
+  QTest::keyClick(&editor, Qt::Key_A, Qt::ControlModifier);
+  QTest::keyClick(&editor, Qt::Key_Backspace);
+  QTest::keyClick(&editor, Qt::Key_M);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 300));
+  application.processEvents();
+  if (!snapshotMatches(
+          expected({layer(Annotation::Kind::Marker, {200, 195}, {}, 1)}))) {
+    error = QStringLiteral("Marker numbering did not restart after clearing");
+    return false;
+  }
+
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -3203,6 +3339,10 @@ int main(int argc, char **argv) {
   if (!runTextPillSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 103;
+  }
+  if (!runSelectAllDeleteSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 101;
   }
   if (!runSpotlightWheelSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
The Select phase already treats `Ctrl+A` as "select everything", so the edit phase does the same now, filling the multi-selection that's already there. `Delete` clears the canvas, group move and group bounds work as they do for a marquee, and clicking empty canvas drops the group. Clearing also restarts counter numbering, which the same undo puts back.

While I was in there: a group selection outlines each member now, not just the union, so you can see what's in the group rather than only its extent. The union survives as the group's extent, drawn fainter behind.

That turned out to fix flat arrows and lines too. Their bounds have zero height, so `isEmpty()` called them nothing and they were dropped from the extent and drew no outline, despite being selected and about to be deleted. Both changes apply to the marquee selection, which had the same blind spot.

`runSelectAllDeleteSmoke` (exit 101): `Delete` with nothing selected does nothing, a click drops the group, `Ctrl+A` draws a visible indicator, `Ctrl+A` then `Delete` clears four layers as one undo step, and numbering restarts at 1.
