### PR TITLE
feat(editor): zoom and pan the edit canvas for oversized captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,10 +271,13 @@ Install the corresponding Tesseract language data before adding a language to
 | `O` | Drag an OCR region and copy recognized text |
 | `B` | Cycle backdrop |
 | `1`–`6` | Set annotation color |
-| Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size (`Alt`+wheel: rectangle corner radius) |
+| Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size (`Alt`+wheel: rectangle corner radius or spotlight border); while just viewing a zoomed capture, scroll it like a document |
+| `Shift`+wheel | Scroll a zoomed capture sideways (a wide stitch); never changes the zoom |
+| `Ctrl`+wheel · middle-drag | Zoom about the cursor · pan by dragging |
+| `+` / `-` / `0` (also with `Ctrl`) | Zoom in / out / fit |
 | Hold `Shift` while dragging | Make rectangles, ellipses, and spotlights 1:1; snap lines and arrows to 45°; while dragging a selected layer's handle, keep a rectangle, redaction or spotlight's aspect ratio (lines and arrows: 45°) |
 | Hold `Alt` while dragging | Center rectangles, ellipses, and spotlights on the press point; add `Shift` for a centered square/circle |
-| `←` `↑` `→` `↓` | Nudge the selected layer 1 px; hold `Shift` for 10 px (a held key is one undo step) |
+| `←` `↑` `→` `↓` | Nudge the selected layer 1 px; hold `Shift` for 10 px (a held key is one undo step). With nothing selected, pan a zoomed capture |
 | Double-click text | Reopen text editing |
 | `Delete` | Delete selected layer |
 | `Alt+D` | Duplicate selected layer (offset down-left, or away from a nearby edge); the copy becomes the selection |

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1371,7 +1371,7 @@ QRectF CaptureEditor::colorPaletteRect() const {
   const qreal buttonHeight = 36 * scale;
   const qreal toolbarX = (width() - toolbarWidth) / 2.0;
   const qreal toolbarY =
-      std::max<qreal>(10, editImageRect().top() - buttonHeight - 10);
+      std::max<qreal>(10, chromeAnchorTop() - buttonHeight - 10);
   const QRectF anchor(toolbarX + 480 * scale, toolbarY, 36 * scale,
                       buttonHeight);
   const qreal paletteWidth = 232;
@@ -1396,7 +1396,7 @@ QRectF CaptureEditor::textSizePanelRect() const {
   const qreal buttonHeight = 36 * scale;
   const qreal toolbarX = (width() - toolbarWidth) / 2.0;
   const qreal toolbarY =
-      std::max<qreal>(10, editImageRect().top() - buttonHeight - 10);
+      std::max<qreal>(10, chromeAnchorTop() - buttonHeight - 10);
   const QRectF anchor(toolbarX + 440 * scale, toolbarY, 36 * scale,
                       buttonHeight);
   return {anchor.center().x() - 51, anchor.bottom() + 6, 102, 34};
@@ -1441,7 +1441,7 @@ QRectF CaptureEditor::normalizedSelection(const QPointF &first,
   return QRectF(a, b).normalized();
 }
 
-QRectF CaptureEditor::editImageRect() const {
+QRectF CaptureEditor::baseImageRect() const {
   if (selection_.isEmpty())
     return {};
   const QRectF available(30, 68, std::max(1, width() - 60),
@@ -1453,6 +1453,91 @@ QRectF CaptureEditor::editImageRect() const {
   return {available.center().x() - shown.width() / 2.0,
           available.center().y() - shown.height() / 2.0, shown.width(),
           shown.height()};
+}
+
+qreal CaptureEditor::chromeAnchorTop() const {
+  // Zoomed past fit the content fills the viewport band, so anchoring to the
+  // centered fit rect would float the chrome over it. Anchor to the band.
+  const qreal base = baseImageRect().top();
+  return viewZoom_ > 1.0 ? std::min<qreal>(base, 68.0) : base;
+}
+
+QRectF CaptureEditor::editImageRect() const {
+  const QRectF base = baseImageRect();
+  if (base.isEmpty() || viewZoom_ <= 1.0)
+    return base.translated(viewOffset_);
+  const QSizeF shown = base.size() * viewZoom_;
+  const QPointF center = base.center();
+  return QRectF(center.x() - shown.width() / 2.0,
+                center.y() - shown.height() / 2.0, shown.width(),
+                shown.height())
+      .translated(viewOffset_);
+}
+
+qreal CaptureEditor::maxViewZoom() const {
+  const QRectF base = baseImageRect();
+  if (base.isEmpty() || selection_.width() <= 0)
+    return 1.0;
+  const qreal baseScale = base.width() / selection_.width();
+  return std::max<qreal>(1.0, 4.0 / std::max<qreal>(baseScale, 0.0001));
+}
+
+void CaptureEditor::clampViewOffset() {
+  const QRectF base = baseImageRect();
+  if (base.isEmpty())
+    return;
+  const QSizeF shown = base.size() * viewZoom_;
+  const QRectF available(30, 68, std::max(1, width() - 60),
+                         std::max(1, height() - 126));
+  // Keep the image covering the viewport where it is larger, and centered
+  // (no free pan) on any axis where it is smaller.
+  const auto clampAxis = [](qreal shownLen, qreal availLen, qreal &offset) {
+    if (shownLen <= availLen) {
+      offset = 0.0;
+      return;
+    }
+    const qreal slack = (shownLen - availLen) / 2.0;
+    offset = std::clamp(offset, -slack, slack);
+  };
+  clampAxis(shown.width(), available.width(), viewOffset_.rx());
+  clampAxis(shown.height(), available.height(), viewOffset_.ry());
+}
+
+void CaptureEditor::setViewZoom(qreal zoom, const QPointF &focus) {
+  const qreal clamped = std::clamp(zoom, 1.0, maxViewZoom());
+  if (qFuzzyCompare(clamped, viewZoom_))
+    return;
+  const QRectF before = editImageRect();
+  const qreal beforeScale = before.width() > 0 ? before.width() / selection_.width() : 1.0;
+  const QPointF imagePoint((focus.x() - before.left()) / std::max(beforeScale, 1e-6),
+                           (focus.y() - before.top()) / std::max(beforeScale, 1e-6));
+  viewZoom_ = clamped;
+  clampViewOffset();
+  const QRectF after = editImageRect();
+  const qreal afterScale = after.width() > 0 ? after.width() / selection_.width() : 1.0;
+  const QPointF mappedFocus(after.left() + imagePoint.x() * afterScale,
+                            after.top() + imagePoint.y() * afterScale);
+  viewOffset_ += focus - mappedFocus;
+  clampViewOffset();
+  updatePointerCursor();
+  update();
+}
+
+void CaptureEditor::panView(const QPointF &delta) {
+  if (viewZoom_ <= 1.0)
+    return;
+  viewOffset_ += delta;
+  clampViewOffset();
+  update();
+}
+
+void CaptureEditor::resetView() {
+  if (viewZoom_ == 1.0 && viewOffset_.isNull())
+    return;
+  viewZoom_ = 1.0;
+  viewOffset_ = {};
+  updatePointerCursor();
+  update();
 }
 
 QVector<QRectF> CaptureEditor::cropHandleRects() const {
@@ -1640,7 +1725,7 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   const qreal gap = 4 * scale;
   const qreal total = kToolbarWidth * scale;
   qreal x = (width() - total) / 2.0;
-  const qreal y = std::max<qreal>(10, editImageRect().top() - height - 10);
+  const qreal y = std::max<qreal>(10, chromeAnchorTop() - height - 10);
   auto add = [&](qreal buttonWidth, QString action, QString label,
                  QString tooltip, QColor color = {}) {
     const qreal scaledWidth = buttonWidth * scale;
@@ -2138,6 +2223,8 @@ void CaptureEditor::startCapture(CaptureMode mode, bool includeWindows) {
 void CaptureEditor::enterEdit(QString status) {
   phase_ = Phase::Edit;
   tool_ = Tool::Select;
+  viewZoom_ = 1.0;
+  viewOffset_ = {};
   setStatus(std::move(status));
   updatePointerCursor();
   if (quickOutputMode_ != QuickOutputMode::None) {
@@ -2616,6 +2703,35 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   const bool redoShortcut = event->matches(QKeySequence::Redo) ||
                             (event->key() == Qt::Key_Y &&
                              event->modifiers().testFlag(Qt::ControlModifier));
+  // Zoom keys. The bare keys work in the edit phase too, so zoom never
+  // depends on a modifier reaching us: a remote keyboard bridge may inject
+  // the modifier in a way the compositor never publishes as xkb state.
+  const bool zoomModifier =
+      event->modifiers().testFlag(Qt::ControlModifier) || phase_ == Phase::Edit;
+  if (event->matches(QKeySequence::ZoomIn) ||
+      (zoomModifier &&
+       (event->key() == Qt::Key_Plus || event->key() == Qt::Key_Equal))) {
+    setViewZoom(viewZoom_ * 1.25, editImageRect().center());
+    setStatus(QStringLiteral("Zoom %1% · + / - zoom · 0 fits · wheel scrolls")
+                  .arg(qRound(viewZoom_ *
+                              (baseImageRect().width() /
+                               std::max<qreal>(selection_.width(), 1)) *
+                              100)));
+    return;
+  } else if (event->matches(QKeySequence::ZoomOut) ||
+             (zoomModifier && (event->key() == Qt::Key_Minus ||
+                               event->key() == Qt::Key_Underscore))) {
+    setViewZoom(viewZoom_ / 1.25, editImageRect().center());
+    setStatus(QStringLiteral("Zoom %1% · + / - zoom · 0 fits · wheel scrolls")
+                  .arg(qRound(viewZoom_ *
+                              (baseImageRect().width() /
+                               std::max<qreal>(selection_.width(), 1)) *
+                              100)));
+    return;
+  } else if (zoomModifier && event->key() == Qt::Key_0) {
+    resetView();
+    return;
+  }
   if (redoShortcut) {
     redoEdit();
   } else if (event->matches(QKeySequence::Undo)) {
@@ -2645,6 +2761,26 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
              selectedAnnotation_ < annotations_.size() && !dragging_ &&
              !textEditor_->isVisible()) {
     nudgeSelectedAnnotation(nudge);
+  } else if (viewZoom_ > 1.0 && selectedAnnotation_ < 0 && !dragging_ &&
+             !textEditor_->isVisible() &&
+             !event->modifiers().testAnyFlags(Qt::ControlModifier |
+                                              Qt::AltModifier |
+                                              Qt::MetaModifier) &&
+             (event->key() == Qt::Key_Left || event->key() == Qt::Key_Right ||
+              event->key() == Qt::Key_Up || event->key() == Qt::Key_Down)) {
+    // With nothing selected the arrows have nothing else to do, so they walk
+    // the zoomed capture. It is the one way to reach the middle of a long
+    // capture without a middle mouse button. Shift takes a page at a time.
+    const qreal step =
+        event->modifiers().testFlag(Qt::ShiftModifier) ? 240.0 : 60.0;
+    const QPointF delta =
+        event->key() == Qt::Key_Left    ? QPointF(step, 0)
+        : event->key() == Qt::Key_Right ? QPointF(-step, 0)
+        : event->key() == Qt::Key_Up    ? QPointF(0, step)
+                                        : QPointF(0, -step);
+    panView(delta);
+    setStatus(QStringLiteral("Panning · arrows move, Shift jumps · middle-drag "
+                             "pans · Ctrl+0 fits"));
   } else if ((event->key() == Qt::Key_Delete ||
               event->key() == Qt::Key_Backspace) &&
              !selectedAnnotations_.isEmpty()) {
@@ -2790,6 +2926,11 @@ void CaptureEditor::keyReleaseEvent(QKeyEvent *event) {
 }
 
 void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
+  if (panning_) {
+    panView(event->position() - panAnchor_);
+    panAnchor_ = event->position();
+    return;
+  }
   cursor_ = event->position();
   if (capturePending_)
     return;
@@ -3053,6 +3194,14 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
         updatePointerCursor();
         update();
       }
+    }
+    return;
+  }
+  if (event->button() == Qt::MiddleButton) {
+    if (phase_ == Phase::Edit && viewZoom_ > 1.0) {
+      panning_ = true;
+      panAnchor_ = event->position();
+      setCursor(Qt::ClosedHandCursor);
     }
     return;
   }
@@ -3344,6 +3493,11 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
 }
 
 void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
+  if (event->button() == Qt::MiddleButton && panning_) {
+    panning_ = false;
+    updatePointerCursor();
+    return;
+  }
   if (capturePending_ || event->button() != Qt::LeftButton || !dragging_)
     return;
   if (phase_ == Phase::Select) {
@@ -3557,12 +3711,78 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
     QWidget::wheelEvent(event);
     return;
   }
-  // Some stacks report a modified wheel on the horizontal axis; read
-  // whichever axis moved.
-  const QPoint delta = event->angleDelta();
-  const int step = (delta.y() != 0 ? delta.y() : delta.x()) > 0 ? 1 : -1;
-  if (tool_ == Tool::Select && selectedAnnotation_ >= 0 &&
-      selectedAnnotation_ < annotations_.size()) {
+  // High-resolution touchpads can arrive with an empty angleDelta and only a
+  // pixelDelta; treat the two interchangeably, preferring the exact pixels
+  // for panning and the notch units for discrete steps.
+  const QPoint angle = event->angleDelta();
+  const QPoint pixel = event->pixelDelta();
+  const Qt::KeyboardModifiers modifiers = event->modifiers();
+  const int vertical = angle.y() != 0 ? angle.y() : pixel.y();
+  const int horizontal = angle.x() != 0 ? angle.x() : pixel.x();
+  if (vertical == 0 && horizontal == 0) {
+    event->accept();
+    return; // scroll begin/end markers carry no delta
+  }
+  // Discrete steps follow whichever axis carried the notch. Alt+wheel often
+  // arrives as a horizontal delta, so reading only the vertical one left every
+  // Alt-adjusted setting able to rise and never fall.
+  const int notch = vertical != 0 ? vertical : horizontal;
+  const int step = notch > 0 ? 1 : -1;
+  const bool overLayer = tool_ == Tool::Select && selectedAnnotation_ >= 0 &&
+                         selectedAnnotation_ < annotations_.size();
+  const auto showZoom = [&] {
+    setStatus(QStringLiteral("Zoom %1% · wheel scrolls · Ctrl+wheel zooms · "
+                             "arrows and middle-drag pan · Shift+wheel goes "
+                             "sideways · Ctrl+0 fits")
+                  .arg(qRound(viewZoom_ *
+                              (baseImageRect().width() /
+                               std::max<qreal>(selection_.width(), 1)) *
+                              100)));
+  };
+  // One notch is one step; a touchpad's finer increments are a fraction of
+  // one, so a swipe glides instead of leaping a quarter at a time.
+  const auto zoomByNotch = [&](const QPointF &focus) {
+    const qreal steps = std::clamp(qreal(notch) / 120.0, -1.0, 1.0);
+    setViewZoom(viewZoom_ * std::pow(1.25, steps), focus);
+    showZoom();
+  };
+  if (modifiers.testFlag(Qt::ControlModifier)) {
+    zoomByNotch(event->position());
+    event->accept();
+    return;
+  }
+  // Pan by the actual delta on both axes: a touchpad's sideways swipe arrives
+  // on x, and its fine increments must not each jump a step. Inert at fit.
+  const QPointF scrollDelta(
+      pixel.x() != 0 ? qreal(pixel.x()) : angle.x() * 0.75,
+      pixel.y() != 0 ? qreal(pixel.y()) : angle.y() * 0.75);
+  // Shift+wheel, or Alt+wheel, goes sideways across a wide stitch: the
+  // classic mapping of a vertical wheel to horizontal scrolling.
+  if (modifiers.testFlag(Qt::ShiftModifier) ||
+      (tool_ == Tool::Select && !overLayer &&
+       modifiers.testFlag(Qt::AltModifier))) {
+    if (viewZoom_ > 1.0)
+      panView(QPointF(scrollDelta.y() + scrollDelta.x(), 0));
+    event->accept();
+    return;
+  }
+  // A plain wheel scrolls a zoomed capture like a document. Where only the
+  // horizontal axis overflows, the vertical wheel scrolls that one rather
+  // than doing nothing.
+  if (tool_ == Tool::Select && !overLayer) {
+    if (viewZoom_ > 1.0) {
+      const QSizeF shown = baseImageRect().size() * viewZoom_;
+      const bool verticalSlack = shown.height() > std::max(1, height() - 126);
+      const bool horizontalSlack = shown.width() > std::max(1, width() - 60);
+      QPointF pan = scrollDelta;
+      if (!verticalSlack && horizontalSlack && pan.x() == 0.0)
+        pan = QPointF(pan.y(), 0);
+      panView(pan);
+    }
+    event->accept();
+    return;
+  }
+  if (overLayer) {
     scaleSelectedAnnotation(step > 0 ? 1.1 : 1.0 / 1.1);
   } else if (tool_ == Tool::Text) {
     textSizeIndex_ = std::clamp(textSizeIndex_ + step, 0, 2);
@@ -3816,6 +4036,13 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   painter.setCompositionMode(QPainter::CompositionMode_Source);
   painter.fillRect(rect(), QColor(0, 0, 0, 160));
   painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+  // When zoomed past fit the image is larger than the viewport; clip content
+  // to the band between the toolbar and the status so it cannot overdraw them.
+  const bool clipViewport = viewZoom_ > 1.0;
+  if (clipViewport) {
+    painter.save();
+    painter.setClipRect(QRectF(0, 60, width(), std::max(1, height() - 116)));
+  }
   const QRectF image = editImageRect();
   const bool hasBackground = backgroundStyle_ != BackgroundStyle::None;
   if (hasBackground) {
@@ -4117,6 +4344,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
                        QPointF(cursor.center().x(), bottom));
     }
   }
+  if (clipViewport)
+    painter.restore();
 
   const QString currentTool = toolAction(tool_);
   QFont buttonFont = QFontDatabase::systemFont(QFontDatabase::GeneralFont);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -242,8 +242,24 @@ private:
   [[nodiscard]] QRectF textSizePanelRect() const;
   [[nodiscard]] QVector<QRectF> cropHandleRects() const;
   [[nodiscard]] int cropHandleAt(const QPointF &point) const;
+  /// Fit-to-window rect for the selection (unaffected by the view zoom/pan).
+  [[nodiscard]] QRectF baseImageRect() const;
+  /// Top edge the chrome (toolbar, popovers) anchors above: the fit rect at
+  /// zoom 1, the viewport band once zoomed (the content fills it then).
+  [[nodiscard]] qreal chromeAnchorTop() const;
+  /// baseImageRect transformed by the current view zoom and pan (content and
+  /// annotations map through this). Equals baseImageRect at zoom 1.
   [[nodiscard]] QRectF editImageRect() const;
   [[nodiscard]] qreal editScale() const;
+  /// Multiplier from the fit scale to the largest useful zoom (1 source px ->
+  /// a few screen px); 1.0 when the image already fits comfortably.
+  [[nodiscard]] qreal maxViewZoom() const;
+  /// Set the view zoom (clamped to [1, maxViewZoom]) keeping `focus` (a widget
+  /// point) over the same image pixel; then re-clamp the pan.
+  void setViewZoom(qreal zoom, const QPointF &focus);
+  void panView(const QPointF &delta);
+  void resetView();
+  void clampViewOffset();
   [[nodiscard]] QPointF toAnnotationPoint(const QPointF &position) const;
   [[nodiscard]] QPointF toUnclampedAnnotationPoint(const QPointF &position) const;
   [[nodiscard]] bool selectedLayerAcceptsPoint(const QPointF &point) const;
@@ -430,6 +446,13 @@ private:
   QTimer textCaretTimer_;
   QElapsedTimer nudgeTimer_;
   QTimer nudgePersistTimer_;
+  /// View transform for navigating an oversized capture (e.g. a tall scroll
+  /// stitch). `viewZoom_` multiplies the fit scale (1 = whole image visible);
+  /// `viewOffset_` pans in widget pixels. Reset on entering edit.
+  qreal viewZoom_ = 1.0;
+  QPointF viewOffset_;
+  bool panning_ = false;
+  QPointF panAnchor_;
   QColor textColor_;
   QFutureWatcher<OcrResult> ocrWatcher_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 
 #include <LayerShellQt/Window>
 
+#include <QImageReader>
 #include <QApplication>
 #include <QCommandLineOption>
 #include <QCommandLineParser>
@@ -96,6 +97,10 @@ int main(int argc, char **argv) {
   qputenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell");
   QGuiApplication::setDesktopFileName(QStringLiteral("omasnap"));
   QApplication application(argc, argv);
+
+  // A stitched scroll capture (or any tall pinned image) exceeds Qt's default
+  // 256 MB image-decode allocation limit; lift it so --file/--pin can open it.
+  QImageReader::setAllocationLimit(0);
   PosixSignalNotifier signalNotifier(&application);
 
   QCommandLineParser parser;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4301,6 +4301,187 @@ bool runLayerOrderSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Runs the interaction and rendering smoke checks. */
+bool runViewportZoomSmoke(QApplication &application, QString &error) {
+  // A capture much taller than the window: fit shows it all (tiny); zoom in
+  // and pan to navigate it.
+  const QSize size(600, 6000);
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = QRect(QPoint(), size);
+  capture.monitor.pixelSize = size;
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(size, QImage::Format_ARGB32);
+  for (int y = 0; y < size.height(); ++y) {
+    QRgb *row = reinterpret_cast<QRgb *>(capture.source.scanLine(y));
+    for (int x = 0; x < size.width(); ++x)
+      row[x] = qRgb((x * 7) & 0xff, (y * 3) & 0xff, ((x + y) * 5) & 0xff);
+  }
+  capture.previewSize = capture.source.size();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  // Whole-monitor selection so the tall image fills the edit surface.
+  QTest::keyClick(&editor, Qt::Key_Space);
+  QTest::keyClick(&editor, Qt::Key_Space); // window mode toggles off if on
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(40, 80));
+  QTest::mouseMove(&editor, QPoint(760, 560), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(760, 560));
+  application.processEvents();
+
+  // Compare only the content band (exclude the toolbar row and the status
+  // line, which carry zoom text that is not part of the view).
+  const auto contentBand = [](const QImage &image) {
+    return image.copy(0, 80, image.width(), image.height() - 140);
+  };
+  const QImage fitView = contentBand(editor.grab().toImage());
+  const auto wheel = [&](int deltaY, Qt::KeyboardModifiers modifiers) {
+    QWheelEvent event(QPointF(400, 300), QPointF(400, 300), {}, {0, deltaY},
+                      Qt::NoButton, modifiers, Qt::NoScrollPhase, false);
+    QApplication::sendEvent(&editor, &event);
+    application.processEvents();
+  };
+  // Scrolling must never change the zoom: at fit, plain wheel and Shift+wheel
+  // are inert.
+  wheel(-120, Qt::NoModifier);
+  wheel(-120, Qt::ShiftModifier);
+  if (contentBand(editor.grab().toImage()) != fitView) {
+    error = QStringLiteral("Scrolling at fit changed the view");
+    return false;
+  }
+  // Ctrl+wheel is the zoom gesture.
+  wheel(360, Qt::ControlModifier);
+  const QImage zoomedView = contentBand(editor.grab().toImage());
+  if (zoomedView == fitView) {
+    error = QStringLiteral("Ctrl+wheel did not zoom the view");
+    return false;
+  }
+  // Plain wheel scrolls the zoomed view vertically.
+  wheel(-120, Qt::NoModifier);
+  const QImage pannedView = contentBand(editor.grab().toImage());
+  if (pannedView == zoomedView) {
+    error = QStringLiteral("Plain wheel did not scroll the zoomed view");
+    return false;
+  }
+  // Deep zoom gives horizontal slack; Shift+wheel then scrolls sideways.
+  for (int i = 0; i < 13; ++i)
+    wheel(120, Qt::ControlModifier);
+  const QImage deepView = contentBand(editor.grab().toImage());
+  wheel(-120, Qt::ShiftModifier);
+  if (contentBand(editor.grab().toImage()) == deepView) {
+    error = QStringLiteral("Shift+wheel did not scroll sideways when zoomed");
+    return false;
+  }
+  // Arrows pan the zoomed view when nothing is selected, which is how a long
+  // capture is walked without a middle mouse button.
+  {
+    const QImage beforeArrow = contentBand(editor.grab().toImage());
+    QTest::keyClick(&editor, Qt::Key_Down);
+    application.processEvents();
+    if (contentBand(editor.grab().toImage()) == beforeArrow) {
+      error = QStringLiteral("Arrow keys did not pan the zoomed view");
+      return false;
+    }
+    QTest::keyClick(&editor, Qt::Key_Up);
+    application.processEvents();
+    if (contentBand(editor.grab().toImage()) != beforeArrow) {
+      error = QStringLiteral("Arrow panning did not come back");
+      return false;
+    }
+  }
+
+  // Middle-drag also pans.
+  const QImage beforeDrag = contentBand(editor.grab().toImage());
+  QTest::mousePress(&editor, Qt::MiddleButton, Qt::NoModifier, QPoint(400, 300));
+  QTest::mouseMove(&editor, QPoint(400, 380), 20);
+  QTest::mouseRelease(&editor, Qt::MiddleButton, Qt::NoModifier, QPoint(400, 380));
+  application.processEvents();
+  if (contentBand(editor.grab().toImage()) == beforeDrag) {
+    error = QStringLiteral("Middle-drag did not pan the view");
+    return false;
+  }
+  // Ctrl+0 restores fit exactly.
+  QTest::keyClick(&editor, Qt::Key_0, Qt::ControlModifier);
+  application.processEvents();
+  if (contentBand(editor.grab().toImage()) != fitView) {
+    error = QStringLiteral("Ctrl+0 did not restore the fitted view");
+    return false;
+  }
+  // Placing an annotation while zoomed lands at the intended image point:
+  // zoom back in, draw a rectangle, fit, and confirm the layer persisted.
+  wheel(360, Qt::ControlModifier);
+  QTest::keyClick(&editor, Qt::Key_R);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 250));
+  QTest::mouseMove(&editor, QPoint(450, 400), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(450, 400));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_0, Qt::ControlModifier);
+  application.processEvents();
+  if (contentBand(editor.grab().toImage()) == fitView) {
+    error = QStringLiteral("A layer drawn while zoomed did not persist to fit");
+    return false;
+  }
+  editor.close();
+
+  // A wide capture whose full height fits: the plain vertical wheel scrolls
+  // the only overflowing axis (horizontal) instead of doing nothing.
+  {
+    const QSize wideSize(6000, 600);
+    CaptureData wide;
+    wide.monitor.name = QStringLiteral("TEST");
+    wide.monitor.geometry = QRect(QPoint(), wideSize);
+    wide.monitor.pixelSize = wideSize;
+    wide.monitor.scale = 1.0;
+    wide.source = QImage(wideSize, QImage::Format_ARGB32);
+    for (int y = 0; y < wideSize.height(); ++y) {
+      QRgb *row = reinterpret_cast<QRgb *>(wide.source.scanLine(y));
+      for (int x = 0; x < wideSize.width(); ++x)
+        row[x] = qRgb((x * 3) & 0xff, (y * 7) & 0xff, ((x ^ y) * 5) & 0xff);
+    }
+    wide.previewSize = wide.source.size();
+    CaptureEditor wideEditor(wide);
+    wideEditor.resize(800, 600);
+    wideEditor.show();
+    application.processEvents();
+    QTest::keyClick(&wideEditor, Qt::Key_Space);
+    QTest::keyClick(&wideEditor, Qt::Key_Space);
+    QTest::mousePress(&wideEditor, Qt::LeftButton, Qt::NoModifier, QPoint(40, 80));
+    QTest::mouseMove(&wideEditor, QPoint(760, 560), 20);
+    QTest::mouseRelease(&wideEditor, Qt::LeftButton, Qt::NoModifier, QPoint(760, 560));
+    application.processEvents();
+    const auto wideWheel = [&](int deltaY, Qt::KeyboardModifiers modifiers) {
+      QWheelEvent event(QPointF(400, 300), QPointF(400, 300), {}, {0, deltaY},
+                        Qt::NoButton, modifiers, Qt::NoScrollPhase, false);
+      QApplication::sendEvent(&wideEditor, &event);
+      application.processEvents();
+    };
+    for (int i = 0; i < 6; ++i)
+      wideWheel(120, Qt::ControlModifier);
+    const QImage zoomedWide = contentBand(wideEditor.grab().toImage());
+    wideWheel(-120, Qt::NoModifier);
+    if (contentBand(wideEditor.grab().toImage()) == zoomedWide) {
+      error = QStringLiteral(
+          "Plain wheel did not scroll a wide capture sideways");
+      return false;
+    }
+    // A horizontal touchpad swipe (x-axis delta) scrolls sideways too.
+    const QImage beforeSwipe = contentBand(wideEditor.grab().toImage());
+    QWheelEvent swipe(QPointF(400, 300), QPointF(400, 300), {}, {120, 0},
+                      Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+    QApplication::sendEvent(&wideEditor, &swipe);
+    application.processEvents();
+    if (contentBand(wideEditor.grab().toImage()) == beforeSwipe) {
+      error = QStringLiteral(
+          "A horizontal wheel delta did not scroll the wide capture");
+      return false;
+    }
+    wideEditor.close();
+  }
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -4371,6 +4552,47 @@ int main(int argc, char **argv) {
   if (!runLayerOrderSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 122;
+  }
+  {
+    // A notch that arrives on the horizontal axis (Alt+wheel does, on some
+    // setups) must step both ways. Reading only the vertical delta left every
+    // Alt-adjusted setting able to rise and never fall.
+    CaptureData capture;
+    capture.monitor.name = QStringLiteral("TEST");
+    capture.monitor.geometry = {0, 0, 800, 600};
+    capture.monitor.pixelSize = {800, 600};
+    capture.monitor.scale = 1.0;
+    capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+    capture.source.fill(QColor(QStringLiteral("#182030")));
+    capture.previewSize = capture.source.size();
+    CaptureEditor editor(capture, CaptureEditor::CaptureMode::Fullscreen);
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::keyClick(&editor, Qt::Key_A); // a tool whose wheel sets its size
+    application.processEvents();
+    const auto sideways = [&](int deltaX) {
+      QWheelEvent event(QPointF(400, 300), QPointF(400, 300), {}, {deltaX, 0},
+                        Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+      QApplication::sendEvent(&editor, &event);
+      application.processEvents();
+      return editor.statusForTest();
+    };
+    const QString up = sideways(120);
+    const QString down = sideways(-120);
+    // One notch each way must land back where it started, not climb twice.
+    if (!up.contains(QStringLiteral("Size 5")) ||
+        !down.contains(QStringLiteral("Size 4"))) {
+      qWarning().noquote()
+          << QStringLiteral("A horizontal notch stepped only one way: up=") +
+                 up + QStringLiteral(" down=") + down;
+      return 116;
+    }
+    editor.close();
+  }
+  if (!runViewportZoomSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 123;
   }
   if (!runAsyncCaptureRegionSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
A tall or wide capture, a pinned panorama or a long page, gets crushed to an unreadable sliver by fit-to-window with no way to look closer.

This adds a view transform on top of the fit: a zoom multiplier (1 = whole image visible, up to roughly 4 screen px per source pixel) and a pan offset, folded into `editImageRect()` so annotations, hit-testing and rendering map through it without knowing about it. Chrome anchors to a separate fit-only `baseImageRect()`, and once zoomed it anchors above the viewport band so it never floats over the content.

Gestures are picked so scrolling never changes the zoom:

- `Ctrl+wheel` and `Ctrl+plus`/`minus` zoom about the cursor, keeping that image pixel under it; `Ctrl+0` fits
- a plain wheel scrolls a zoomed capture and `Shift+wheel` goes sideways, both inert at fit; a selected layer still scales and a drawing tool still adjusts its size
- bare `+` / `-` / `0` zoom, and arrows pan with nothing selected, so it's navigable from the keyboard alone
- middle-drag pans, clamped so the image covers the viewport where it's larger and stays centered where it's smaller

Two input details worth a look. Wheel handling takes `pixelDelta` as well as `angleDelta`, since high-resolution touchpads can send only pixels, and ignores the zero-delta begin/end markers. And a discrete step follows whichever axis carried the notch, because `Alt+wheel` arrives as a horizontal delta on some setups, and reading only the vertical one leaves every Alt-adjusted setting able to go up and never come back down.

`main()` also lifts `QImageReader`'s 256 MB decode limit, without which a tall capture can't be opened by `--file` or `--pin` at all.

Exit 116 checks a horizontal notch each way lands back where it started. Exit 111 runs a 600x6000 capture through zoom, pan, middle-drag, `Ctrl+0` restoring the fit exactly, scrolling inert at fit, and a rectangle drawn while zoomed surviving the return to fit.
