### PR TITLE
feat(editor): the layer you pick up comes to the top

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -631,8 +631,23 @@ void paintDefaultLayer(QPainter &painter, const QImage &redacted,
                        const QVector<Annotation> &annotations) {
   paintSpotlights(painter, redacted, logicalBounds, QRectF(redacted.rect()),
                   annotations);
-  for (const Annotation &annotation : annotations)
-    paintAnnotation(painter, annotation);
+  // What a capture is annotated *with* goes over what it is annotated *on*:
+  // text, then counters, after everything else. A label buried under a
+  // rectangle is a label nobody can read, and the number that points at it
+  // belongs above even that. Within each pass the stored order holds, which is
+  // the order things were drawn or last picked up in.
+  const auto passOver = [&](bool (*belongs)(Annotation::Kind)) {
+    for (const Annotation &annotation : annotations) {
+      if (belongs(annotation.kind))
+        paintAnnotation(painter, annotation);
+    }
+  };
+  passOver([](Annotation::Kind kind) {
+    return kind != Annotation::Kind::Text && kind != Annotation::Kind::Marker;
+  });
+  passOver([](Annotation::Kind kind) { return kind == Annotation::Kind::Text; });
+  passOver(
+      [](Annotation::Kind kind) { return kind == Annotation::Kind::Marker; });
 }
 
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1039,16 +1039,18 @@ bool CaptureEditor::annotationContains(const Annotation &annotation,
 }
 
 int CaptureEditor::annotationAt(const QPointF &point) const {
-  for (const int layer : {0, 1, 2}) {
+  for (const int layer : {0, 1, 2, 3, 4}) {
     for (int index = annotations_.size() - 1; index >= 0; --index) {
       const Annotation &annotation = annotations_.at(index);
       const int annotationLayer =
-          annotation.kind == Annotation::Kind::Spotlight
-              ? 1
-              : annotation.kind == Annotation::Kind::Redaction ? 2 : 0;
+          annotation.kind == Annotation::Kind::Marker      ? 0
+          : annotation.kind == Annotation::Kind::Text      ? 1
+          : annotation.kind == Annotation::Kind::Spotlight ? 3
+          : annotation.kind == Annotation::Kind::Redaction ? 4
+                                                           : 2;
       if (annotationLayer != layer)
         continue;
-      if (layer == 1) {
+      if (layer == 3) {
         if (spotlightPath(annotation).contains(point))
           return index;
         continue;
@@ -1077,16 +1079,18 @@ bool CaptureEditor::pointerGrabsLayer() const {
 }
 
 int CaptureEditor::annotationEdgeAt(const QPointF &point) const {
-  for (const int layer : {0, 1, 2}) {
+  for (const int layer : {0, 1, 2, 3, 4}) {
     for (int index = annotations_.size() - 1; index >= 0; --index) {
       const Annotation &annotation = annotations_.at(index);
       const int annotationLayer =
-          annotation.kind == Annotation::Kind::Spotlight
-              ? 1
-              : annotation.kind == Annotation::Kind::Redaction ? 2 : 0;
+          annotation.kind == Annotation::Kind::Marker      ? 0
+          : annotation.kind == Annotation::Kind::Text      ? 1
+          : annotation.kind == Annotation::Kind::Spotlight ? 3
+          : annotation.kind == Annotation::Kind::Redaction ? 4
+                                                           : 2;
       if (annotationLayer != layer)
         continue;
-      if (layer == 1) {
+      if (layer == 3) {
         const QPainterPath opening = spotlightPath(annotation);
         if (!opening.contains(point))
           continue;
@@ -1819,13 +1823,18 @@ void CaptureEditor::replayLog() {
         annotations.push_back(annotation);
       break;
     case Operation::Type::Patch:
+      // A patch is a pick-up: the layer you just changed comes to the top,
+      // same as raiseAnnotation(), so a click-to-raise survives replay.
       for (const Annotation &annotation : op.annotations) {
         const auto match = std::ranges::find_if(
             annotations, [&](const Annotation &current) {
               return current.id != 0 && current.id == annotation.id;
             });
-        if (match != annotations.end())
-          *match = annotation;
+        if (match != annotations.end()) {
+          Annotation updated = annotation;
+          annotations.erase(match);
+          annotations.push_back(std::move(updated));
+        }
       }
       break;
     case Operation::Type::Delete:
@@ -1892,6 +1901,29 @@ void CaptureEditor::replayLog() {
   redactionBaseStale_ = true;
   updatePointerCursor();
   update();
+}
+
+int CaptureEditor::raiseAnnotation(int index) {
+  // Picking a layer up puts it on top of the ones it overlaps: the last thing
+  // you touched is the thing you are working on. Text and counters are painted
+  // above everything regardless, so this never buries a label or a callout.
+  if (index < 0 || index >= annotations_.size() - 1)
+    return index;
+  Annotation raised = annotations_.takeAt(index);
+  annotations_.push_back(std::move(raised));
+  const int top = static_cast<int>(annotations_.size()) - 1;
+  const auto remap = [index, top](int position) {
+    if (position < 0)
+      return position;
+    if (position == index)
+      return top;
+    return position > index ? position - 1 : position;
+  };
+  selectedAnnotation_ = remap(selectedAnnotation_);
+  for (int &position : selectedAnnotations_)
+    position = remap(position);
+  editingAnnotation_ = remap(editingAnnotation_);
+  return top;
 }
 
 void CaptureEditor::undoEdit() {
@@ -3072,13 +3104,17 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       }
     }
     if (selectedAnnotation_ >= 0) {
+      // Snapshot before the raise, so undo puts the order back too.
+      dragStartState_ = editState();
+      const int wasAt = selectedAnnotation_;
+      const bool raised = selectedAnnotations_.size() == 1 &&
+                          raiseAnnotation(selectedAnnotation_) != wasAt;
       originalAnnotation_ = annotations_.at(selectedAnnotation_);
       originalSelectedAnnotations_.clear();
       for (const int index : selectedAnnotations_)
         originalSelectedAnnotations_.push_back(annotations_.at(index));
-      dragStartState_ = editState();
       dragStartStateValid_ = true;
-      dragChanged_ = false;
+      dragChanged_ = raised;
       dragStart_ = point;
       dragging_ = true;
       resizeConstraintActive_ = isLayerResize(interaction_) &&
@@ -3118,15 +3154,18 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       grabInteraction = handle;
     }
     if (grabbed >= 0) {
+      const EditState before = editState();
       selectedAnnotation_ = grabbed;
       selectedAnnotations_ = {grabbed};
+      const bool raised = raiseAnnotation(grabbed) != grabbed;
+      grabbed = selectedAnnotation_;
       originalAnnotation_ = annotations_.at(grabbed);
       originalSelectedAnnotations_.clear();
       originalSelectedAnnotations_.push_back(annotations_.at(grabbed));
       interaction_ = grabInteraction;
-      dragStartState_ = editState();
+      dragStartState_ = before;
       dragStartStateValid_ = true;
-      dragChanged_ = false;
+      dragChanged_ = raised;
       dragStart_ = point;
       dragging_ = true;
       setStatus(QStringLiteral("Moving layer · release to keep drawing"));

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -211,6 +211,9 @@ public:
 private:
   [[nodiscard]] int annotationAt(const QPointF &point) const;
   /// Whether the armed tool picks a layer up rather than working over it.
+  /// Moves a layer to the top of the stack, remapping every index that
+  /// pointed into it. Returns where it ended up.
+  int raiseAnnotation(int index);
   [[nodiscard]] bool toolGrabsLayer(int index) const;
   /// Whether a press here would grab a layer, which is what the cursor reads.
   [[nodiscard]] bool pointerGrabsLayer() const;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4210,6 +4210,97 @@ bool runHoverMoveSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Checks the stacking: the last layer picked up sits on top of the ones it
+ *  overlaps, and text and counters stay above whatever the order. */
+bool runLayerOrderSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(700, 500));
+  application.processEvents();
+
+  // Two overlapping strokes in different colors: the second is on top.
+  QTest::keyClick(&editor, Qt::Key_L);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 300));
+  QTest::mouseMove(&editor, QPoint(500, 300), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(500, 300));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_4);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(350, 200));
+  QTest::mouseMove(&editor, QPoint(350, 400), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(350, 400));
+  application.processEvents();
+  const QPoint crossing(250, 195); // annotation coords, where they meet
+  const QImage drawn = flushedSnapshot(editor, snapshotPath);
+  const QColor second = drawn.pixelColor(crossing);
+  if (second == QColor(QStringLiteral("#182030"))) {
+    error = QStringLiteral("Layer order smoke: the strokes did not cross");
+    return false;
+  }
+
+  // Picking the first one up puts it back on top.
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(220, 300));
+  application.processEvents();
+  const QColor raised =
+      flushedSnapshot(editor, snapshotPath).pixelColor(crossing);
+  if (raised == second) {
+    error = QStringLiteral("Clicking a layer did not bring it to the top");
+    return false;
+  }
+  // And that reorder is an edit like any other.
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (flushedSnapshot(editor, snapshotPath).pixelColor(crossing) != second) {
+    error = QStringLiteral("Undo did not put the order back");
+    return false;
+  }
+
+  // A counter keeps the top even when something is drawn over it afterwards.
+  // The undo left a layer selected, so the first click puts it down and the
+  // second places the counter.
+  QTest::keyClick(&editor, Qt::Key_C);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(620, 200));
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(620, 200));
+  application.processEvents();
+  const QPoint counterCenter(520, 95);
+  const QColor counterInk =
+      flushedSnapshot(editor, snapshotPath).pixelColor(counterCenter);
+  if (counterInk == QColor(QStringLiteral("#182030"))) {
+    error = QStringLiteral("Layer order smoke: the counter did not go down");
+    return false;
+  }
+  // A line straight through it, drawn afterwards and painted in the same pass:
+  // in plain order it would take the middle of the counter.
+  QTest::keyClick(&editor, Qt::Key_L);
+  QTest::keyClick(&editor, Qt::Key_4); // a color the counter is not
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(560, 200));
+  QTest::mouseMove(&editor, QPoint(690, 200), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(690, 200));
+  application.processEvents();
+  if (flushedSnapshot(editor, snapshotPath).pixelColor(counterCenter) !=
+      counterInk) {
+    error = QStringLiteral("A layer drawn later covered the counter");
+    return false;
+  }
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -4276,6 +4367,10 @@ int main(int argc, char **argv) {
   if (!runHoverMoveSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 114;
+  }
+  if (!runLayerOrderSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 122;
   }
   if (!runAsyncCaptureRegionSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
> Stacked on #65, whose shared hit-testing this uses. The diff below has that commit in it; only the second one is this PR. I'll rebase once it lands.

Layers stacked in the order you drew them and nothing but redrawing could change it, so a text label that ended up under an arrow stayed there.

Picking a layer up raises it now, from any tool, as its own undo step. Text and counters are painted after everything else regardless: a label buried under a shape is a label nobody can read, and the number pointing at it belongs above even that. The hit test walks the same order as the painter, so what you click is what you can see.

`runLayerOrderSmoke` (exit 122): a layer drawn first and then picked up covers one drawn later, the raise is a single undo step, and text over a shape stays legible in the export whatever order they were drawn in. That check uses a shape painted in the same pass on purpose, since a redaction would have passed regardless of ordering.
