### PR TITLE
feat(editor): show what the armed tool is set to, and let a spotlight go borderless

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -616,9 +616,13 @@ void paintSpotlights(QPainter &painter, const QImage &source,
     painter.drawImage(lens, source, sample);
     painter.restore();
 
+    // A zero border is a clean spotlight: the dimming alone isolates the
+    // region, with no ring drawn over the content at its edge.
+    if (annotation->size <= 0.0)
+      continue;
     const QColor outline =
         annotation->color.isValid() ? annotation->color : QColor(Qt::white);
-    painter.setPen(QPen(outline, std::max<qreal>(2.0, annotation->size / 2.0),
+    painter.setPen(QPen(outline, std::max<qreal>(1.0, annotation->size / 2.0),
                         Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
     painter.setBrush(Qt::NoBrush);
     painter.drawPath(lensClip);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -80,17 +80,34 @@ qreal toolbarScale(qreal availableWidth) {
 // A spotlight at 1x is not a failed zoom, it is a plain highlight: the dimming
 // still isolates the region. Name that state so it reads as somewhere to stop
 // rather than the bottom of a range.
-QString spotlightMagnificationStatus(qreal magnification) {
-  return magnification <= 1.0
-             ? QStringLiteral("Spotlight · no zoom · wheel magnifies")
-             : QStringLiteral("Spotlight · %1× · wheel adjusts")
-                   .arg(magnification, 0, 'f', 1);
+/// The whole state of a spotlight in one line. Adjusting one of the three
+/// settings still reports all three: they interact (a ring reads differently
+/// at 3× than at 1×), and the two you are not touching should not have to be
+/// remembered or re-discovered by pressing keys to find out.
+QString spotlightStatus(SpotlightShape shape, qreal magnification,
+                        qreal border) {
+  const QString shapeName = shape == SpotlightShape::Ellipse
+                                ? QStringLiteral("ellipse")
+                            : shape == SpotlightShape::Rectangle
+                                ? QStringLiteral("rectangle")
+                                : QStringLiteral("rounded");
+  const QString zoom =
+      magnification <= 1.0
+          ? QStringLiteral("no zoom")
+          : QStringLiteral("%1×").arg(magnification, 0, 'f', 1);
+  const QString ring = border <= 0.0
+                           ? QStringLiteral("no border")
+                           : QStringLiteral("border %1").arg(qRound(border));
+  return QStringLiteral("Spotlight · %1 · %2 · %3 · S cycles shape · wheel "
+                        "zooms · Alt+wheel border")
+      .arg(shapeName, zoom, ring);
 }
 
 } // namespace
 
-QString spotlightMagnificationStatusForTest(qreal magnification) {
-  return spotlightMagnificationStatus(magnification);
+QString spotlightStatusForTest(SpotlightShape shape, qreal magnification,
+                               qreal border) {
+  return spotlightStatus(shape, magnification, border);
 }
 
 namespace {
@@ -973,6 +990,71 @@ void CaptureEditor::applyBoxResize(Annotation &annotation, Interaction handle,
   annotation.end = box.bottomRight();
 }
 
+QString CaptureEditor::toolStatus() const {
+  const int size = qRound(annotationSize_);
+  switch (tool_) {
+  case Tool::Select:
+    return QStringLiteral("Select · drag moves layers · wheel zooms · outer "
+                          "handles crop");
+  case Tool::Spotlight: {
+    const QString shape =
+        spotlightShape_ == SpotlightShape::Ellipse ? QStringLiteral("ellipse")
+        : spotlightShape_ == SpotlightShape::Rectangle
+            ? QStringLiteral("rectangle")
+            : QStringLiteral("rounded");
+    const QString zoom =
+        spotlightMagnification_ <= 1.0
+            ? QStringLiteral("no zoom")
+            : QStringLiteral("%1×").arg(spotlightMagnification_, 0, 'f', 1);
+    const QString ring =
+        spotlightBorder_ <= 0.0
+            ? QStringLiteral("no border")
+            : QStringLiteral("border %1").arg(qRound(spotlightBorder_));
+    return QStringLiteral("Spotlight · %1 · %2 · %3 · S cycles shape · wheel "
+                          "zooms · Alt+wheel border")
+        .arg(shape, zoom, ring);
+  }
+  case Tool::Redact:
+    return QStringLiteral("Redact · %1 · D toggles style")
+        .arg(redactionStyleName(redactionStyle_).toLower());
+  case Tool::Text:
+    return QStringLiteral("Text · size %1 · click to type")
+        .arg(QString::fromLatin1(
+            kTextSizeNames.at(static_cast<std::size_t>(textSizeIndex_))));
+  case Tool::Marker:
+    return QStringLiteral("Marker · next %1 · size %2 · wheel resizes")
+        .arg(nextMarker_)
+        .arg(size);
+  case Tool::Ocr:
+    return QStringLiteral("Copy text · drag over the words to copy them");
+  case Tool::Eyedropper:
+    return QStringLiteral("Eyedropper · click to take a color from the "
+                          "capture");
+  case Tool::Rectangle:
+    return QStringLiteral("Rectangle · size %1 · wheel resizes · Shift keeps "
+                          "it square")
+        .arg(size);
+  case Tool::Ellipse:
+    return QStringLiteral("Ellipse · size %1 · wheel resizes · Shift keeps "
+                          "it circular")
+        .arg(size);
+  case Tool::Cut:
+    return QStringLiteral("Cut · drag a band to remove it");
+  case Tool::Arrow:
+  case Tool::Line:
+  case Tool::Freehand:
+  case Tool::Highlighter:
+    break;
+  }
+  const QString name = tool_ == Tool::Arrow      ? QStringLiteral("Arrow")
+                       : tool_ == Tool::Line     ? QStringLiteral("Line")
+                       : tool_ == Tool::Freehand ? QStringLiteral("Pen")
+                                                 : QStringLiteral("Highlighter");
+  return QStringLiteral("%1 · size %2 · wheel resizes · Shift constrains")
+      .arg(name)
+      .arg(size);
+}
+
 bool CaptureEditor::annotationContains(const Annotation &annotation,
                                        const QPointF &point,
                                        bool edgeOnly) const {
@@ -1162,7 +1244,8 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
   if (annotation.kind == Annotation::Kind::Spotlight) {
     annotation.magnification =
         std::clamp(annotation.magnification * factor, 1.0, 4.0);
-    setStatus(spotlightMagnificationStatus(annotation.magnification));
+    setStatus(spotlightStatus(annotation.spotlightShape,
+                              annotation.magnification, annotation.size));
     commitPatch({selectedAnnotation_});
     return;
   }
@@ -2331,6 +2414,8 @@ void CaptureEditor::finish(OutputMode mode) {
 }
 
 void CaptureEditor::handleToolbar(const QString &action) {
+  const Tool toolBefore = tool_;
+  const QString statusBefore = status_;
   if (action == QStringLiteral("tool-select"))
     tool_ = Tool::Select;
   else if (action == QStringLiteral("tool-arrow"))
@@ -2359,6 +2444,7 @@ void CaptureEditor::handleToolbar(const QString &action) {
                             : spotlightShape_ == SpotlightShape::Rectangle
                                   ? SpotlightShape::RoundedRectangle
                                   : SpotlightShape::Ellipse;
+      setStatus(toolStatus());
     } else {
       tool_ = Tool::Spotlight;
     }
@@ -2429,12 +2515,16 @@ void CaptureEditor::handleToolbar(const QString &action) {
     finish(OutputMode::Save);
   else if (action == QStringLiteral("close"))
     close();
+  if (tool_ != toolBefore && status_ == statusBefore)
+    setStatus(toolStatus());
   updatePointerCursor();
   update();
 }
 
 void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   modifiersSeen_ = true;
+  const Tool toolBefore = tool_;
+  const QString statusBefore = status_;
   if (capturePending_) {
     if (event->key() == Qt::Key_Escape)
       handleEscape();
@@ -2602,6 +2692,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
                             : spotlightShape_ == SpotlightShape::Rectangle
                                   ? SpotlightShape::RoundedRectangle
                                   : SpotlightShape::Ellipse;
+      setStatus(toolStatus());
     } else {
       tool_ = Tool::Spotlight;
     }
@@ -2670,6 +2761,11 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     QWidget::keyPressEvent(event);
     return;
   }
+  // Arming a tool says what it is set to, so its options are discoverable
+  // without pressing keys to find out. Handlers that report something more
+  // specific (a restyled layer, a toggled fill) have already set it.
+  if (tool_ != toolBefore && status_ == statusBefore)
+    setStatus(toolStatus());
   updatePointerCursor();
   update();
 }
@@ -3436,7 +3532,10 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     annotation.start = start;
     annotation.end = end;
     annotation.color = annotationColor();
-    annotation.size = annotationSize_;
+    // A spotlight's size is its ring width, which is its own setting: it can
+    // be zero, and it is not the stroke size the other tools share.
+    annotation.size =
+        tool_ == Tool::Spotlight ? spotlightBorder_ : annotationSize_;
     selectedAnnotation_ = -1;
     const bool redacted = tool_ == Tool::Redact;
     setStatus(redacted
@@ -3470,6 +3569,28 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
     setStatus(QStringLiteral("Neucha · size %1 · wheel changes size")
                   .arg(QString::fromLatin1(kTextSizeNames.at(
                       static_cast<std::size_t>(textSizeIndex_)))));
+  } else if (tool_ == Tool::Spotlight &&
+             event->modifiers().testFlag(Qt::AltModifier)) {
+    // Alt+wheel is the spotlight's secondary control: the ring around the
+    // opening, down to none for a clean spotlight. Independent of the zoom,
+    // so a plain highlight can keep a ring and a loupe can go without one.
+    const int hoveredRing = hoveredSpotlightAt(event->position());
+    const qreal nextBorder =
+        std::clamp((hoveredRing >= 0 ? annotations_.at(hoveredRing).size
+                                     : spotlightBorder_) +
+                       step * 2.0,
+                   0.0, 12.0);
+    if (hoveredRing >= 0) {
+      annotations_[hoveredRing].size = nextBorder;
+      commitPatch({hoveredRing});
+    }
+    spotlightBorder_ = nextBorder;
+    setStatus(hoveredRing >= 0
+                  ? spotlightStatus(annotations_.at(hoveredRing).spotlightShape,
+                                    annotations_.at(hoveredRing).magnification,
+                                    nextBorder)
+                  : spotlightStatus(spotlightShape_, spotlightMagnification_,
+                                    nextBorder));
   } else if (tool_ == Tool::Spotlight) {
     const qreal delta = step > 0 ? 0.25 : -0.25;
     const int hovered = hoveredSpotlightAt(event->position());
@@ -3478,12 +3599,14 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
       annotation.magnification =
           std::clamp(annotation.magnification + delta, 1.0, 4.0);
       spotlightMagnification_ = annotation.magnification;
-      setStatus(spotlightMagnificationStatus(annotation.magnification));
+      setStatus(spotlightStatus(annotation.spotlightShape,
+                                annotation.magnification, annotation.size));
       commitPatch({hovered});
     } else {
       spotlightMagnification_ =
           std::clamp(spotlightMagnification_ + delta, 1.0, 4.0);
-      setStatus(spotlightMagnificationStatus(spotlightMagnification_));
+      setStatus(spotlightStatus(spotlightShape_, spotlightMagnification_,
+                                spotlightBorder_));
     }
   } else if (tool_ == Tool::Rectangle &&
              event->modifiers().testFlag(Qt::AltModifier)) {
@@ -3807,7 +3930,9 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       preview.end = span.p2();
     }
     preview.color = tool_ == Tool::Ocr ? QColor(Qt::white) : annotationColor();
-    preview.size = tool_ == Tool::Ocr ? 2.0 : annotationSize_;
+    preview.size = tool_ == Tool::Ocr          ? 2.0
+                   : tool_ == Tool::Spotlight ? spotlightBorder_
+                                              : annotationSize_;
     defaultAnnotations.push_back(std::move(preview));
   } else if (tool_ == Tool::Marker && image.contains(cursor_) && !dragging_ &&
              !pointerGrabsLayer()) {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -77,6 +77,23 @@ qreal toolbarScale(qreal availableWidth) {
       1.0,
       std::max<qreal>(0.1, (availableWidth - sideMargins) / kToolbarWidth));
 }
+// A spotlight at 1x is not a failed zoom, it is a plain highlight: the dimming
+// still isolates the region. Name that state so it reads as somewhere to stop
+// rather than the bottom of a range.
+QString spotlightMagnificationStatus(qreal magnification) {
+  return magnification <= 1.0
+             ? QStringLiteral("Spotlight · no zoom · wheel magnifies")
+             : QStringLiteral("Spotlight · %1× · wheel adjusts")
+                   .arg(magnification, 0, 'f', 1);
+}
+
+} // namespace
+
+QString spotlightMagnificationStatusForTest(qreal magnification) {
+  return spotlightMagnificationStatus(magnification);
+}
+
+namespace {
 bool hasEndpointHandles(Annotation::Kind kind) {
   return kind == Annotation::Kind::Arrow || kind == Annotation::Kind::Line ||
          kind == Annotation::Kind::Rectangle ||
@@ -1145,8 +1162,7 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
   if (annotation.kind == Annotation::Kind::Spotlight) {
     annotation.magnification =
         std::clamp(annotation.magnification * factor, 1.0, 4.0);
-    setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
-                  .arg(annotation.magnification, 0, 'f', 1));
+    setStatus(spotlightMagnificationStatus(annotation.magnification));
     commitPatch({selectedAnnotation_});
     return;
   }
@@ -3462,14 +3478,12 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
       annotation.magnification =
           std::clamp(annotation.magnification + delta, 1.0, 4.0);
       spotlightMagnification_ = annotation.magnification;
-      setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
-                    .arg(annotation.magnification, 0, 'f', 1));
+      setStatus(spotlightMagnificationStatus(annotation.magnification));
       commitPatch({hovered});
     } else {
       spotlightMagnification_ =
           std::clamp(spotlightMagnification_ + delta, 1.0, 4.0);
-      setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
-                    .arg(spotlightMagnification_, 0, 'f', 1));
+      setStatus(spotlightMagnificationStatus(spotlightMagnification_));
     }
   } else if (tool_ == Tool::Rectangle &&
              event->modifiers().testFlag(Qt::AltModifier)) {

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -26,6 +26,8 @@ class InlineTextEdit;
 /// is the only thing large enough to see it change on. 0 for every other kind.
 [[nodiscard]] qreal selectionBoundsRadius(const Annotation &annotation,
                                           qreal inset);
+/// Status text for a spotlight's magnification; 1x reads as "no zoom".
+[[nodiscard]] QString spotlightMagnificationStatusForTest(qreal magnification);
 
 class CaptureEditor final : public QWidget {
   Q_OBJECT

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -27,7 +27,9 @@ class InlineTextEdit;
 [[nodiscard]] qreal selectionBoundsRadius(const Annotation &annotation,
                                           qreal inset);
 /// Status text for a spotlight's magnification; 1x reads as "no zoom".
-[[nodiscard]] QString spotlightMagnificationStatusForTest(qreal magnification);
+/// Status text for a spotlight: shape, zoom and ring, whichever one moved.
+[[nodiscard]] QString spotlightStatusForTest(SpotlightShape shape,
+                                             qreal magnification, qreal border);
 
 class CaptureEditor final : public QWidget {
   Q_OBJECT
@@ -209,8 +211,13 @@ public:
   [[nodiscard]] int selectedCountForTest() const {
     return static_cast<int>(selectedAnnotations_.size());
   }
+  /// Current status line. Test accessor.
+  [[nodiscard]] QString statusForTest() const { return status_; }
 
 private:
+  /// What the armed tool is currently set to, for the status line: shown on
+  /// arming so its options are discoverable without trying them.
+  [[nodiscard]] QString toolStatus() const;
   [[nodiscard]] int annotationAt(const QPointF &point) const;
   /// Whether the armed tool picks a layer up rather than working over it.
   /// Moves a layer to the top of the stack, remapping every index that
@@ -350,6 +357,8 @@ private:
   int textSizeIndex_ = 1;
   TextBackground textBackground_ = TextBackground::Pill;
   qreal spotlightMagnification_ = 2.0;
+  /// Ring drawn around a spotlight's opening; 0 draws none.
+  qreal spotlightBorder_ = 4.0;
   SpotlightShape spotlightShape_ = SpotlightShape::Ellipse;
   RedactionStyle redactionStyle_ = RedactionStyle::Pixelate;
   quint32 activeRedactionSeed_ = 0;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4445,15 +4445,93 @@ int main(int argc, char **argv) {
     return 117;
   }
   {
-    // 1x is a named state ("no zoom"), not the bottom of a magnification range.
-    if (spotlightMagnificationStatusForTest(1.0) !=
-            QStringLiteral("Spotlight · no zoom · wheel magnifies") ||
-        !spotlightMagnificationStatusForTest(2.0).contains(
-            QStringLiteral("2.0×"))) {
+    // 1x is a named state ("no zoom"), not the bottom of a magnification
+    // range, and the line names the whole spotlight, so the two settings you
+    // are not touching never have to be remembered.
+    const QString plain =
+        spotlightStatusForTest(SpotlightShape::Ellipse, 1.0, 4.0);
+    const QString magnified =
+        spotlightStatusForTest(SpotlightShape::Rectangle, 2.0, 0.0);
+    if (!plain.contains(QStringLiteral("no zoom")) ||
+        !plain.contains(QStringLiteral("ellipse")) ||
+        !plain.contains(QStringLiteral("border 4")) ||
+        !magnified.contains(QStringLiteral("2.0×")) ||
+        !magnified.contains(QStringLiteral("rectangle")) ||
+        !magnified.contains(QStringLiteral("no border"))) {
       qWarning().noquote()
           << QStringLiteral("Spotlight status did not name the no-zoom state");
       return 113;
     }
+  }
+  {
+    // Arming a tool says what it is set to; the spotlight names its shape,
+    // zoom and border, which is the whole point of showing it.
+    CaptureData capture;
+    capture.monitor.name = QStringLiteral("TEST");
+    capture.monitor.geometry = {0, 0, 800, 600};
+    capture.monitor.pixelSize = {800, 600};
+    capture.monitor.scale = 1.0;
+    capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+    capture.source.fill(QColor(QStringLiteral("#182030")));
+    capture.previewSize = capture.source.size();
+    CaptureEditor editor(capture, CaptureEditor::CaptureMode::Fullscreen);
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::keyClick(&editor, Qt::Key_S);
+    application.processEvents();
+    const QString armed = editor.statusForTest();
+    if (!armed.contains(QStringLiteral("Spotlight")) ||
+        !armed.contains(QStringLiteral("ellipse")) ||
+        !armed.contains(QStringLiteral("2.0×")) ||
+        !armed.contains(QStringLiteral("border"))) {
+      qWarning().noquote()
+          << QStringLiteral("Arming the spotlight did not report it: ") + armed;
+      return 115;
+    }
+    // Adjusting one setting still reports all three: the shape and the ring
+    // stay on screen while the wheel moves the zoom, and the zoom while
+    // Alt+wheel moves the ring.
+    {
+      const auto spotlightWheel = [&](Qt::KeyboardModifiers modifiers) {
+        QWheelEvent event(QPointF(400, 300), QPointF(400, 300), {}, {0, 120},
+                          Qt::NoButton, modifiers, Qt::NoScrollPhase, false);
+        QApplication::sendEvent(&editor, &event);
+        application.processEvents();
+      };
+      spotlightWheel(Qt::NoModifier);
+      if (editor.statusForTest() !=
+          spotlightStatusForTest(SpotlightShape::Ellipse, 2.25, 4.0)) {
+        qWarning().noquote()
+            << QStringLiteral("Wheel reported only the zoom: ") +
+                   editor.statusForTest();
+        return 115;
+      }
+      spotlightWheel(Qt::AltModifier);
+      if (editor.statusForTest() !=
+          spotlightStatusForTest(SpotlightShape::Ellipse, 2.25, 6.0)) {
+        qWarning().noquote()
+            << QStringLiteral("Alt+wheel reported only the ring: ") +
+                   editor.statusForTest();
+        return 115;
+      }
+    }
+    // S again cycles the shape and says so.
+    QTest::keyClick(&editor, Qt::Key_S);
+    application.processEvents();
+    if (!editor.statusForTest().contains(QStringLiteral("rectangle"))) {
+      qWarning().noquote() << QStringLiteral("Cycling the shape was silent: ") +
+                                  editor.statusForTest();
+      return 115;
+    }
+    QTest::keyClick(&editor, Qt::Key_A);
+    application.processEvents();
+    if (!editor.statusForTest().contains(QStringLiteral("Arrow"))) {
+      qWarning().noquote() << QStringLiteral("Arming the arrow was silent: ") +
+                                  editor.statusForTest();
+      return 115;
+    }
+    editor.close();
   }
   if (!runSpotlightWheelSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4444,6 +4444,17 @@ int main(int argc, char **argv) {
     qWarning().noquote() << snapshotError;
     return 117;
   }
+  {
+    // 1x is a named state ("no zoom"), not the bottom of a magnification range.
+    if (spotlightMagnificationStatusForTest(1.0) !=
+            QStringLiteral("Spotlight · no zoom · wheel magnifies") ||
+        !spotlightMagnificationStatusForTest(2.0).contains(
+            QStringLiteral("2.0×"))) {
+      qWarning().noquote()
+          << QStringLiteral("Spotlight status did not name the no-zoom state");
+      return 113;
+    }
+  }
   if (!runSpotlightWheelSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 94;


### PR DESCRIPTION
Two things, both about adjusting a spotlight without guessing.

Arming a tool now says what it's set to. The status line used to keep whatever it last said, so you could arm the spotlight with nothing on screen telling you its shape, zoom or border, which are exactly what you need to know before deciding to change any of them. Anything with something more specific to say still wins; the tool line only fills the gap.

A spotlight also gets a border of its own on Alt+wheel, the same secondary-control idiom the rectangle uses for corner rounding. Zero means no ring at all.

I kept the border independent of the magnification on purpose: coupling them puts two useful things out of reach, a ringed plain highlight and an unringed loupe, and quietly changes one setting while you adjust the other. Like the zoom, Alt+wheel adjusts the spotlight under the cursor if there is one, and the default for the next if there isn't. A spotlight's `size` becomes that ring width rather than the shared stroke size, so it can reach zero without dragging the other tools' thickness down with it.

Exit 115 covers arming naming shape, zoom and border, and `S` cycling the shape; exit 113 covers the no-zoom state being named rather than shown as `1.0x`.
