### PR TITLE
feat(editor): the wheel sets a selected layer's weight, not its size

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -70,6 +70,10 @@ constexpr qreal kNudgeStepShift = 10.0;
 /// Arrow presses closer together than this share one undo entry, so a held
 /// key reads as one move.
 constexpr qint64 kNudgeCoalesceMs = 100;
+/// How long after the last wheel notch the selection chrome stays faint. Long
+/// enough to cover a run of notches, short enough that it is back before the
+/// hand has left the wheel.
+constexpr int kAdjustSettleMs = 400;
 
 qreal toolbarScale(qreal availableWidth) {
   constexpr qreal sideMargins = 16.0;
@@ -688,6 +692,12 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     setStatus(QStringLiteral("Window mode · click or Super+Arrows then Enter · "
                              "Space returns to area"));
   }
+  adjustSettleTimer_.setSingleShot(true);
+  adjustSettleTimer_.setInterval(kAdjustSettleMs);
+  connect(&adjustSettleTimer_, &QTimer::timeout, this, [this] {
+    adjustingSelection_ = false;
+    update();
+  });
   updatePointerCursor();
 }
 
@@ -1237,51 +1247,91 @@ void CaptureEditor::duplicateSelectedAnnotation() {
   setStatus(QStringLiteral("Duplicated · Alt+D again offsets further"));
 }
 
-void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
+bool CaptureEditor::adjustSelectedAnnotationRing(int step) {
+  // Alt+wheel is the secondary control, and with a layer selected it belongs
+  // to that layer rather than to what the next one will look like. Kinds with
+  // no second setting say so, and the wheel falls through to the armed tool.
+  beginSelectionAdjust();
+  if (selectedAnnotation_ < 0 || selectedAnnotation_ >= annotations_.size())
+    return false;
+  Annotation &annotation = annotations_[selectedAnnotation_];
+  if (annotation.kind != Annotation::Kind::Spotlight)
+    return false;
+  annotation.size = std::clamp(annotation.size + step * 2.0, 0.0, 12.0);
+  setStatus(spotlightStatus(annotation.spotlightShape,
+                            annotation.magnification, annotation.size));
+  commitPatch({selectedAnnotation_});
+  return true;
+}
+
+void CaptureEditor::beginSelectionAdjust() {
+  adjustingSelection_ = true;
+  adjustSettleTimer_.start();
+}
+
+void CaptureEditor::adjustSelectedAnnotation(int step) {
+  // The wheel is the weight control: a layer keeps the shape and the place it
+  // was drawn in, and only gets heavier or lighter. How big it is belongs to
+  // the corner handle, where Shift keeps the proportions: one gesture each,
+  // so neither has to be undone to reach the other.
+  beginSelectionAdjust();
   if (selectedAnnotation_ < 0 || selectedAnnotation_ >= annotations_.size())
     return;
   Annotation &annotation = annotations_[selectedAnnotation_];
-  if (annotation.kind == Annotation::Kind::Spotlight) {
+  const auto weigh = [step](qreal size, qreal lowest, qreal highest) {
+    return std::clamp(size + step, lowest, highest);
+  };
+  switch (annotation.kind) {
+  case Annotation::Kind::Spotlight:
     annotation.magnification =
-        std::clamp(annotation.magnification * factor, 1.0, 4.0);
+        std::clamp(annotation.magnification + step * 0.25, 1.0, 4.0);
     setStatus(spotlightStatus(annotation.spotlightShape,
                               annotation.magnification, annotation.size));
     commitPatch({selectedAnnotation_});
     return;
-  }
-  const QPointF center = annotationBounds(annotation).center();
-  qreal geometryFactor = factor;
-  if (annotation.kind == Annotation::Kind::Redaction) {
+  case Annotation::Kind::Marker:
+    // A counter has no stroke to weigh: its size is the counter itself.
+    annotation.size = weigh(annotation.size, 2.0, 30.0);
+    setStatus(QStringLiteral("Counter %1 · size %2 · wheel resizes")
+                  .arg(annotation.number)
+                  .arg(qRound(annotation.size)));
+    commitPatch({selectedAnnotation_});
+    return;
+  case Annotation::Kind::Text:
+    // Type has no stroke either; its weight is its size.
+    annotation.size = weigh(annotation.size, 1.0, 24.0);
+    setStatus(QStringLiteral("Selected text · size %1 · wheel resizes")
+                  .arg(qRound(annotation.size)));
+    commitPatch({selectedAnnotation_});
+    return;
+  case Annotation::Kind::Redaction: {
+    // A cover-up is all fill, so the only thing its wheel can mean is how
+    // much it covers.
+    const qreal factor = step > 0 ? 1.1 : 1.0 / 1.1;
     const QRectF bounds = annotationBounds(annotation);
-    if (bounds.width() > 0 && bounds.height() > 0) {
-      geometryFactor =
-          std::max({factor, kMinimumRedactionExtent / bounds.width(),
-                    kMinimumRedactionExtent / bounds.height()});
-    }
+    const QPointF center = bounds.center();
+    const qreal scale =
+        bounds.width() > 0 && bounds.height() > 0
+            ? std::max({factor, kMinimumRedactionExtent / bounds.width(),
+                        kMinimumRedactionExtent / bounds.height()})
+            : factor;
+    annotation.start = center + (annotation.start - center) * scale;
+    annotation.end = center + (annotation.end - center) * scale;
+    setStatus(QStringLiteral("Redaction · %1%").arg(qRound(scale * 100)));
+    commitPatch({selectedAnnotation_});
+    return;
   }
-  const auto scaledPoint = [center, geometryFactor](const QPointF &point) {
-    return center + (point - center) * geometryFactor;
-  };
-  if (hasEndpointHandles(annotation.kind)) {
-    annotation.start = scaledPoint(annotation.start);
-    annotation.end = scaledPoint(annotation.end);
-    annotation.size = std::clamp(annotation.size * geometryFactor, 2.0, 30.0);
-  } else if (isStrokeKind(annotation.kind)) {
-    for (QPointF &point : annotation.points)
-      point = scaledPoint(point);
-    if (!annotation.points.isEmpty()) {
-      annotation.start = annotation.points.first();
-      annotation.end = annotation.points.last();
-    }
-    annotation.size = std::clamp(annotation.size * factor, 2.0, 30.0);
-  } else if (annotation.kind == Annotation::Kind::Marker) {
-    annotation.size = std::clamp(annotation.size * factor, 2.0, 30.0);
-  } else if (annotation.kind == Annotation::Kind::Text) {
-    annotation.size = std::clamp(annotation.size * factor, 1.0, 24.0);
-    annotation.start += center - annotationBounds(annotation).center();
+  case Annotation::Kind::Arrow:
+  case Annotation::Kind::Line:
+  case Annotation::Kind::Freehand:
+  case Annotation::Kind::Highlighter:
+  case Annotation::Kind::Rectangle:
+  case Annotation::Kind::Ellipse:
+    break;
   }
-  setStatus(QStringLiteral("Selected layer · wheel zoom %1%")
-                .arg(qRound(factor * 100)));
+  annotation.size = weigh(annotation.size, 2.0, 30.0);
+  setStatus(QStringLiteral("Selected layer · thickness %1 · handle resizes")
+                .arg(qRound(annotation.size)));
   commitPatch({selectedAnnotation_});
 }
 
@@ -3728,8 +3778,16 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
   // Alt-adjusted setting able to rise and never fall.
   const int notch = vertical != 0 ? vertical : horizontal;
   const int step = notch > 0 ? 1 : -1;
-  const bool overLayer = tool_ == Tool::Select && selectedAnnotation_ >= 0 &&
-                         selectedAnnotation_ < annotations_.size();
+  // A selected layer owns the plain wheel whatever tool is armed. Selecting a
+  // layer to adjust it is the same gesture as selecting it to move it, and the
+  // tool still in hand should not change the answer, and the color keys
+  // already act on the selection this way. The spotlight tool keeps its own
+  // wheel,
+  // which deliberately follows the spotlight under the pointer.
+  const bool layerSelected = selectedAnnotation_ >= 0 &&
+                             selectedAnnotation_ < annotations_.size();
+  const bool overLayer = layerSelected && tool_ != Tool::Spotlight &&
+                         !modifiers.testFlag(Qt::AltModifier);
   const auto showZoom = [&] {
     setStatus(QStringLiteral("Zoom %1% · wheel scrolls · Ctrl+wheel zooms · "
                              "arrows and middle-drag pan · Shift+wheel goes "
@@ -3759,7 +3817,7 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
   // Shift+wheel, or Alt+wheel, goes sideways across a wide stitch: the
   // classic mapping of a vertical wheel to horizontal scrolling.
   if (modifiers.testFlag(Qt::ShiftModifier) ||
-      (tool_ == Tool::Select && !overLayer &&
+      (tool_ == Tool::Select && !layerSelected &&
        modifiers.testFlag(Qt::AltModifier))) {
     if (viewZoom_ > 1.0)
       panView(QPointF(scrollDelta.y() + scrollDelta.x(), 0));
@@ -3769,7 +3827,7 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
   // A plain wheel scrolls a zoomed capture like a document. Where only the
   // horizontal axis overflows, the vertical wheel scrolls that one rather
   // than doing nothing.
-  if (tool_ == Tool::Select && !overLayer) {
+  if (tool_ == Tool::Select && !layerSelected) {
     if (viewZoom_ > 1.0) {
       const QSizeF shown = baseImageRect().size() * viewZoom_;
       const bool verticalSlack = shown.height() > std::max(1, height() - 126);
@@ -3782,8 +3840,15 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
     event->accept();
     return;
   }
+  // A selected layer owns Alt+wheel too: its ring, its corners.
+  if (layerSelected && modifiers.testFlag(Qt::AltModifier) &&
+      adjustSelectedAnnotationRing(step)) {
+    event->accept();
+    update();
+    return;
+  }
   if (overLayer) {
-    scaleSelectedAnnotation(step > 0 ? 1.1 : 1.0 / 1.1);
+    adjustSelectedAnnotation(step);
   } else if (tool_ == Tool::Text) {
     textSizeIndex_ = std::clamp(textSizeIndex_ + step, 0, 2);
     setStatus(QStringLiteral("Neucha · size %1 · wheel changes size")
@@ -4217,6 +4282,10 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         (multiple ? selectedAnnotationsBounds()
                   : annotationBounds(annotations_.at(selectedAnnotation_)))
             .adjusted(-4, -4, 4, 4);
+    // Faint while a wheel adjustment is in flight: the handles sit exactly
+    // where the change shows, so at full strength they hide it.
+    const qreal chromeOpacity = adjustingSelection_ ? 0.25 : 1.0;
+    painter.setOpacity(chromeOpacity);
     if (multiple ||
         showsSelectionBounds(annotations_.at(selectedAnnotation_).kind)) {
       // The union reads as the group's extent, so draw it faintly and outline
@@ -4259,6 +4328,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       for (const auto &[position, handle] : annotationHandles(selected))
         painter.drawEllipse(position, radius, radius);
     }
+    painter.setOpacity(1.0);
   }
   painter.restore();
 

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -213,6 +213,11 @@ public:
   }
   /// Current status line. Test accessor.
   [[nodiscard]] QString statusForTest() const { return status_; }
+  /// Whether the selection chrome is currently stepped back for an adjustment.
+  /// Test accessor.
+  [[nodiscard]] bool selectionFadedForTest() const {
+    return adjustingSelection_;
+  }
 
 private:
   /// What the armed tool is currently set to, for the status line: shown on
@@ -308,11 +313,22 @@ private:
   void refreshComposedCapture(const CutOp *liveCut = nullptr);
   void runOcr(const QRectF &localSelection = {});
   void setStatus(QString status);
-  void scaleSelectedAnnotation(qreal factor);
   void toggleShapeFill();
   void toggleTextBackground();
   void nudgeSelectedAnnotation(const QPointF &delta);
   void endNudgeRun();
+  /// Wheel over a selected layer: weight, not size. Thickness for anything
+  /// with a stroke, the counter or text's own size, magnification for a
+  /// spotlight, extent for the one kind that is all fill.
+  void adjustSelectedAnnotation(int step);
+  /// Alt+wheel on the selected layer: a spotlight's ring. False when the layer
+  /// has no second setting to move.
+  bool adjustSelectedAnnotationRing(int step);
+  /// Starts (or extends) the window in which the selection chrome steps back
+  /// so a wheel adjustment can be seen. The handles sit exactly where a
+  /// corner radius or a spotlight's ring changes, so at full strength they
+  /// hide the thing being adjusted.
+  void beginSelectionAdjust();
   void undoEdit();
   void updatePointerCursor();
 
@@ -370,6 +386,10 @@ private:
   qreal annotationSize_ = 4.0;
   bool fillShapes_ = false;
   qreal cornerRadius_ = 0.0;
+  /// True while a wheel adjustment is in flight; the selection chrome draws
+  /// faintly until it settles.
+  bool adjustingSelection_ = false;
+  QTimer adjustSettleTimer_;
   int textSizeIndex_ = 1;
   TextBackground textBackground_ = TextBackground::Pill;
   qreal spotlightMagnification_ = 2.0;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4482,6 +4482,101 @@ bool runViewportZoomSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Checks that the wheel over a selected layer changes its weight, not its
+ *  extent: a stroke gets heavier where it already is, and resizing stays with
+ *  the corner handle. */
+bool runLayerWeightSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  const QString snapshotPath = temporarySnapshotPath();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  // 600x400 selection shown 1:1 at widget offset (100, 105).
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(700, 500));
+  application.processEvents();
+  const auto wheel = [&](int notches) {
+    for (int notch = 0; notch < std::abs(notches); ++notch) {
+      QWheelEvent event(QPointF(400, 300), QPointF(400, 300), {},
+                        {0, notches > 0 ? 120 : -120}, Qt::NoButton,
+                        Qt::NoModifier, Qt::NoScrollPhase, false);
+      QApplication::sendEvent(&editor, &event);
+    }
+    application.processEvents();
+  };
+  const auto ink = [](const QImage &image, int x, int y) {
+    return image.pixelColor(x, y) != QColor(QStringLiteral("#182030"));
+  };
+
+  // A rectangle at annotation (100,95)-(300,195), stroke 4.
+  QTest::keyClick(&editor, Qt::Key_R);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 200));
+  QTest::mouseMove(&editor, QPoint(400, 300), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(400, 300));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 250));
+  application.processEvents();
+  {
+    const QImage drawn = flushedSnapshot(editor, snapshotPath);
+    if (!ink(drawn, 100, 145) || ink(drawn, 105, 145)) {
+      error = QStringLiteral("Weight smoke: the stroke is not where expected");
+      return false;
+    }
+  }
+  // Four notches take the stroke from 4 to 8: it thickens about the same
+  // outline, so the left edge stays at x 100 and now reaches x 103. Scaling
+  // instead would have carried that edge out to x 54.
+  wheel(4);
+  {
+    const QImage heavier = flushedSnapshot(editor, snapshotPath);
+    if (!ink(heavier, 100, 145) || !ink(heavier, 103, 145)) {
+      error = QStringLiteral("The wheel did not thicken the selected layer");
+      return false;
+    }
+    if (ink(heavier, 54, 145)) {
+      error = QStringLiteral("The wheel resized the layer instead of "
+                             "thickening it");
+      return false;
+    }
+  }
+  wheel(-4);
+  {
+    const QImage lighter = flushedSnapshot(editor, snapshotPath);
+    if (!ink(lighter, 100, 145) || ink(lighter, 105, 145)) {
+      error = QStringLiteral("The wheel did not thin the layer back down");
+      return false;
+    }
+  }
+  // The chrome steps back while the wheel is turning, because the handles sit
+  // where the change shows, and comes back once it settles.
+  wheel(2);
+  if (!editor.selectionFadedForTest()) {
+    error = QStringLiteral("Selection chrome did not step back for the wheel");
+    return false;
+  }
+  QTest::qWait(600);
+  application.processEvents();
+  if (editor.selectionFadedForTest()) {
+    error = QStringLiteral("Selection chrome stayed faint after the wheel "
+                           "settled");
+    return false;
+  }
+  editor.close();
+  QFile::remove(snapshotPath);
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -4593,6 +4688,10 @@ int main(int argc, char **argv) {
   if (!runViewportZoomSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 123;
+  }
+  if (!runLayerWeightSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 118;
   }
   if (!runAsyncCaptureRegionSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
> Stacked on #67, which it needs for the wheel handling. The diff below has that commit in it; only the second one is this PR. I'll rebase once it lands.

Turning the wheel on a selected layer kept its shape and just made it bigger or smaller, which is what the corner handle is already for. It changes weight now:

- a stroke thickens where it is, rather than moving
- a counter or a text takes its own size
- a spotlight takes its magnification
- a redaction, the one kind that's all fill, keeps growing, since covering more is the only thing its wheel can mean

`Alt+wheel` goes to the selected layer too, adjusting whatever second setting that kind has: a spotlight's ring, a rectangle's corners. Kinds without one let the wheel fall through to the armed tool.

The selection chrome also steps back while the wheel turns, drawing at 25% and coming back 400 ms after the last notch. The handles sit exactly where a spotlight's ring or a rectangle's corners change, so at full strength they hide what you're adjusting. Those two numbers are a taste call.

The selection owns the wheel whatever tool is armed, the way the color keys already do.

`runLayerWeightSmoke` (exit 118) covers each kind's wheel, `Alt+wheel` reaching the second setting, the chrome fading and coming back, and the selection winning the wheel from a drawing tool.
