### PR TITLE
feat(editor): move the layer under a drawing tool without losing the tool

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -97,6 +97,10 @@ bool isBoxResize(CaptureEditor::Interaction interaction) {
          interaction <= CaptureEditor::Interaction::ResizeLeft;
 }
 
+/// How far from an edge a press still counts as grabbing it: wide enough to
+/// hit without aiming, since some layers are grabbable only by their border.
+constexpr qreal kEdgeGrabTolerance = 12.0;
+
 bool showsSelectionBounds(Annotation::Kind kind) {
   return kind != Annotation::Kind::Arrow && kind != Annotation::Kind::Line;
 }
@@ -952,8 +956,9 @@ void CaptureEditor::applyBoxResize(Annotation &annotation, Interaction handle,
   annotation.end = box.bottomRight();
 }
 
-int CaptureEditor::annotationAt(const QPointF &point) const {
-  const auto containsPoint = [this, &point](const Annotation &annotation) {
+bool CaptureEditor::annotationContains(const Annotation &annotation,
+                                       const QPointF &point,
+                                       bool edgeOnly) const {
     if (annotation.kind == Annotation::Kind::Arrow ||
         annotation.kind == Annotation::Kind::Line) {
       const QPointF delta = annotation.end - annotation.start;
@@ -992,12 +997,13 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
     } else {
       const QRectF bounds = annotationBounds(annotation);
       if (annotation.kind == Annotation::Kind::Rectangle) {
-        // Filled rectangles hit anywhere inside; hollow ones only on the
-        // stroke band.
-        const qreal tolerance = std::max<qreal>(7.0, annotation.size + 3.0);
+        // Filled rectangles hit anywhere inside unless this is an edge-only
+        // grab; hollow ones only on the stroke band.
+        const qreal tolerance =
+            std::max<qreal>(kEdgeGrabTolerance, annotation.size + 3.0);
         const QRectF outer =
             bounds.adjusted(-tolerance, -tolerance, tolerance, tolerance);
-        if (annotation.filled)
+        if (!edgeOnly && annotation.filled)
           return outer.contains(point);
         const QRectF inner =
             bounds.adjusted(tolerance, tolerance, -tolerance, -tolerance);
@@ -1005,22 +1011,34 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
                (inner.isEmpty() || !inner.contains(point));
       }
       if (annotation.kind == Annotation::Kind::Ellipse) {
-        // Same rule for ellipses: filled hits the silhouette, hollow only a
-        // band around the outline.
-        const qreal tolerance = std::max<qreal>(7.0, annotation.size + 3.0);
+        // Same rule for ellipses: filled hits the silhouette unless this is
+        // an edge-only grab; hollow only a band around the outline.
+        const qreal tolerance =
+            std::max<qreal>(kEdgeGrabTolerance, annotation.size + 3.0);
         QPainterPath outline;
         outline.addEllipse(bounds);
         QPainterPathStroker band;
         band.setWidth(tolerance * 2.0);
         return band.createStroke(outline).contains(point) ||
-               (annotation.filled && outline.contains(point));
+               (!edgeOnly && annotation.filled && outline.contains(point));
+      }
+      if (edgeOnly && annotation.kind == Annotation::Kind::Redaction) {
+        const QRectF outer =
+            bounds.adjusted(kEdgeGrabTolerance, kEdgeGrabTolerance,
+                            -kEdgeGrabTolerance, -kEdgeGrabTolerance);
+        return bounds
+                   .adjusted(-kEdgeGrabTolerance, -kEdgeGrabTolerance,
+                             kEdgeGrabTolerance, kEdgeGrabTolerance)
+                   .contains(point) &&
+               (outer.isEmpty() || !outer.contains(point));
       }
       if (bounds.adjusted(-7, -7, 7, 7).contains(point))
         return true;
     }
     return false;
-  };
+}
 
+int CaptureEditor::annotationAt(const QPointF &point) const {
   for (const int layer : {0, 1, 2}) {
     for (int index = annotations_.size() - 1; index >= 0; --index) {
       const Annotation &annotation = annotations_.at(index);
@@ -1035,7 +1053,50 @@ int CaptureEditor::annotationAt(const QPointF &point) const {
           return index;
         continue;
       }
-      if (containsPoint(annotation))
+      if (annotationContains(annotation, point, false))
+        return index;
+    }
+  }
+  return -1;
+}
+
+bool CaptureEditor::toolGrabsLayer(int index) const {
+  if (index < 0 || index >= annotations_.size())
+    return false;
+  // A counter is stamped over anything that is not a counter. It still picks
+  // up its own kind: two that must overlap are placed apart and dragged
+  // together.
+  if (tool_ == Tool::Marker)
+    return annotations_.at(index).kind == Annotation::Kind::Marker;
+  return true;
+}
+
+bool CaptureEditor::pointerGrabsLayer() const {
+  return editImageRect().contains(cursor_) &&
+         toolGrabsLayer(annotationEdgeAt(toAnnotationPoint(cursor_)));
+}
+
+int CaptureEditor::annotationEdgeAt(const QPointF &point) const {
+  for (const int layer : {0, 1, 2}) {
+    for (int index = annotations_.size() - 1; index >= 0; --index) {
+      const Annotation &annotation = annotations_.at(index);
+      const int annotationLayer =
+          annotation.kind == Annotation::Kind::Spotlight
+              ? 1
+              : annotation.kind == Annotation::Kind::Redaction ? 2 : 0;
+      if (annotationLayer != layer)
+        continue;
+      if (layer == 1) {
+        const QPainterPath opening = spotlightPath(annotation);
+        if (!opening.contains(point))
+          continue;
+        QPainterPathStroker band;
+        band.setWidth(kEdgeGrabTolerance * 2.0);
+        if (band.createStroke(opening).contains(point))
+          return index;
+        continue;
+      }
+      if (annotationContains(annotation, point, true))
         return index;
     }
   }
@@ -2659,8 +2720,10 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
       selection_ = updated;
       if (updated != originalSelection_)
         dragChanged_ = true;
-    } else if (tool_ == Tool::Select && dragging_ &&
-               selectedAnnotation_ >= 0 &&
+    } else if ((tool_ == Tool::Select ||
+                interaction_ == Interaction::Move ||
+                isLayerResize(interaction_)) &&
+               dragging_ && selectedAnnotation_ >= 0 &&
                selectedAnnotation_ < annotations_.size()) {
       const QPointF point = toAnnotationPoint(cursor_);
       if (selectedAnnotations_.size() > 1 && interaction_ == Interaction::Move) {
@@ -2784,7 +2847,8 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
         refreshComposedCapture(&liveCut_);
       }
     }
-    if ((tool_ == Tool::Freehand || tool_ == Tool::Highlighter) && dragging_) {
+    if ((tool_ == Tool::Freehand || tool_ == Tool::Highlighter) && dragging_ &&
+        interaction_ == Interaction::None) {
       const QPointF point = toAnnotationPoint(cursor_);
       if (freehandPoints_.isEmpty() ||
           QLineF(freehandPoints_.last(), point).length() >= 1.5)
@@ -3035,6 +3099,59 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     update();
     return;
   }
+  // Edges move, interiors are canvas: with any tool armed, an edge under the
+  // pointer grabs that layer and the tool is left alone.
+  if (tool_ != Tool::Select && !dragging_) {
+    // A handle of the layer already selected wins over grabbing anything, so
+    // a selected layer can still be resized without switching to Select. The
+    // text tool's wrap handle is the one that would otherwise be unreachable.
+    int grabbed = annotationEdgeAt(point);
+    if (!toolGrabsLayer(grabbed))
+      grabbed = -1;
+    Interaction grabInteraction = Interaction::Move;
+    // Eight handles (and a text wrap handle) of the layer already selected
+    // win over grabbing anything, so a selected layer can still be resized
+    // without switching to Select.
+    const Interaction handle = selectedHandleAt(point);
+    if (handle != Interaction::None) {
+      grabbed = selectedAnnotation_;
+      grabInteraction = handle;
+    }
+    if (grabbed >= 0) {
+      selectedAnnotation_ = grabbed;
+      selectedAnnotations_ = {grabbed};
+      originalAnnotation_ = annotations_.at(grabbed);
+      originalSelectedAnnotations_.clear();
+      originalSelectedAnnotations_.push_back(annotations_.at(grabbed));
+      interaction_ = grabInteraction;
+      dragStartState_ = editState();
+      dragStartStateValid_ = true;
+      dragChanged_ = false;
+      dragStart_ = point;
+      dragging_ = true;
+      setStatus(QStringLiteral("Moving layer · release to keep drawing"));
+      updatePointerCursor();
+      update();
+      return;
+    }
+    // Nothing under the pointer: put down whatever was selected. A click that
+    // goes nowhere then only deselects, because a drag shorter than the commit
+    // dead-zone draws nothing; a real drag still draws, so dismissing costs no
+    // extra click.
+    if (selectedAnnotation_ >= 0 || !selectedAnnotations_.isEmpty()) {
+      selectedAnnotation_ = -1;
+      selectedAnnotations_.clear();
+      setStatus(QStringLiteral("No layer selected · drag to draw"));
+      // Tools that place on press must not place on the click that was only
+      // meant to put the last layer down. The tool stays armed, so the next
+      // click starts the next one.
+      if (tool_ == Tool::Text || tool_ == Tool::Marker) {
+        updatePointerCursor();
+        update();
+        return;
+      }
+    }
+  }
   if (tool_ == Tool::Marker) {
     Annotation annotation;
     annotation.kind = Annotation::Kind::Marker;
@@ -3059,6 +3176,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
   } else {
     dragStart_ = point;
     dragging_ = true;
+    interaction_ = Interaction::None;
     creationConstraintActive_ = supportsCreationConstraint(tool_) &&
                                 heldModifiers(event->modifiers()).testFlag(Qt::ShiftModifier);
     creationCenteredActive_ = supportsCenteredCreation(tool_) &&
@@ -3083,6 +3201,22 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     if (selection_.width() >= 2 && selection_.height() >= 2)
       enterEdit(QStringLiteral("Area selected · Select moves layers · wheel "
                                "zooms · outer handles crop"));
+    updatePointerCursor();
+    update();
+    return;
+  }
+  if ((interaction_ == Interaction::Move || isLayerResize(interaction_)) &&
+      tool_ != Tool::Select) {
+    // A grab with a drawing tool armed: keep the move, keep the tool. It is
+    // an edit like any other, so it takes its own undo step. Ctrl+Z after
+    // nudging a layer must put that layer back, not remove the one before it.
+    dragging_ = false;
+    interaction_ = Interaction::None;
+    if (dragStartStateValid_ && dragChanged_)
+      commitPatch(selectedAnnotations_);
+    dragStartStateValid_ = false;
+    dragChanged_ = false;
+    setStatus(QStringLiteral("Layer moved · keep drawing, or Esc to select"));
     updatePointerCursor();
     update();
     return;
@@ -3362,7 +3496,13 @@ void CaptureEditor::updatePointerCursor() {
       setCursor(Qt::SizeHorCursor);
     else
       setCursor(Qt::ArrowCursor);
-  } else if (tool_ == Tool::Marker)
+  } else if (interaction_ == Interaction::Move && dragging_)
+    setCursor(Qt::SizeAllCursor);
+  else if (!dragging_ && pointerGrabsLayer())
+    // An I-beam over a committed text reads as "click to edit" when the click
+    // will move it, so what is under the pointer decides the cursor.
+    setCursor(Qt::SizeAllCursor);
+  else if (tool_ == Tool::Marker)
     setCursor(Qt::PointingHandCursor);
   else if (tool_ == Tool::Text)
     setCursor(Qt::IBeamCursor);
@@ -3554,7 +3694,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   }
 
   QImage redactionLayer = redactionLayerCache_;
-  if (dragging_ && tool_ == Tool::Redact) {
+  if (dragging_ && interaction_ == Interaction::None &&
+      tool_ == Tool::Redact) {
     Annotation preview;
     preview.kind = Annotation::Kind::Redaction;
     preview.start = dragStart_;
@@ -3588,7 +3729,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         AnnotationLayer::Default)
       defaultAnnotations.push_back(annotations_.at(index));
   }
-  if (dragging_ && tool_ != Tool::Select && tool_ != Tool::Redact &&
+  if (dragging_ && interaction_ == Interaction::None &&
+      tool_ != Tool::Select && tool_ != Tool::Redact &&
       tool_ != Tool::Cut) {
     Annotation preview;
     if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
@@ -3614,7 +3756,11 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     preview.color = tool_ == Tool::Ocr ? QColor(Qt::white) : annotationColor();
     preview.size = tool_ == Tool::Ocr ? 2.0 : annotationSize_;
     defaultAnnotations.push_back(std::move(preview));
-  } else if (tool_ == Tool::Marker && image.contains(cursor_)) {
+  } else if (tool_ == Tool::Marker && image.contains(cursor_) && !dragging_ &&
+             !pointerGrabsLayer()) {
+    // The ghost counter shows where the next one would land, so it belongs
+    // only where the press would actually place one: over another counter the
+    // press moves that counter instead.
     Annotation preview;
     preview.kind = Annotation::Kind::Marker;
     preview.start = toAnnotationPoint(cursor_);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -195,7 +195,33 @@ private:
   /// on a corner keeps the proportions.
   void applyBoxResize(Annotation &annotation, Interaction handle,
                       const QPointF &point, const QRectF &original);
+public:
+  /// Number of annotation layers. Test accessor.
+  [[nodiscard]] int annotationCountForTest() const {
+    return static_cast<int>(annotations_.size());
+  }
+  /// Currently armed tool. Test accessor: cursor shape is a poor proxy, since
+  /// what is under the pointer changes it.
+  [[nodiscard]] Tool armedToolForTest() const { return tool_; }
+  /// Number of selected layers. Test accessor.
+  [[nodiscard]] int selectedCountForTest() const {
+    return static_cast<int>(selectedAnnotations_.size());
+  }
+
+private:
   [[nodiscard]] int annotationAt(const QPointF &point) const;
+  /// Whether the armed tool picks a layer up rather than working over it.
+  [[nodiscard]] bool toolGrabsLayer(int index) const;
+  /// Whether a press here would grab a layer, which is what the cursor reads.
+  [[nodiscard]] bool pointerGrabsLayer() const;
+  /// Topmost layer whose *edge* is under `point`. Areas that a drawing tool
+  /// should be able to draw across, such as redactions, spotlights and filled
+  /// shapes, are grabbable only by their border, so their interiors stay
+  /// canvas.
+  [[nodiscard]] int annotationEdgeAt(const QPointF &point) const;
+  [[nodiscard]] bool annotationContains(const Annotation &annotation,
+                                        const QPointF &point,
+                                        bool edgeOnly) const;
   [[nodiscard]] int hoveredSpotlightAt(const QPointF &position) const;
   [[nodiscard]] QRectF normalizedSelection(const QPointF &first,
                                            const QPointF &second) const;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1493,7 +1493,7 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
     QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(endX, endY));
     application.processEvents();
-    if (editor.cursor().shape() != Qt::CrossCursor) {
+    if (editor.armedToolForTest() != CaptureEditor::Tool::Arrow) {
       error = QStringLiteral("Arrow tool did not remain active after drawing");
       return false;
     }
@@ -1543,7 +1543,7 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
        {std::pair{200, 300}, std::pair{250, 300}, std::pair{300, 300}}) {
     QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(x, y));
     application.processEvents();
-    if (editor.cursor().shape() != Qt::PointingHandCursor) {
+    if (editor.armedToolForTest() != CaptureEditor::Tool::Marker) {
       error = QStringLiteral("Marker tool did not remain active after click");
       return false;
     }
@@ -1551,12 +1551,15 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
 
   QTest::keyClick(&editor, Qt::Key_Escape);
   application.processEvents();
-  if (editor.cursor().shape() != Qt::ArrowCursor) {
+  if (editor.armedToolForTest() != CaptureEditor::Tool::Select) {
     error = QStringLiteral("Escape did not return to Select tool");
     return false;
   }
 
   QTest::keyClick(&editor, Qt::Key_R);
+  // Over empty canvas: a drawing tool draws, so it shows the crosshair. (Over
+  // a layer's edge it shows the move cursor, checked separately below.)
+  QTest::mouseMove(&editor, QPoint(680, 480), 10);
   application.processEvents();
   if (editor.cursor().shape() != Qt::CrossCursor) {
     error = QStringLiteral("Rectangle tool did not set cross cursor");
@@ -1573,7 +1576,7 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
     QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
                         QPoint(endX, endY));
     application.processEvents();
-    if (editor.cursor().shape() != Qt::CrossCursor) {
+    if (editor.armedToolForTest() != CaptureEditor::Tool::Rectangle) {
       error =
           QStringLiteral("Rectangle tool did not remain active after drawing");
       return false;
@@ -1589,7 +1592,7 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
 
   QTest::keyClick(&editor, Qt::Key_T);
   application.processEvents();
-  if (editor.cursor().shape() != Qt::IBeamCursor) {
+  if (editor.armedToolForTest() != CaptureEditor::Tool::Text) {
     error = QStringLiteral("Text tool did not set IBeam cursor");
     return false;
   }
@@ -1599,7 +1602,7 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
   QTest::keyClicks(QApplication::focusWidget(), QStringLiteral("Text 1"));
   QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
   application.processEvents();
-  if (editor.cursor().shape() != Qt::IBeamCursor) {
+  if (editor.armedToolForTest() != CaptureEditor::Tool::Text) {
     error = QStringLiteral(
         "Text tool did not remain active after submitting new text");
     return false;
@@ -1610,7 +1613,7 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
   QTest::keyClicks(QApplication::focusWidget(), QStringLiteral("Text 2"));
   QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
   application.processEvents();
-  if (editor.cursor().shape() != Qt::IBeamCursor) {
+  if (editor.armedToolForTest() != CaptureEditor::Tool::Text) {
     error = QStringLiteral(
         "Text tool did not remain active after second text commit");
     return false;
@@ -1618,7 +1621,7 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
 
   QTest::mouseClick(&editor, Qt::RightButton, Qt::NoModifier, QPoint(100, 100));
   application.processEvents();
-  if (editor.cursor().shape() != Qt::ArrowCursor) {
+  if (editor.armedToolForTest() != CaptureEditor::Tool::Select) {
     error = QStringLiteral(
         "Right-click did not return from Text tool to Select tool");
     return false;
@@ -3601,6 +3604,10 @@ bool runDuplicateLayerSmoke(QApplication &application, QString &error) {
   }
 
   // A duplicated marker takes the next number.
+  // Alt+D leaves the copy selected; a Marker press on empty canvas first
+  // puts that layer down (#65) and would not stamp, so drop the selection.
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(150, 450));
+  application.processEvents();
   QTest::keyClick(&editor, Qt::Key_C);
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(600, 200));
   QTest::keyClick(&editor, Qt::Key_V);
@@ -3634,7 +3641,7 @@ bool runDuplicateLayerSmoke(QApplication &application, QString &error) {
   // Plain D still arms the Redact tool.
   QTest::keyClick(&editor, Qt::Key_D);
   application.processEvents();
-  if (editor.cursor().shape() != Qt::CrossCursor) {
+  if (editor.armedToolForTest() != CaptureEditor::Tool::Redact) {
     error = QStringLiteral("Plain D no longer arms the Redact tool");
     return false;
   }
@@ -3940,6 +3947,269 @@ bool runLineHandleLegendSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Checks that a drawing tool moves the layer under its edge without losing
+ *  the tool: adjust what is there, then keep drawing. */
+bool runHoverMoveSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(700, 500));
+  application.processEvents();
+
+  // A hollow rectangle, then the arrow tool armed.
+  QTest::keyClick(&editor, Qt::Key_R);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 250));
+  QTest::mouseMove(&editor, QPoint(500, 400), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(500, 400));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_A);
+  application.processEvents();
+
+  // Inside the outline is canvas: the arrow tool draws there.
+  const QImage beforeDraw = flushedSnapshot(editor, snapshotPath);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(380, 320));
+  QTest::mouseMove(&editor, QPoint(450, 360), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(450, 360));
+  application.processEvents();
+  if (flushedSnapshot(editor, snapshotPath) == beforeDraw) {
+    error = QStringLiteral("Drawing inside a hollow shape did not draw");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+
+  // On the outline it grabs and moves, and the arrow tool survives.
+  const QImage beforeMove = flushedSnapshot(editor, snapshotPath);
+  const int layersBeforeMove = editor.annotationCountForTest();
+  QTest::mouseMove(&editor, QPoint(300, 250), 10);
+  application.processEvents();
+  if (editor.cursor().shape() != Qt::SizeAllCursor) {
+    error = QStringLiteral("An edge under a drawing tool showed no move cursor");
+    return false;
+  }
+  // The border is wide enough to hit without aiming: 10 px outside the stroke
+  // still grabs, which is what makes a hollow shape draggable in practice.
+  QTest::mouseMove(&editor, QPoint(400, 240), 10);
+  application.processEvents();
+  if (editor.cursor().shape() != Qt::SizeAllCursor) {
+    error = QStringLiteral("The edge grab band was too narrow to hit");
+    return false;
+  }
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 250));
+  QTest::mouseMove(&editor, QPoint(340, 290), 10);
+  application.processEvents();
+  {
+    // Mid-grab there must be no half-drawn annotation following the pointer:
+    // the on-screen frame should differ from a live arrow being dragged out.
+    const QImage midGrab = editor.grab().toImage();
+    QTest::mouseMove(&editor, QPoint(420, 370), 10);
+    application.processEvents();
+    const QImage laterGrab = editor.grab().toImage();
+    if (midGrab == laterGrab) {
+      error = QStringLiteral("Grab did not track the pointer");
+      return false;
+    }
+    // With the arrow tool armed, a grab must not also draw an arrow from the
+    // grab point to the pointer. Halfway along that line is empty canvas once
+    // the rectangle has moved away, so it must still read as background.
+    const QColor midLine = laterGrab.pixelColor(360, 310);
+    if (midLine != QColor(QStringLiteral("#182030"))) {
+      error = QStringLiteral("A grab also drew the armed tool (%1 at 360,310)")
+                  .arg(midLine.name());
+      return false;
+    }
+  }
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(420, 370));
+  application.processEvents();
+  if (editor.annotationCountForTest() != layersBeforeMove) {
+    error = QStringLiteral("A grab left a stray annotation behind (%1 -> %2)")
+                .arg(layersBeforeMove)
+                .arg(editor.annotationCountForTest());
+    return false;
+  }
+  if (flushedSnapshot(editor, snapshotPath) == beforeMove) {
+    error = QStringLiteral("Grabbing an edge did not move the layer");
+    return false;
+  }
+  // The distinction that matters: it moved the layer rather than drawing a
+  // new one, which would also have changed the snapshot.
+  if (editor.annotationCountForTest() != layersBeforeMove) {
+    error = QStringLiteral("Grabbing an edge drew instead of moving (%1 -> %2)")
+                .arg(layersBeforeMove)
+                .arg(editor.annotationCountForTest());
+    return false;
+  }
+
+  // That move is an edit like any other, so one undo puts it back and a
+  // second one is needed to reach whatever came before it.
+  {
+    const QImage moved = flushedSnapshot(editor, snapshotPath);
+    QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    const QImage undone = flushedSnapshot(editor, snapshotPath);
+    if (undone == moved) {
+      error = QStringLiteral("Undo did not put the moved layer back");
+      return false;
+    }
+    if (editor.annotationCountForTest() != layersBeforeMove) {
+      error = QStringLiteral("Undoing a move removed the layer instead");
+      return false;
+    }
+    QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+    application.processEvents();
+    if (flushedSnapshot(editor, snapshotPath) != moved) {
+      error = QStringLiteral("Redo did not restore the move");
+      return false;
+    }
+  }
+
+  // Still the arrow tool. The moved layer is selected, so one click on empty
+  // canvas puts it down without drawing anything...
+  const QImage beforeDismiss = flushedSnapshot(editor, snapshotPath);
+  const int layersBeforeDismiss = editor.annotationCountForTest();
+  if (editor.selectedCountForTest() == 0) {
+    error = QStringLiteral("Moving a layer did not leave it selected");
+    return false;
+  }
+  QTest::mouseMove(&editor, QPoint(620, 200), 10);
+  application.processEvents();
+  if (editor.cursor().shape() != Qt::CrossCursor) {
+    error = QStringLiteral("Moving a layer left the drawing tool behind");
+    return false;
+  }
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(620, 200));
+  application.processEvents();
+  if (editor.annotationCountForTest() != layersBeforeDismiss ||
+      flushedSnapshot(editor, snapshotPath) != beforeDismiss) {
+    error = QStringLiteral("Clicking off a selected layer drew something");
+    return false;
+  }
+  // ...and it really is deselected.
+  if (editor.selectedCountForTest() != 0) {
+    error = QStringLiteral("Clicking off a selected layer left it selected");
+    return false;
+  }
+
+  // A selected layer's handle resizes it rather than being grabbed as a move,
+  // with the tool still armed. The text tool's wrap handle depends on this.
+  {
+    QTest::keyClick(&editor, Qt::Key_R);
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 200));
+    QTest::mouseMove(&editor, QPoint(350, 300), 10);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(350, 300));
+    application.processEvents();
+    QTest::keyClick(&editor, Qt::Key_V);
+    QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(275, 200));
+    application.processEvents();
+    if (editor.selectedCountForTest() == 0) {
+      error = QStringLiteral("Could not select the rectangle to resize it");
+      return false;
+    }
+    QTest::keyClick(&editor, Qt::Key_A); // a drawing tool, not Select
+    application.processEvents();
+    const QImage beforeResize = flushedSnapshot(editor, snapshotPath);
+    const int layersBeforeResize = editor.annotationCountForTest();
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(350, 300));
+    QTest::mouseMove(&editor, QPoint(420, 360), 10);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(420, 360));
+    application.processEvents();
+    if (editor.annotationCountForTest() != layersBeforeResize) {
+      error = QStringLiteral("Dragging a handle drew instead of resizing");
+      return false;
+    }
+    if (flushedSnapshot(editor, snapshotPath) == beforeResize) {
+      error = QStringLiteral("Dragging a handle did not resize the layer");
+      return false;
+    }
+    // The distinction that matters: a resize leaves the opposite corner where
+    // it was, a move would have taken the whole rectangle with it.
+    const QImage resized = editor.grab().toImage();
+    if (resized.pixelColor(202, 202) == QColor(QStringLiteral("#182030"))) {
+      error = QStringLiteral("Dragging a handle moved the layer instead of "
+                             "resizing it");
+      return false;
+    }
+  }
+
+  // A counter is stamped on top of the work, so it goes down over an existing
+  // layer instead of grabbing it, including on the edge that every other tool
+  // would move.
+  {
+    QTest::keyClick(&editor, Qt::Key_C);
+    application.processEvents();
+    QTest::mouseMove(&editor, QPoint(420, 370), 10);
+    application.processEvents();
+    if (editor.cursor().shape() != Qt::PointingHandCursor) {
+      error = QStringLiteral("The counter offered to move the layer under it");
+      return false;
+    }
+    const int layersBeforeMarker = editor.annotationCountForTest();
+    // The resized layer is still selected, so this click only puts it down.
+    QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(420, 370));
+    application.processEvents();
+    if (editor.annotationCountForTest() != layersBeforeMarker ||
+        editor.selectedCountForTest() != 0) {
+      error = QStringLiteral("Dismissing a selection also placed a counter");
+      return false;
+    }
+    QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(420, 370));
+    application.processEvents();
+    if (editor.annotationCountForTest() != layersBeforeMarker + 1) {
+      error = QStringLiteral("A counter on top of a layer did not go down");
+      return false;
+    }
+    if (editor.selectedCountForTest() != 0) {
+      error = QStringLiteral("Placing a counter grabbed the layer under it");
+      return false;
+    }
+    // Its own counters it does pick up: one just placed has to be movable
+    // without changing tools, and two that must overlap are placed apart and
+    // dragged together.
+    QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(420, 370));
+    application.processEvents();
+    if (editor.annotationCountForTest() != layersBeforeMarker + 1) {
+      error = QStringLiteral("Clicking a counter placed another on top of it");
+      return false;
+    }
+    if (editor.selectedCountForTest() != 1) {
+      error = QStringLiteral("Clicking a counter did not pick it up");
+      return false;
+    }
+    QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+    application.processEvents();
+    QTest::keyClick(&editor, Qt::Key_A);
+    application.processEvents();
+  }
+
+  // ...and the drag after that draws an arrow.
+  const QImage beforeSecond = flushedSnapshot(editor, snapshotPath);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(620, 200));
+  QTest::mouseMove(&editor, QPoint(660, 260), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(660, 260));
+  application.processEvents();
+  if (flushedSnapshot(editor, snapshotPath) == beforeSecond) {
+    error = QStringLiteral("Could not draw after dismissing the selection");
+    return false;
+  }
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -4002,6 +4272,10 @@ int main(int argc, char **argv) {
   if (!runLayerHandlesSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 120;
+  }
+  if (!runHoverMoveSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 114;
   }
   if (!runAsyncCaptureRegionSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
@@ -4400,15 +4674,20 @@ int main(int argc, char **argv) {
   QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
                       QPoint(530, 420));
   application.processEvents();
-  if (editor.cursor().shape() != Qt::CrossCursor ||
-      flushedSnapshot(editor, snapshotPath) == beforeFreehandSnapshot)
+  if (flushedSnapshot(editor, snapshotPath) == beforeFreehandSnapshot)
+    return 28;
+  // The pointer is left on the stroke it just drew, where a press would move
+  // it; the crosshair belongs to empty canvas.
+  QTest::mouseMove(&editor, QPoint(680, 470), 10);
+  application.processEvents();
+  if (editor.cursor().shape() != Qt::CrossCursor)
     return 28;
   const QImage beforeMarkerSnapshot = flushedSnapshot(editor, snapshotPath);
   QTest::keyClick(&editor, Qt::Key_2);
   QTest::keyClick(&editor, Qt::Key_C);
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(470, 300));
   application.processEvents();
-  if (editor.cursor().shape() != Qt::PointingHandCursor ||
+  if (editor.armedToolForTest() != CaptureEditor::Tool::Marker ||
       flushedSnapshot(editor, snapshotPath) == beforeMarkerSnapshot)
     return 48;
   const QImage beforeTextSnapshot = flushedSnapshot(editor, snapshotPath);


### PR DESCRIPTION
Continuous tools (#32) keep the tool armed so you can draw several annotations in a row, but adjusting one of them still meant going to Select and back.

Now, with a drawing tool armed, pressing on a layer's edge moves that layer and leaves your tool where it was. Edges move, interiors are canvas: redactions and spotlights grab by their border band so a tool can still draw across the middle (the common case of pointing at what you just redacted), hollow shapes already worked this way, and arrows, lines and strokes grab along their whole length since they have no interior to protect. Counters and text grab like anything else, so putting a counter inside a redaction still works.

A handle of the already-selected layer beats grabbing anything else, so you can resize without switching tools. The text tool's wrap handle needs that, or its own tool grabs the pill and the handle is unreachable.

Whatever's under the pointer decides the cursor too, ahead of what the tool would do: an I-beam over a committed text says "click to edit" when the click will move it, so it shows the move cursor. Double-click still edits.

Pressing empty canvas puts down whatever was selected and does only that. A drag shorter than the commit dead-zone draws nothing, so dropping a selection costs no extra click, while a real drag still draws.

One subtlety: while a grab is moving a layer the armed tool must not also draw. The creation preview, redaction preview and freehand point collection are suppressed for the duration, or moving a box by its edge trails a half-drawn box behind the pointer.

`annotationEdgeAt()` is the edge-only sibling of `annotationAt()`, which keeps click-anywhere selection for Select; both go through `annotationContains()` so they can't drift apart.

Two kinds of existing check needed adjusting, noted in the diff: several read the cursor shape to ask "is the tool still armed", which it can't answer now that any layer under the pointer changes it, so they ask the editor directly; two others asserted the crosshair with the pointer sitting on a layer, and move to empty canvas first.

`runHoverMoveSmoke` (exit 114) covers drawing inside a hollow shape, grabbing and moving its outline (layer count proves it moved rather than drew), no armed-tool stroke mid-grab, a click on empty canvas deselecting without drawing, a handle resizing rather than moving, and the next drag still drawing an arrow.
