### PR TITLE
feat(editor): eight handles on a box, four on a counter, two on a line

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -85,6 +85,18 @@ bool hasEndpointHandles(Annotation::Kind kind) {
          kind == Annotation::Kind::Spotlight;
 }
 
+/// Any handle drag on a layer (as opposed to a move, or a capture crop).
+bool isLayerResize(CaptureEditor::Interaction interaction) {
+  return interaction >= CaptureEditor::Interaction::ResizeStart &&
+         interaction <= CaptureEditor::Interaction::ResizeLeft;
+}
+
+/// The eight handles that reshape a box, as opposed to the two ends of a line.
+bool isBoxResize(CaptureEditor::Interaction interaction) {
+  return interaction >= CaptureEditor::Interaction::ResizeTopLeft &&
+         interaction <= CaptureEditor::Interaction::ResizeLeft;
+}
+
 bool showsSelectionBounds(Annotation::Kind kind) {
   return kind != Annotation::Kind::Arrow && kind != Annotation::Kind::Line;
 }
@@ -731,27 +743,202 @@ bool CaptureEditor::annotationSelected(int index) const {
   return selectedAnnotations_.contains(index);
 }
 
+QVector<QPair<QPointF, CaptureEditor::Interaction>>
+CaptureEditor::annotationHandles(const Annotation &annotation) const {
+  // A line or an arrow is two points, so it has two handles and no box.
+  if (annotation.kind == Annotation::Kind::Arrow ||
+      annotation.kind == Annotation::Kind::Line) {
+    return {{annotation.start, Interaction::ResizeStart},
+            {annotation.end, Interaction::ResizeEnd}};
+  }
+  const QRectF bounds = annotationBounds(annotation);
+  // A text's handle is its wrap width, not its size: one handle, on the edge
+  // the wrapping actually moves.
+  if (annotation.kind == Annotation::Kind::Text)
+    return {{bounds.bottomRight(), Interaction::ResizeEnd}};
+  // A counter is a disc: any corner sets its size, and sides would say
+  // something about width and height that a disc cannot honour.
+  if (annotation.kind == Annotation::Kind::Marker) {
+    return {{bounds.topLeft(), Interaction::ResizeTopLeft},
+            {bounds.topRight(), Interaction::ResizeTopRight},
+            {bounds.bottomRight(), Interaction::ResizeBottomRight},
+            {bounds.bottomLeft(), Interaction::ResizeBottomLeft}};
+  }
+  QVector<QPair<QPointF, Interaction>> handles{
+      {bounds.topLeft(), Interaction::ResizeTopLeft},
+      {bounds.topRight(), Interaction::ResizeTopRight},
+      {bounds.bottomRight(), Interaction::ResizeBottomRight},
+      {bounds.bottomLeft(), Interaction::ResizeBottomLeft}};
+  // Side handles only where there is room for them: on a layer barely wider
+  // than the handles themselves they would be a blob of overlapping dots.
+  const qreal room = 34.0 / std::max<qreal>(editScale(), 0.01);
+  if (bounds.width() >= room) {
+    handles.push_back({QPointF(bounds.center().x(), bounds.top()),
+                       Interaction::ResizeTop});
+    handles.push_back({QPointF(bounds.center().x(), bounds.bottom()),
+                       Interaction::ResizeBottom});
+  }
+  if (bounds.height() >= room) {
+    handles.push_back({QPointF(bounds.right(), bounds.center().y()),
+                       Interaction::ResizeRight});
+    handles.push_back({QPointF(bounds.left(), bounds.center().y()),
+                       Interaction::ResizeLeft});
+  }
+  return handles;
+}
+
 CaptureEditor::Interaction
 CaptureEditor::selectedHandleAt(const QPointF &point) const {
-  // A layer's handles can sit well outside the layer itself. A spotlight is
-  // hit-tested against its opening, and the corners of its bounds are out in
-  // the dimmed surround, so a press has to ask about handles before it asks
-  // what shape is under the pointer. Otherwise the handle misses, the press
-  // reads as empty canvas, and dragging a spotlight's corner starts a marquee
-  // instead of resizing it.
+  // The single answer to "is this press a resize?", shared by every tool. A
+  // handle can sit well outside the layer it belongs to, a spotlight's corner
+  // being out in the dimmed surround, so hit-testing the shape alone would
+  // miss it and start a marquee or a new drawing instead.
   if (selectedAnnotation_ < 0 || selectedAnnotation_ >= annotations_.size())
     return Interaction::None;
-  const Annotation &selected = annotations_.at(selectedAnnotation_);
   const qreal tolerance = 9.0 / std::max<qreal>(editScale(), 0.01);
-  const QRectF bounds = annotationBounds(selected);
-  const bool endpoints = hasEndpointHandles(selected.kind);
-  const QPointF first = endpoints ? selected.start : bounds.topLeft();
-  const QPointF last = endpoints ? selected.end : bounds.bottomRight();
-  if (endpoints && QLineF(point, first).length() <= tolerance)
-    return Interaction::ResizeStart;
-  if (QLineF(point, last).length() <= tolerance)
-    return Interaction::ResizeEnd;
-  return Interaction::None;
+  Interaction nearest = Interaction::None;
+  qreal nearestDistance = tolerance;
+  for (const auto &[position, handle] :
+       annotationHandles(annotations_.at(selectedAnnotation_))) {
+    const qreal distance = QLineF(point, position).length();
+    if (distance <= nearestDistance) {
+      nearestDistance = distance;
+      nearest = handle;
+    }
+  }
+  return nearest;
+}
+
+CaptureEditor::Interaction CaptureEditor::pointerHandle() const {
+  if (!editImageRect().contains(cursor_))
+    return Interaction::None;
+  return selectedHandleAt(toAnnotationPoint(cursor_));
+}
+
+Qt::CursorShape CaptureEditor::handleCursorShape(Interaction handle) const {
+  // Never the move cursor: the handle resizes, the body moves, and the pointer
+  // should say which one, and which way, before the press.
+  switch (handle) {
+  case Interaction::ResizeStart:
+  case Interaction::ResizeEnd:
+    if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+        annotations_.at(selectedAnnotation_).kind == Annotation::Kind::Text)
+      return Qt::SizeHorCursor;
+    return Qt::PointingHandCursor;
+  case Interaction::ResizeTopLeft:
+  case Interaction::ResizeBottomRight:
+    return Qt::SizeFDiagCursor;
+  case Interaction::ResizeTopRight:
+  case Interaction::ResizeBottomLeft:
+    return Qt::SizeBDiagCursor;
+  case Interaction::ResizeTop:
+  case Interaction::ResizeBottom:
+    return Qt::SizeVerCursor;
+  case Interaction::ResizeLeft:
+  case Interaction::ResizeRight:
+    return Qt::SizeHorCursor;
+  default:
+    return Qt::ArrowCursor;
+  }
+}
+
+void CaptureEditor::applyBoxResize(Annotation &annotation, Interaction handle,
+                                   const QPointF &point,
+                                   const QRectF &original) {
+  if (annotation.kind == Annotation::Kind::Marker) {
+    annotation.size =
+        std::clamp(QLineF(annotation.start, point).length() / 3.0, 2.0, 30.0);
+    return;
+  }
+  const bool movesLeft = handle == Interaction::ResizeTopLeft ||
+                         handle == Interaction::ResizeLeft ||
+                         handle == Interaction::ResizeBottomLeft;
+  const bool movesRight = handle == Interaction::ResizeTopRight ||
+                          handle == Interaction::ResizeRight ||
+                          handle == Interaction::ResizeBottomRight;
+  const bool movesTop = handle == Interaction::ResizeTopLeft ||
+                        handle == Interaction::ResizeTop ||
+                        handle == Interaction::ResizeTopRight;
+  const bool movesBottom = handle == Interaction::ResizeBottomLeft ||
+                           handle == Interaction::ResizeBottom ||
+                           handle == Interaction::ResizeBottomRight;
+  QPointF target = point;
+  if (resizeConstraintActive_ && (movesLeft || movesRight) &&
+      (movesTop || movesBottom)) {
+    // Shift keeps the proportions, measured against the corner that stays.
+    const QPointF fixed(movesLeft ? original.right() : original.left(),
+                        movesTop ? original.bottom() : original.top());
+    const QPointF moving(movesLeft ? original.left() : original.right(),
+                         movesTop ? original.top() : original.bottom());
+    target = aspectLockedEndpoint(fixed, moving, point);
+  }
+  // An edge dragged past its opposite turns the layer inside out and keeps
+  // following the pointer, the way every drawing tool behaves. Pulling the
+  // right edge left across the shape gives a shape on the left, not a sliver
+  // pinned at the crossing point.
+  QRectF box = original;
+  if (movesLeft)
+    box.setLeft(target.x());
+  if (movesRight)
+    box.setRight(target.x());
+  if (movesTop)
+    box.setTop(target.y());
+  if (movesBottom)
+    box.setBottom(target.y());
+  box = box.normalized();
+  // A redaction still has a floor: it covers something, so it may not be
+  // reduced to a line. The edge nearer where it started is the one that holds.
+  const qreal minimum = annotation.kind == Annotation::Kind::Redaction
+                            ? kMinimumRedactionExtent
+                            : 0.0;
+  if (minimum > 0.0) {
+    const qreal fixedX = movesLeft ? original.right() : original.left();
+    const qreal fixedY = movesTop ? original.bottom() : original.top();
+    if (box.width() < minimum) {
+      if (std::abs(box.left() - fixedX) <= std::abs(box.right() - fixedX))
+        box.setRight(box.left() + minimum);
+      else
+        box.setLeft(box.right() - minimum);
+    }
+    if (box.height() < minimum) {
+      if (std::abs(box.top() - fixedY) <= std::abs(box.bottom() - fixedY))
+        box.setBottom(box.top() + minimum);
+      else
+        box.setTop(box.bottom() - minimum);
+    }
+  }
+
+  if (isStrokeKind(annotation.kind)) {
+    // Mirrored when the drag crossed over: the stroke flips with the box
+    // rather than piling up against the edge it crossed.
+    const bool flippedX = movesLeft ? target.x() > original.right()
+                          : movesRight ? target.x() < original.left()
+                                       : false;
+    const bool flippedY = movesTop ? target.y() > original.bottom()
+                          : movesBottom ? target.y() < original.top()
+                                        : false;
+    const qreal scaleX =
+        (original.width() > 0 ? box.width() / original.width() : 1.0) *
+        (flippedX ? -1.0 : 1.0);
+    const qreal scaleY =
+        (original.height() > 0 ? box.height() / original.height() : 1.0) *
+        (flippedY ? -1.0 : 1.0);
+    for (int index = 0; index < annotation.points.size(); ++index) {
+      const QPointF relative =
+          originalAnnotation_.points.at(index) - original.topLeft();
+      const QPointF anchor(scaleX < 0 ? box.right() : box.left(),
+                           scaleY < 0 ? box.bottom() : box.top());
+      annotation.points[index] =
+          anchor + QPointF(relative.x() * scaleX, relative.y() * scaleY);
+    }
+    if (!annotation.points.isEmpty()) {
+      annotation.start = annotation.points.first();
+      annotation.end = annotation.points.last();
+    }
+    return;
+  }
+  annotation.start = box.topLeft();
+  annotation.end = box.bottomRight();
 }
 
 int CaptureEditor::annotationAt(const QPointF &point) const {
@@ -1959,8 +2146,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     // Shift pressed mid-drag constrains the drag: creation for drawing
     // tools, handle resizing for the Select tool.
     const bool resizing =
-        tool_ == Tool::Select && (interaction_ == Interaction::ResizeStart ||
-                                  interaction_ == Interaction::ResizeEnd);
+        isLayerResize(interaction_);
     if (resizing)
       resizeConstraintActive_ = true;
     else if (supportsCreationConstraint(tool_))
@@ -2323,8 +2509,11 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
       } else {
         Annotation &annotation = annotations_[selectedAnnotation_];
         annotation = originalAnnotation_;
+      const QRectF originalBox = annotationBounds(originalAnnotation_);
       if (interaction_ == Interaction::Move) {
         translateAnnotation(annotation, point - dragStart_);
+      } else if (isBoxResize(interaction_)) {
+        applyBoxResize(annotation, interaction_, point, originalBox);
       } else if (interaction_ == Interaction::ResizeStart) {
         if (hasEndpointHandles(annotation.kind)) {
           annotation.start = constrainedResizeEndpoint(
@@ -2592,7 +2781,8 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     const bool additive =
         heldModifiers(event->modifiers()).testFlag(Qt::ControlModifier) ||
         heldModifiers(event->modifiers()).testFlag(Qt::MetaModifier);
-    // A handle of the layer already selected is a resize wherever it sits.
+    // A handle of the layer already selected is a resize wherever it sits:
+    // a box's corner can lie well outside the shape it belongs to.
     const Interaction handle = selectedHandleAt(point);
     const int hit =
         handle != Interaction::None ? selectedAnnotation_ : annotationAt(point);
@@ -2653,8 +2843,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       dragChanged_ = false;
       dragStart_ = point;
       dragging_ = true;
-      resizeConstraintActive_ = (interaction_ == Interaction::ResizeStart ||
-                                 interaction_ == Interaction::ResizeEnd) &&
+      resizeConstraintActive_ = isLayerResize(interaction_) &&
                                 event->modifiers().testFlag(Qt::ShiftModifier);
       setStatus(selectedAnnotations_.size() > 1
                     ? QStringLiteral("%1 layers selected · drag to move")
@@ -3003,6 +3192,11 @@ void CaptureEditor::updatePointerCursor() {
       setCursor(Qt::PointingHandCursor);
       return;
     }
+  }
+  const bool resizing = dragging_ && isLayerResize(interaction_);
+  if (resizing || (!dragging_ && pointerHandle() != Interaction::None)) {
+    setCursor(handleCursorShape(resizing ? interaction_ : pointerHandle()));
+    return;
   }
   if (tool_ == Tool::Select) {
     int cropHandle = cropHandleAt(cursor_);
@@ -3363,11 +3557,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       const qreal radius = 5.0 / scale;
       painter.setPen(QPen(Qt::white, 1.0 / scale));
       painter.setBrush(QColor(QStringLiteral("#0a84ff")));
-      if (hasEndpointHandles(selected.kind))
-        painter.drawEllipse(selected.start, radius, radius);
-      const QPointF last =
-          hasEndpointHandles(selected.kind) ? selected.end : bounds.bottomRight();
-      painter.drawEllipse(last, radius, radius);
+      for (const auto &[position, handle] : annotationHandles(selected))
+        painter.drawEllipse(position, radius, radius);
     }
   }
   painter.restore();

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -108,11 +108,23 @@ public:
 private:
   enum class Phase { Select, Edit };
   enum class OutputMode { Copy, Save, Both };
+public:
   enum class Interaction {
     None,
     Move,
+    /// The two ends of a line or arrow, and the single handle on the kinds
+    /// that have only one (a text's wrap width).
     ResizeStart,
     ResizeEnd,
+    /// A box's eight handles, in the same clockwise order as the crop ones.
+    ResizeTopLeft,
+    ResizeTop,
+    ResizeTopRight,
+    ResizeRight,
+    ResizeBottomRight,
+    ResizeBottom,
+    ResizeBottomLeft,
+    ResizeLeft,
     CropTopLeft,
     CropTop,
     CropTopRight,
@@ -122,6 +134,8 @@ private:
     CropBottomLeft,
     CropLeft
   };
+
+private:
 
   struct ToolbarButton {
     QRectF rect;
@@ -159,10 +173,21 @@ private:
   heldModifiers(Qt::KeyboardModifiers reported) const {
     return modifiersSeen_ ? reported : Qt::KeyboardModifiers(Qt::NoModifier);
   }
+  /// Every handle a layer offers, with what dragging it does: two ends for a
+  /// line or arrow, four corners for a counter, eight for anything with a box
+  /// (the four sides stretch one axis), one for a text's wrap width.
+  [[nodiscard]] QVector<QPair<QPointF, Interaction>>
+  annotationHandles(const Annotation &annotation) const;
   /// Which handle of the selected layer is under `point`, if any. Asked
   /// before what shape is under the pointer, since a handle can sit outside
   /// the layer it belongs to.
   [[nodiscard]] Interaction selectedHandleAt(const QPointF &point) const;
+  [[nodiscard]] Interaction pointerHandle() const;
+  [[nodiscard]] Qt::CursorShape handleCursorShape(Interaction handle) const;
+  /// Moves the edges a box handle owns, keeping the opposite ones put; Shift
+  /// on a corner keeps the proportions.
+  void applyBoxResize(Annotation &annotation, Interaction handle,
+                      const QPointF &point, const QRectF &original);
   [[nodiscard]] int annotationAt(const QPointF &point) const;
   [[nodiscard]] int hoveredSpotlightAt(const QPointF &position) const;
   [[nodiscard]] QRectF normalizedSelection(const QPointF &first,

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2200,8 +2200,9 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
     return false;
   }
   QTest::keyClick(&editor, Qt::Key_V);
-  // Press the top edge, clear of the corner handles, so this is a move.
-  drag(QPoint(575, 300), QPoint(675, 300));
+  // Press the top edge, clear of the corner and mid-side handles (eight on
+  // a box), so this is a move.
+  drag(QPoint(540, 300), QPoint(640, 300));
   Annotation shifted = rectangle;
   shifted.start.rx() += 100;
   shifted.end.rx() += 100;
@@ -2227,9 +2228,9 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
     return false;
   }
 
-  // Its right edge is outside the canvas too (widget x 750); grabbing the
-  // layer there drags it back in.
-  drag(QPoint(750, 375), QPoint(650, 375));
+  // Its right edge is outside the canvas too (widget x 750); grab off the
+  // mid-side handle so this is a move, not a one-axis resize.
+  drag(QPoint(750, 340), QPoint(650, 340));
   if (!snapshotMatches(expected({rectangle}))) {
     error = QStringLiteral(
         "Grabbing a selected layer outside the canvas did not move it");

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2465,7 +2465,7 @@ bool runEllipseToolSmoke(QApplication &application, QString &error) {
       return false;
     }
   }
-  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 200));
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(250, 200));
   QTest::keyClick(&editor, Qt::Key_Delete);
   application.processEvents();
   if (!snapshotMatches(expected({circle}))) {
@@ -2480,10 +2480,11 @@ bool runEllipseToolSmoke(QApplication &application, QString &error) {
   }
 
   // Selected ellipse moves with its whole (hollow) body like other layers.
-  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 200));
-  QTest::mouseMove(&editor, QPoint(320, 230), 20);
+  // Off the mid-side handle (300,200) so this is a move, not a resize.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(250, 200));
+  QTest::mouseMove(&editor, QPoint(270, 230), 20);
   QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
-                      QPoint(320, 230));
+                      QPoint(270, 230));
   application.processEvents();
   if (!snapshotMatches(
           expected({ellipseAnnotation({120, 125}, {320, 225}), circle}))) {

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2740,6 +2740,10 @@ bool runShapeFillToolSmoke(QApplication &application, QString &error) {
     error = QStringLiteral("R did not fill the selected rectangle");
     return false;
   }
+  // Off any handle: with eight box handles the press point may be a resize
+  // cursor even though the tool is still Select.
+  QTest::mouseMove(&editor, QPoint(160, 480));
+  application.processEvents();
   if (editor.cursor().shape() != Qt::ArrowCursor) {
     error = QStringLiteral("Toggling a selected rectangle switched tools");
     return false;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -3521,6 +3521,95 @@ bool runKeyboardNudgeSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Checks the handle set: a box offers eight, a counter four, a line two.
+ *  Side handles stretch one axis, corners take Shift for the proportions, and
+ *  a box dragged through itself comes out the other side. */
+bool runLayerHandlesSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  // 600x400 selection shown 1:1 at widget offset (100, 105).
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(700, 500));
+  application.processEvents();
+  const auto drag = [&](const QPoint &from, const QPoint &to,
+                        Qt::KeyboardModifiers modifiers = Qt::NoModifier) {
+    QTest::mousePress(&editor, Qt::LeftButton, modifiers, from);
+    QTest::mouseMove(&editor, to, 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, modifiers, to);
+    application.processEvents();
+  };
+  const auto inkBounds = [](const QImage &image) {
+    QRect bounds;
+    for (int y = 0; y < image.height(); ++y) {
+      for (int x = 0; x < image.width(); ++x) {
+        if (image.pixelColor(x, y) != QColor(QStringLiteral("#182030")))
+          bounds = bounds.isNull() ? QRect(x, y, 1, 1)
+                                   : bounds.united(QRect(x, y, 1, 1));
+      }
+    }
+    return bounds;
+  };
+
+  // A rectangle at annotation (100,95)-(300,195).
+  QTest::keyClick(&editor, Qt::Key_R);
+  drag(QPoint(200, 200), QPoint(400, 300));
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 250));
+  application.processEvents();
+
+  // Its right edge midpoint is at widget (400,250): a side handle stretches
+  // that axis and leaves the other alone, however far the pointer wanders.
+  QTest::mouseMove(&editor, QPoint(400, 250), 10);
+  application.processEvents();
+  if (editor.cursor().shape() != Qt::SizeHorCursor) {
+    error = QStringLiteral("A box offered no handle on its right edge");
+    return false;
+  }
+  drag(QPoint(400, 250), QPoint(460, 320));
+  {
+    const QRect after = inkBounds(flushedSnapshot(editor, snapshotPath));
+    if (std::abs(after.right() - 360) > 4) {
+      error = QStringLiteral("The right handle did not move that edge");
+      return false;
+    }
+    if (std::abs(after.top() - 95) > 4 || std::abs(after.bottom() - 195) > 4) {
+      error = QStringLiteral("A side handle changed the other axis too");
+      return false;
+    }
+  }
+
+  // Dragged through itself, the box comes out the other side rather than
+  // collapsing against the edge it crossed.
+  drag(QPoint(460, 250), QPoint(150, 250));
+  {
+    const QRect flipped = inkBounds(flushedSnapshot(editor, snapshotPath));
+    if (flipped.width() < 20) {
+      error = QStringLiteral("Dragging an edge through the shape collapsed it");
+      return false;
+    }
+    if (std::abs(flipped.right() - 100) > 6) {
+      error = QStringLiteral("The crossed edge did not become the far side");
+      return false;
+    }
+  }
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -3579,6 +3668,10 @@ int main(int argc, char **argv) {
   if (!runEyedropperSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 107;
+  }
+  if (!runLayerHandlesSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 120;
   }
   if (!runAsyncCaptureRegionSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
> Stacked on #63, which it needs for the Shift-constraint machinery. The diff below has that commit in it; only the second one is this PR. I'll rebase once it lands.

A layer had two handles, at whichever corners it was drawn from, so fixing a rectangle that came out too wide meant finding the one corner that could do it, or moving the whole thing and having another go.

The handle set matches the shape now: anything with a box gets four corners and four side handles (sides stretch one axis, corners take Shift for the proportions), a counter gets four corners that size it from the middle since sides would claim a disc has a separate width and height, a line or arrow keeps its two ends, and a text keeps one for its wrap width.

Cursors name the direction each handle takes, so you can tell what a drag will do before starting it. And a box dragged through itself comes out the other side instead of collapsing against the edge it crossed: the edges move freely and the rectangle is normalized afterwards, rather than clamped at zero.

`runLayerHandlesSmoke` (exit 120) covers the handle count per kind, a side handle stretching one axis only, Shift on a corner holding the proportions, and a box dragged through itself inverting.
