### PR TITLE
feat(editor): arrow-key nudge and Shift-constrained handle resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,9 @@ Install the corresponding Tesseract language data before adding a language to
 | `B` | Cycle backdrop |
 | `1`–`6` | Set annotation color |
 | Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size (`Alt`+wheel: rectangle corner radius) |
-| Hold `Shift` while dragging | Make rectangles, ellipses, and spotlights 1:1; snap lines and arrows to 45° |
+| Hold `Shift` while dragging | Make rectangles, ellipses, and spotlights 1:1; snap lines and arrows to 45°; while dragging a selected layer's handle, keep a rectangle, redaction or spotlight's aspect ratio (lines and arrows: 45°) |
 | Hold `Alt` while dragging | Center rectangles, ellipses, and spotlights on the press point; add `Shift` for a centered square/circle |
+| `←` `↑` `→` `↓` | Nudge the selected layer 1 px; hold `Shift` for 10 px (a held key is one undo step) |
 | Double-click text | Reopen text editing |
 | `Delete` | Delete selected layer |
 | `Alt+D` | Duplicate selected layer (offset down-left, or away from a nearby edge); the copy becomes the selection |

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -65,6 +65,11 @@ constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
 constexpr qreal kToolbarWidth = 880;
 constexpr qreal kMinimumRedactionExtent = 5.0;
 constexpr int kBackdropDim = 143;
+constexpr qreal kNudgeStep = 1.0;
+constexpr qreal kNudgeStepShift = 10.0;
+/// Arrow presses closer together than this share one undo entry, so a held
+/// key reads as one move.
+constexpr qint64 kNudgeCoalesceMs = 100;
 
 qreal toolbarScale(qreal availableWidth) {
   constexpr qreal sideMargins = 16.0;
@@ -121,6 +126,40 @@ QPointF duplicateOffset(const QRectF &bounds, const QSizeF &canvas) {
   if (bounds.bottom() + dy > canvas.height() && bounds.top() - dy >= 0)
     dy = -dy;
   return {dx, dy};
+}
+
+/// Endpoint that keeps the original |dx|:|dy| ratio around the fixed
+/// endpoint while a bounding-box shape is resized with Shift; the axis the
+/// user has scaled more wins and the other follows.
+QPointF aspectLockedEndpoint(const QPointF &fixed,
+                             const QPointF &originalMoving,
+                             const QPointF &candidate) {
+  const QPointF original = originalMoving - fixed;
+  if (qFuzzyIsNull(original.x()) || qFuzzyIsNull(original.y()))
+    return candidate;
+  const QPointF offset = candidate - fixed;
+  const qreal scale = std::max(std::abs(offset.x()) / std::abs(original.x()),
+                               std::abs(offset.y()) / std::abs(original.y()));
+  const qreal signX = offset.x() < 0 ? -1.0 : 1.0;
+  const qreal signY = offset.y() < 0 ? -1.0 : 1.0;
+  return fixed + QPointF(signX * scale * std::abs(original.x()),
+                         signY * scale * std::abs(original.y()));
+}
+
+/// Unit move for an arrow key; null for any other key.
+QPointF arrowKeyDelta(int key, qreal step) {
+  switch (key) {
+  case Qt::Key_Left:
+    return {-step, 0};
+  case Qt::Key_Right:
+    return {step, 0};
+  case Qt::Key_Up:
+    return {0, -step};
+  case Qt::Key_Down:
+    return {0, step};
+  default:
+    return {};
+  }
 }
 
 bool supportsCreationConstraint(CaptureEditor::Tool tool) {
@@ -441,6 +480,12 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     textCaretTimer_.start();
     update();
   });
+  // A run of nudges persists once, shortly after the last key, instead of
+  // re-rendering the snapshot on every auto-repeat.
+  nudgePersistTimer_.setSingleShot(true);
+  nudgePersistTimer_.setInterval(kNudgeCoalesceMs);
+  connect(&nudgePersistTimer_, &QTimer::timeout, this,
+          [this] { scheduleSnapshot(); });
   connect(
       textEditor_, &QLineEdit::textChanged, this, [this](const QString &text) {
         const QFontMetrics metrics(textEditor_->font());
@@ -918,6 +963,44 @@ void CaptureEditor::toggleTextBackground() {
                 .arg(textBackgroundName(textBackground_).toLower()));
 }
 
+QPointF CaptureEditor::constrainedResizeEndpoint(
+    const Annotation &annotation, const QPointF &candidate,
+    const QPointF &fixed, const QPointF &originalMoving) const {
+  QPointF point = candidate;
+  if (resizeConstraintActive_) {
+    if (annotation.kind == Annotation::Kind::Arrow ||
+        annotation.kind == Annotation::Kind::Line) {
+      point = constrainedCreationEndpoint(Tool::Line, fixed, candidate);
+    } else {
+      point = aspectLockedEndpoint(fixed, originalMoving, candidate);
+    }
+  }
+  if (annotation.kind == Annotation::Kind::Redaction)
+    return constrainedRedactionEndpoint(point, fixed, originalMoving);
+  return point;
+}
+
+void CaptureEditor::nudgeSelectedAnnotation(const QPointF &delta) {
+  if (selectedAnnotation_ < 0 || selectedAnnotation_ >= annotations_.size())
+    return;
+  // Presses in quick succession (a held key) share one undo entry and one
+  // deferred snapshot.
+  if (!nudgeTimer_.isValid() || nudgeTimer_.elapsed() > kNudgeCoalesceMs)
+    recordEdit();
+  nudgeTimer_.restart();
+  translateAnnotation(annotations_[selectedAnnotation_], delta);
+  setStatus(QStringLiteral("Nudged · arrows move 1 px · Shift 10 px"));
+  nudgePersistTimer_.start();
+}
+
+void CaptureEditor::endNudgeRun() {
+  nudgeTimer_.invalidate();
+  if (nudgePersistTimer_.isActive()) {
+    nudgePersistTimer_.stop();
+    scheduleSnapshot();
+  }
+}
+
 QRectF CaptureEditor::colorPaletteRect() const {
   const qreal scale = toolbarScale(width());
   const qreal toolbarWidth = kToolbarWidth * scale;
@@ -1334,6 +1417,7 @@ void CaptureEditor::cancelActiveDragForHistory() {
   dragging_ = false;
   creationConstraintActive_ = false;
   creationCenteredActive_ = false;
+  resizeConstraintActive_ = false;
   interaction_ = Interaction::None;
   dragStartStateValid_ = false;
   dragChanged_ = false;
@@ -1345,6 +1429,8 @@ void CaptureEditor::cancelActiveDragForHistory() {
 }
 
 void CaptureEditor::pushUndoState(const EditState &state) {
+  // Any other edit ends a run of coalesced nudges.
+  endNudgeRun();
   undoStack_.push_back(state);
   constexpr qsizetype maximumUndoStates = 100;
   while (undoStack_.size() > maximumUndoStates)
@@ -1355,6 +1441,7 @@ void CaptureEditor::pushUndoState(const EditState &state) {
 void CaptureEditor::recordEdit() { pushUndoState(editState()); }
 
 void CaptureEditor::undoEdit() {
+  endNudgeRun();
   cancelActiveDragForHistory();
   if (undoStack_.isEmpty()) {
     setStatus(QStringLiteral("Nothing to undo"));
@@ -1367,6 +1454,7 @@ void CaptureEditor::undoEdit() {
 }
 
 void CaptureEditor::redoEdit() {
+  endNudgeRun();
   cancelActiveDragForHistory();
   if (redoStack_.isEmpty()) {
     setStatus(QStringLiteral("Nothing to redo"));
@@ -1535,6 +1623,7 @@ void CaptureEditor::handleEscape() {
   dragChanged_ = false;
   creationConstraintActive_ = false;
   creationCenteredActive_ = false;
+  resizeConstraintActive_ = false;
   dragging_ = false;
   interaction_ = Interaction::None;
   colorPaletteOpen_ = false;
@@ -1866,12 +1955,21 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     event->accept();
     return;
   }
-  if (event->key() == Qt::Key_Shift && phase_ == Phase::Edit && dragging_ &&
-      supportsCreationConstraint(tool_)) {
-    creationConstraintActive_ = true;
-    event->accept();
-    update();
-    return;
+  if (event->key() == Qt::Key_Shift && phase_ == Phase::Edit && dragging_) {
+    // Shift pressed mid-drag constrains the drag: creation for drawing
+    // tools, handle resizing for the Select tool.
+    const bool resizing =
+        tool_ == Tool::Select && (interaction_ == Interaction::ResizeStart ||
+                                  interaction_ == Interaction::ResizeEnd);
+    if (resizing)
+      resizeConstraintActive_ = true;
+    else if (supportsCreationConstraint(tool_))
+      creationConstraintActive_ = true;
+    if (resizing || supportsCreationConstraint(tool_)) {
+      event->accept();
+      update();
+      return;
+    }
   }
   if (event->key() == Qt::Key_Alt && phase_ == Phase::Edit && dragging_ &&
       supportsCenteredCreation(tool_)) {
@@ -1959,6 +2057,19 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if (event->key() == Qt::Key_D &&
              event->modifiers() == Qt::AltModifier) {
     duplicateSelectedAnnotation();
+  } else if (const QPointF nudge = arrowKeyDelta(
+                 event->key(), heldModifiers(event->modifiers())
+                                       .testFlag(Qt::ShiftModifier)
+                                   ? kNudgeStepShift
+                                   : kNudgeStep);
+             !nudge.isNull() &&
+             !heldModifiers(event->modifiers())
+                  .testAnyFlags(Qt::ControlModifier | Qt::AltModifier |
+                                Qt::MetaModifier) &&
+             selectedAnnotation_ >= 0 &&
+             selectedAnnotation_ < annotations_.size() && !dragging_ &&
+             !textEditor_->isVisible()) {
+    nudgeSelectedAnnotation(nudge);
   } else if ((event->key() == Qt::Key_Delete ||
               event->key() == Qt::Key_Backspace) &&
              !selectedAnnotations_.isEmpty()) {
@@ -2095,8 +2206,10 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
 
 void CaptureEditor::keyReleaseEvent(QKeyEvent *event) {
   modifiersSeen_ = true;
-  if (event->key() == Qt::Key_Shift && creationConstraintActive_) {
+  if (event->key() == Qt::Key_Shift &&
+      (creationConstraintActive_ || resizeConstraintActive_)) {
     creationConstraintActive_ = false;
+    resizeConstraintActive_ = false;
     event->accept();
     update();
     return;
@@ -2214,19 +2327,13 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
         translateAnnotation(annotation, point - dragStart_);
       } else if (interaction_ == Interaction::ResizeStart) {
         if (hasEndpointHandles(annotation.kind)) {
-          annotation.start =
-              annotation.kind == Annotation::Kind::Redaction
-                  ? constrainedRedactionEndpoint(point, annotation.end,
-                                                 originalAnnotation_.start)
-                  : point;
+          annotation.start = constrainedResizeEndpoint(
+              annotation, point, annotation.end, originalAnnotation_.start);
         }
       } else if (interaction_ == Interaction::ResizeEnd) {
         if (hasEndpointHandles(annotation.kind)) {
-          annotation.end =
-              annotation.kind == Annotation::Kind::Redaction
-                  ? constrainedRedactionEndpoint(point, annotation.start,
-                                                 originalAnnotation_.end)
-                  : point;
+          annotation.end = constrainedResizeEndpoint(
+              annotation, point, annotation.start, originalAnnotation_.end);
         } else if (isStrokeKind(annotation.kind)) {
           const QRectF originalBounds = annotationBounds(originalAnnotation_);
           const qreal scaleX =
@@ -2380,6 +2487,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
   if (event->button() != Qt::LeftButton)
     return;
   cursor_ = event->position();
+  endNudgeRun();
   if (phase_ == Phase::Select) {
     if (windowMode_) {
       chooseWindow(windowAt(cursor_));
@@ -2545,6 +2653,9 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       dragChanged_ = false;
       dragStart_ = point;
       dragging_ = true;
+      resizeConstraintActive_ = (interaction_ == Interaction::ResizeStart ||
+                                 interaction_ == Interaction::ResizeEnd) &&
+                                event->modifiers().testFlag(Qt::ShiftModifier);
       setStatus(selectedAnnotations_.size() > 1
                     ? QStringLiteral("%1 layers selected · drag to move")
                           .arg(selectedAnnotations_.size())
@@ -2654,6 +2765,7 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     dragStartStateValid_ = false;
     dragChanged_ = false;
     dragging_ = false;
+    resizeConstraintActive_ = false;
     interaction_ = Interaction::None;
     if (cropped)
       setStatus(QStringLiteral(

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -186,6 +186,10 @@ private:
   [[nodiscard]] QVector<ToolbarButton> toolbarButtons() const;
   [[nodiscard]] QColor annotationColor() const;
   [[nodiscard]] QLineF creationSpan(const QPointF &rawEnd) const;
+  [[nodiscard]] QPointF
+  constrainedResizeEndpoint(const Annotation &annotation,
+                            const QPointF &candidate, const QPointF &fixed,
+                            const QPointF &originalMoving) const;
 
   void acceptText();
   void applyCustomColor(const QPointF &position);
@@ -216,6 +220,8 @@ private:
   void scaleSelectedAnnotation(qreal factor);
   void toggleShapeFill();
   void toggleTextBackground();
+  void nudgeSelectedAnnotation(const QPointF &delta);
+  void endNudgeRun();
   void undoEdit();
   void updatePointerCursor();
 
@@ -243,6 +249,7 @@ private:
   bool marqueeSelecting_ = false;
   bool marqueeAdditive_ = false;
   bool creationCenteredActive_ = false;
+  bool resizeConstraintActive_ = false;
   Interaction interaction_ = Interaction::None;
   QVector<QPointF> freehandPoints_;
   // Cut tool live-drag state. cutDragStart_/cutBandLo_/cutBandHi_ and
@@ -351,6 +358,8 @@ private:
   bool textEditPill_ = false;
   bool textCaretOn_ = true;
   QTimer textCaretTimer_;
+  QElapsedTimer nudgeTimer_;
+  QTimer nudgePersistTimer_;
   QColor textColor_;
   QFutureWatcher<OcrResult> ocrWatcher_;
 };

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1982,6 +1982,7 @@ bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
+/** Runs the interaction and rendering smoke checks. */
 /** Checks that a modifier left over from the launch binding is not believed.
  *  A binding with a modifier in it, such as the README's ALT + SHIFT + 4,
  *  leaves that modifier held as the overlay takes keyboard focus. Its release
@@ -3363,6 +3364,163 @@ bool runDuplicateLayerSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Runs the interaction and rendering smoke checks. */
+bool runKeyboardNudgeSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  // 600x400 selection shown 1:1 at widget offset (100, 105).
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(700, 500));
+  application.processEvents();
+  const QRectF selection(100, 100, 600, 400);
+  const auto rectangle = [](const QPointF &start, const QPointF &end) {
+    Annotation annotation;
+    annotation.kind = Annotation::Kind::Rectangle;
+    annotation.start = start;
+    annotation.end = end;
+    annotation.color = QColor(QStringLiteral("#ff375f"));
+    annotation.size = 4;
+    return annotation;
+  };
+  const auto snapshotMatches = [&](const Annotation &expected) {
+    const QImage image =
+        renderCapture(capture, selection, {expected}, BackgroundStyle::None);
+    return flushedSnapshot(editor, snapshotPath)
+                   .convertToFormat(image.format()) == image;
+  };
+  // A run of nudges writes its snapshot once, ~100 ms after the last key.
+  const auto settle = [&] {
+    QTest::qWait(150);
+    application.processEvents();
+  };
+
+  QTest::keyClick(&editor, Qt::Key_R);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 200));
+  QTest::mouseMove(&editor, QPoint(400, 300), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(400, 300));
+  application.processEvents();
+  const Annotation drawn = rectangle({100, 95}, {300, 195});
+  if (!snapshotMatches(drawn)) {
+    error = QStringLiteral("Nudge smoke: rectangle did not render");
+    return false;
+  }
+
+  // Arrow keys with nothing selected leave the layer alone.
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::keyClick(&editor, Qt::Key_Right);
+  application.processEvents();
+  if (!snapshotMatches(drawn)) {
+    error = QStringLiteral("Arrow key moved a layer that was not selected");
+    return false;
+  }
+
+  // Select the rectangle on its stroke, then nudge: quick presses coalesce
+  // into one undo entry.
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 200));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_Right);
+  QTest::keyClick(&editor, Qt::Key_Right);
+  QTest::keyClick(&editor, Qt::Key_Down);
+  QTest::keyClick(&editor, Qt::Key_Left, Qt::ShiftModifier);
+  settle();
+  if (!snapshotMatches(rectangle({92, 96}, {292, 196}))) {
+    error = QStringLiteral("Arrow nudges did not move the selected layer");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(drawn)) {
+    error = QStringLiteral("Quick nudges did not coalesce into one undo step");
+    return false;
+  }
+
+  // A pause between presses starts a new undo entry.
+  QTest::keyClick(&editor, Qt::Key_Down, Qt::ShiftModifier);
+  settle();
+  QTest::keyClick(&editor, Qt::Key_Down, Qt::ShiftModifier);
+  settle();
+  if (!snapshotMatches(rectangle({100, 115}, {300, 215}))) {
+    error = QStringLiteral("Shift nudges did not move by 10 px");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(rectangle({100, 105}, {300, 205}))) {
+    error = QStringLiteral("Separated nudges did not get separate undo steps");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(drawn)) {
+    error = QStringLiteral("Second undo did not restore the drawn rectangle");
+    return false;
+  }
+
+  // Arrow keys typed into the inline text editor edit text, not layers:
+  // with the rectangle still selected, open a text field and press Down.
+  QTest::keyClick(&editor, Qt::Key_T);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(500, 450));
+  application.processEvents();
+  QTest::keyClick(QApplication::focusWidget(), Qt::Key_Down);
+  QTest::keyClick(QApplication::focusWidget(), Qt::Key_Escape);
+  settle();
+  if (!snapshotMatches(drawn)) {
+    error = QStringLiteral("Arrow key inside the text editor nudged a layer");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 200));
+  application.processEvents();
+
+  // Shift while dragging the end handle keeps the original 2:1 aspect ratio;
+  // the axis scaled more (x: 200 -> 300) wins, so y follows to 150.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::ShiftModifier,
+                    QPoint(400, 300));
+  QTest::mouseMove(&editor, QPoint(500, 320), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::ShiftModifier,
+                      QPoint(500, 320));
+  application.processEvents();
+  if (!snapshotMatches(rectangle({100, 95}, {400, 245}))) {
+    error = QStringLiteral("Shift resize did not keep the aspect ratio");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(drawn)) {
+    error = QStringLiteral("Undo did not revert the constrained resize");
+    return false;
+  }
+  // Without Shift the same drag lands on the raw point.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(400, 300));
+  QTest::mouseMove(&editor, QPoint(500, 320), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(500, 320));
+  application.processEvents();
+  if (!snapshotMatches(rectangle({100, 95}, {400, 215}))) {
+    error = QStringLiteral("Plain resize was constrained without Shift");
+    return false;
+  }
+
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -3489,6 +3647,10 @@ int main(int argc, char **argv) {
   if (!runDuplicateLayerSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 100;
+  }
+  if (!runKeyboardNudgeSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 117;
   }
   if (!runSpotlightWheelSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
Two bits of keyboard precision.

Arrow keys nudge the selected layer 1 px, or 10 px with Shift, through the same translation a mouse move uses so the two can't drift apart. Presses closer than 100 ms share an undo entry, so holding a key reads as one move rather than forty, and the snapshot is written once after the last press instead of on every auto-repeat. Arrows with Ctrl/Alt/Meta, with nothing selected, during a drag, or inside the text editor keep doing what they did.

Shift also constrains a handle resize: rectangles, redactions and spotlights hold their aspect ratio around the fixed endpoint, and lines and arrows snap to 45°. That's what Shift already does while drawing them, so it means the same thing whether you're creating a shape or fixing one.

`runKeyboardNudgeSmoke` (exit 99) covers the coalescing window and the gap that ends it, the text-editor exception, and a 2:1-constrained resize checked against the same drag without Shift.
