### PR TITLE
feat(scroll): capture a scrolling region and stitch it (--scroll)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ add_library(omasnap-core STATIC
   src/eyedropper.cpp
   src/eyedropper.hpp
   src/surface-capture.cpp
+  src/stitch.cpp
+  src/stitch.hpp
+  src/auto-capture.cpp
+  src/auto-capture.hpp
   ${PROTOCOL_SOURCES}
   src/editor.cpp
   src/editor.hpp
@@ -99,6 +103,12 @@ qt_add_executable(omasnap-smoke
   tests/pin-lifecycle-smoke.hpp
   tests/pin-layout-smoke.cpp
   tests/pin-layout-smoke.hpp
+  src/stitch.cpp
+  src/stitch.hpp
+  src/auto-capture.cpp
+  src/auto-capture.hpp
+  tests/stitch-smoke.cpp
+  tests/stitch-smoke.hpp
 )
 target_include_directories(omasnap-smoke PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/tests"
@@ -108,6 +118,18 @@ target_link_libraries(omasnap-smoke PRIVATE omasnap-core Qt6::Test)
 add_test(NAME omasnap-smoke COMMAND omasnap-smoke "${CMAKE_CURRENT_BINARY_DIR}/omasnap-smoke-output")
 set_tests_properties(omasnap-smoke PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endif()
+
+qt_add_executable(stitch-replay
+  src/stitch-replay.cpp
+  src/stitch.cpp
+  src/stitch.hpp
+)
+target_include_directories(stitch-replay PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/src"
+)
+target_compile_features(stitch-replay PRIVATE cxx_std_23)
+target_compile_options(stitch-replay PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(stitch-replay PRIVATE Qt6::Core Qt6::Gui)
 
 install(TARGETS omasnap
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(PROTOCOL_XMLS
   /usr/share/wayland-protocols/staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml
   /usr/share/wayland-protocols/staging/ext-image-capture-source/ext-image-capture-source-v1.xml
   /usr/share/wayland-protocols/staging/ext-image-copy-capture/ext-image-copy-capture-v1.xml
+  ${CMAKE_CURRENT_SOURCE_DIR}/protocols/wlr-virtual-pointer-unstable-v1.xml
 )
 set(PROTOCOL_SOURCES)
 foreach(PROTOCOL_XML IN LISTS PROTOCOL_XMLS)
@@ -48,6 +49,8 @@ add_library(omasnap-core STATIC
   src/cut.hpp
   src/palette-config.cpp
   src/palette-config.hpp
+  src/overlay-chrome.cpp
+  src/overlay-chrome.hpp
   src/eyedropper.cpp
   src/eyedropper.hpp
   src/surface-capture.cpp
@@ -55,6 +58,10 @@ add_library(omasnap-core STATIC
   src/stitch.hpp
   src/auto-capture.cpp
   src/auto-capture.hpp
+  src/scroll-capture.cpp
+  src/scroll-capture.hpp
+  src/scroll-inject.cpp
+  src/scroll-inject.hpp
   ${PROTOCOL_SOURCES}
   src/editor.cpp
   src/editor.hpp
@@ -97,6 +104,12 @@ qt_add_executable(omasnap-smoke
   tests/cut-smoke.hpp
   tests/palette-config-smoke.cpp
   tests/palette-config-smoke.hpp
+  src/cli-path.cpp
+  src/cli-path.hpp
+  src/capture.cpp
+  src/capture.hpp
+  src/overlay-chrome.cpp
+  src/overlay-chrome.hpp
   tests/surface-capture-smoke.cpp
   tests/surface-capture-smoke.hpp
   tests/pin-lifecycle-smoke.cpp

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ omasnap --capture-window
 omasnap --capture-fullscreen
 ```
 
+Scroll capture stitches a region that is taller (or wider) than the screen:
+
+```bash
+omasnap --scroll
+```
+
+Drag a region, then pick a direction: **Scroll ↓ / →** scrolls the page
+yourself while omasnap captures each step, and **Auto ↓ / →** scrolls it for
+you, one acknowledged notch at a time, stopping when the page stops moving.
+The frames are aligned and stitched into one image and opened in the editor,
+where `Ctrl`+wheel zooms and the wheel scrolls it.
+
 Compatibility positional names are also accepted:
 
 ```bash

--- a/protocols/wlr-virtual-pointer-unstable-v1.xml
+++ b/protocols/wlr-virtual-pointer-unstable-v1.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_virtual_pointer_unstable_v1">
+  <copyright>
+    Copyright © 2019 Josef Gajdusek
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_virtual_pointer_v1" version="2">
+    <description summary="virtual pointer">
+      This protocol allows clients to emulate a physical pointer device. The
+      requests are mostly mirror opposites of those specified in wl_pointer.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_axis" value="0"
+        summary="client sent invalid axis enumeration value" />
+      <entry name="invalid_axis_source" value="1"
+        summary="client sent invalid axis source enumeration value" />
+    </enum>
+
+    <request name="motion">
+      <description summary="pointer relative motion event">
+        The pointer has moved by a relative amount to the previous request.
+
+        Values are in the global compositor space.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="dx" type="fixed" summary="displacement on the x-axis"/>
+      <arg name="dy" type="fixed" summary="displacement on the y-axis"/>
+    </request>
+
+    <request name="motion_absolute">
+      <description summary="pointer absolute motion event">
+        The pointer has moved in an absolute coordinate frame.
+
+        Value of x can range from 0 to x_extent, value of y can range from 0
+        to y_extent.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="x" type="uint" summary="position on the x-axis"/>
+      <arg name="y" type="uint" summary="position on the y-axis"/>
+      <arg name="x_extent" type="uint" summary="extent of the x-axis"/>
+      <arg name="y_extent" type="uint" summary="extent of the y-axis"/>
+    </request>
+
+    <request name="button">
+      <description summary="button event">
+        A button was pressed or released.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="button" type="uint" summary="button that produced the event"/>
+      <arg name="state" type="uint" enum="wl_pointer.button_state" summary="physical state of the button"/>
+    </request>
+
+    <request name="axis">
+      <description summary="axis event">
+        Scroll and other axis requests.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+    </request>
+
+    <request name="frame">
+      <description summary="end of a pointer event sequence">
+        Indicates the set of events that logically belong together.
+      </description>
+    </request>
+
+    <request name="axis_source">
+      <description summary="axis source event">
+        Source information for scroll and other axis.
+      </description>
+      <arg name="axis_source" type="uint" enum="wl_pointer.axis_source" summary="source of the axis event"/>
+    </request>
+
+    <request name="axis_stop">
+      <description summary="axis stop event">
+        Stop notification for scroll and other axes.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="the axis stopped with this event"/>
+    </request>
+
+    <request name="axis_discrete">
+      <description summary="axis click event">
+        Discrete step information for scroll and other axes.
+
+        This event allows the client to extend data normally sent using the axis
+        event with discrete value.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+      <arg name="discrete" type="int" summary="number of steps"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer object"/>
+    </request>
+  </interface>
+
+  <interface name="zwlr_virtual_pointer_manager_v1" version="2">
+    <description summary="virtual pointer manager">
+      This object allows clients to create individual virtual pointer objects.
+    </description>
+
+    <request name="create_virtual_pointer">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The optional seat is a suggestion to the
+        compositor.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer manager"/>
+    </request>
+
+    <!-- Version 2 additions -->
+    <request name="create_virtual_pointer_with_output" since="2">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The seat and the output arguments are
+        optional. If the seat argument is set, the compositor should assign the
+        input device to the requested seat. If the output argument is set, the
+        compositor should map the input device to the requested output.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/src/auto-capture.cpp
+++ b/src/auto-capture.cpp
@@ -1,0 +1,413 @@
+/** @fileoverview Automatic scroll capture decision loop (see auto-capture.hpp). */
+#include "auto-capture.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <thread>
+
+namespace stitch {
+
+namespace {
+/// Poll granularity while the worker waits for an acknowledgement.
+constexpr int kAckPollMs = 5;
+/// A solid-colour first frame is the copy racing the overlay's paint; it must
+/// never seed the stitcher.
+constexpr int kMaxBlankFirstFrames = 8;
+constexpr int kCalibrationWindow = 5;
+constexpr int kCalibrationMinSamples = 3;
+constexpr int kCalibrationMinJitter = 4;
+constexpr int kCalibrationJitterPercent = 5;
+
+bool imageIsUniform(const QImage &image) {
+  if (image.isNull())
+    return true;
+  const QRgb first = image.pixel(0, 0);
+  const int stepX = std::max(1, image.width() / 64);
+  const int stepY = std::max(1, image.height() / 64);
+  for (int y = 0; y < image.height(); y += stepY)
+    for (int x = 0; x < image.width(); x += stepX)
+      if (image.pixel(x, y) != first)
+        return false;
+  return true;
+}
+} // namespace
+
+// --- AutoStepCalibration ------------------------------------------------------
+
+void AutoStepCalibration::recordVerifiedNormalStep(int delta) {
+  if (delta == 0)
+    return;
+  recent_.push_back(delta);
+  if (static_cast<int>(recent_.size()) > kCalibrationWindow)
+    recent_.erase(recent_.begin());
+}
+
+std::optional<int> AutoStepCalibration::endpointUpperBound() const {
+  if (static_cast<int>(recent_.size()) < kCalibrationMinSamples)
+    return std::nullopt;
+  std::vector<int> sorted = recent_;
+  std::sort(sorted.begin(), sorted.end());
+  const int median = sorted[sorted.size() / 2];
+  const int percentageJitter =
+      (median * kCalibrationJitterPercent + 99) / 100; // ceil of 5%
+  const int jitter = std::max(percentageJitter, kCalibrationMinJitter);
+  if (sorted.back() - sorted.front() > jitter)
+    return std::nullopt;
+  return sorted.back() + jitter;
+}
+
+// --- CaptureHandshake ---------------------------------------------------------
+
+void CaptureHandshake::acknowledgeWithNotches(std::uint64_t cycle, int notches) {
+  const std::uint64_t published = readyCycle();
+  const std::uint64_t clamped = std::min(cycle, published);
+  const std::lock_guard lock(mutex_);
+  // The first acknowledgement of a cycle wins; duplicates are ignored so a
+  // repeated UI event cannot double-scroll.
+  if (clamped <= ackCycle_)
+    return;
+  ackCycle_ = clamped;
+  ackNotches_ = std::clamp(notches, 1, kNotchesPerTick);
+  ackConsumed_ = false;
+}
+
+std::optional<int>
+CaptureHandshake::waitForCapture(std::uint64_t cycle,
+                                 const std::atomic<bool> &stop) {
+  while (true) {
+    if (stop.load(std::memory_order_acquire))
+      return std::nullopt;
+    {
+      const std::lock_guard lock(mutex_);
+      if (ackCycle_ >= cycle && !ackConsumed_) {
+        ackConsumed_ = true;
+        return ackNotches_;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(kAckPollMs));
+  }
+}
+
+// --- autoProbeDecision --------------------------------------------------------
+
+AutoProbeDecision
+autoProbeDecision(const ForwardLookaheadResolution &resolution,
+                  int priorStationaryProbes,
+                  std::optional<ForwardMatchCandidate> calibratedEnd) {
+  AutoProbeDecision decision;
+  switch (resolution.tag) {
+  case ForwardLookaheadResolution::Tag::Resolved:
+    decision.kind = AutoProbeDecision::Kind::Commit;
+    decision.path = *resolution.path;
+    decision.periodic = false;
+    return decision;
+  case ForwardLookaheadResolution::Tag::LowErrorPeriodic:
+    decision.kind = AutoProbeDecision::Kind::Commit;
+    decision.path = *resolution.path;
+    decision.periodic = true;
+    return decision;
+  case ForwardLookaheadResolution::Tag::Unresolved:
+    decision.kind = AutoProbeDecision::Kind::Pause;
+    decision.pauseReason = AutoProbeDecision::PauseReason::StillAmbiguous;
+    decision.bestEffort = resolution.path;
+    return decision;
+  case ForwardLookaheadResolution::Tag::StationaryProbe:
+    break;
+  }
+  if (priorStationaryProbes + 1 < kAutoEndConfirmationProbes) {
+    decision.kind = AutoProbeDecision::Kind::ProbeAgain;
+    return decision;
+  }
+  const StationaryProbeFirstMatch firstMatch = *resolution.firstMatch;
+  if (firstMatch.tag == StationaryProbeFirstMatch::Tag::Unique) {
+    decision.kind = AutoProbeDecision::Kind::End;
+    decision.endCandidate = firstMatch.candidate;
+    return decision;
+  }
+  if (calibratedEnd) {
+    decision.kind = AutoProbeDecision::Kind::End;
+    decision.endCandidate = calibratedEnd;
+    return decision;
+  }
+  if (firstMatch.candidate) {
+    // Two stationary probes prove the endpoint. Repeated pixels may leave
+    // more than one visually valid offset, but that is not a capture failure:
+    // use the matcher-ranked forward seam and finish without interrupting the
+    // user merely because the content repeats.
+    decision.kind = AutoProbeDecision::Kind::End;
+    decision.endCandidate = firstMatch.candidate;
+    return decision;
+  }
+  decision.kind = AutoProbeDecision::Kind::Pause;
+  decision.pauseReason = AutoProbeDecision::PauseReason::Stationary;
+  decision.bestEffort = std::nullopt;
+  return decision;
+}
+
+// --- AutoCapture --------------------------------------------------------------
+
+AutoCapture::AutoCapture(Axis axis) : axis_(axis) {}
+
+AutoCapture::Outcome AutoCapture::outcome(Event event, Ack ack) const {
+  Outcome result;
+  result.event = event;
+  result.ack = ack;
+  return result;
+}
+
+AutoCapture::Outcome AutoCapture::feed(const QImage &input) {
+  if (state_ == State::Halted) {
+    Outcome result = outcome(Event::Halted, Ack::Hold);
+    result.haltReason = haltReason_;
+    return result;
+  }
+  if (state_ == State::EndReached)
+    return outcome(Event::ReachedEnd, Ack::Hold);
+  if (state_ == State::Paused) {
+    Outcome result = outcome(Event::Paused, Ack::Hold);
+    result.pauseReason = pausedReason_;
+    result.hasBestEffort = pausedBestEffort_.has_value();
+    return result;
+  }
+  const QImage cropped = input.format() == QImage::Format_RGBA8888
+                             ? input
+                             : input.convertToFormat(QImage::Format_RGBA8888);
+  QString error;
+  const GrayView gray = downsampleToGray(cropped, axis_);
+
+  if (!accumulator_) {
+    if (imageIsUniform(cropped)) {
+      if (++blankFirstFrames_ >= kMaxBlankFirstFrames) {
+        state_ = State::Halted;
+        haltReason_ = HaltReason::BlankFrames;
+        Outcome result = outcome(Event::Halted, Ack::Hold);
+        result.haltReason = haltReason_;
+        return result;
+      }
+      return outcome(Event::Blank, Ack::Hold);
+    }
+    blankFirstFrames_ = 0;
+    bool ok = false;
+    accumulator_.emplace(cropped, axis_, ok, error);
+    if (!ok) {
+      accumulator_.reset();
+      state_ = State::Halted;
+      haltReason_ = HaltReason::AppendFailed;
+      Outcome result = outcome(Event::Halted, Ack::Hold);
+      result.haltReason = haltReason_;
+      result.error = error;
+      return result;
+    }
+    lastGray_ = gray;
+    kept_ = 1;
+    return outcome(Event::Seeded, Ack::Normal);
+  }
+
+  if (state_ == State::Probing) {
+    // Resolve the held ambiguous pair against this probe frame.
+    const std::optional<int> bound = calibration_.endpointUpperBound();
+    const std::optional<ForwardMatchCandidate> calibratedEnd =
+        bound ? lookahead_->uniqueCandidateAtMost(*bound) : std::nullopt;
+    const ForwardLookaheadResolution resolution = lookahead_->resolveAuto(gray);
+    const AutoProbeDecision decision =
+        autoProbeDecision(resolution, stationaryProbes_, calibratedEnd);
+    switch (decision.kind) {
+    case AutoProbeDecision::Kind::Commit: {
+      if (!accumulator_->pushForward(heldF1_, decision.path.firstDelta, error) ||
+          !accumulator_->pushForward(cropped, decision.path.secondDelta, error)) {
+        state_ = State::Halted;
+        haltReason_ = HaltReason::AppendFailed;
+        Outcome result = outcome(Event::Halted, Ack::Hold);
+        result.haltReason = haltReason_;
+        result.error = error;
+        return result;
+      }
+      kept_ += 2;
+      lastGray_ = gray;
+      calibration_.recordVerifiedNormalStep(decision.path.firstDelta);
+      consecutiveNoScroll_ = 0;
+      state_ = State::Streaming;
+      lookahead_.reset();
+      heldF1_ = {};
+      Outcome result = outcome(Event::Committed, Ack::Normal);
+      result.firstDelta = decision.path.firstDelta;
+      result.secondDelta = decision.path.secondDelta;
+      return result;
+    }
+    case AutoProbeDecision::Kind::ProbeAgain:
+      ++stationaryProbes_;
+      return outcome(Event::ProbeAgain, Ack::Probe);
+    case AutoProbeDecision::Kind::End: {
+      // The probe frames are stationary duplicates of F1; commit only F1.
+      if (!accumulator_->pushForward(heldF1_, decision.endCandidate->delta,
+                                     error)) {
+        state_ = State::Halted;
+        haltReason_ = HaltReason::AppendFailed;
+        Outcome result = outcome(Event::Halted, Ack::Hold);
+        result.haltReason = haltReason_;
+        result.error = error;
+        return result;
+      }
+      ++kept_;
+      lastGray_ = heldF1Gray_;
+      consecutiveNoScroll_ = kAutoEndConfirmationProbes;
+      state_ = State::EndReached;
+      lookahead_.reset();
+      Outcome result = outcome(Event::ReachedEndAtSeam, Ack::Hold);
+      result.firstDelta = decision.endCandidate->delta;
+      return result;
+    }
+    case AutoProbeDecision::Kind::Pause: {
+      state_ = State::Paused;
+      pausedReason_ = decision.pauseReason;
+      pausedBestEffort_ = decision.bestEffort;
+      heldF2_ = cropped;
+      heldF2Gray_ = gray;
+      Outcome result = outcome(Event::Paused, Ack::Hold);
+      result.pauseReason = pausedReason_;
+      result.hasBestEffort = pausedBestEffort_.has_value();
+      return result;
+    }
+    }
+    return outcome(Event::ProbeAgain, Ack::Probe);
+  }
+
+  // Streaming.
+  const ForwardMatch match = classifyForwardWithLookahead(lastGray_, gray, axis_);
+  if (match.tag == ForwardMatch::Tag::Ambiguous) {
+    state_ = State::Probing;
+    lookahead_ = match.ambiguous;
+    heldF1_ = cropped;
+    heldF1Gray_ = gray;
+    stationaryProbes_ = 0;
+    Outcome result = outcome(Event::ProbeStarted, Ack::Probe);
+    result.estimate = match.classified;
+    return result;
+  }
+  const MotionEstimate estimate = match.classified;
+  Outcome result;
+  switch (estimate.motion.kind) {
+  case MotionKind::Forward:
+    if (accumulator_->wouldExceedBudget(estimate.motion.delta)) {
+      // The streaming path is the one that repeats, so stop it at the budget
+      // as a designed limit rather than an append failure.
+      state_ = State::Halted;
+      haltReason_ = HaltReason::ReachedLimit;
+      result = outcome(Event::Halted, Ack::Hold);
+      result.haltReason = haltReason_;
+      return result;
+    }
+    if (!accumulator_->pushForward(cropped, estimate.motion.delta, error)) {
+      state_ = State::Halted;
+      haltReason_ = HaltReason::AppendFailed;
+      result = outcome(Event::Halted, Ack::Hold);
+      result.haltReason = haltReason_;
+      result.error = error;
+      return result;
+    }
+    ++kept_;
+    lastGray_ = gray;
+    calibration_.recordVerifiedNormalStep(estimate.motion.delta);
+    consecutiveNoScroll_ = 0;
+    result = outcome(Event::Appended, Ack::Normal);
+    break;
+  case MotionKind::Stationary:
+    if (++consecutiveNoScroll_ >= kAutoEndConfirmationProbes) {
+      state_ = State::EndReached;
+      result = outcome(Event::ReachedEnd, Ack::Normal);
+    } else {
+      result = outcome(Event::StillOnce, Ack::Normal);
+    }
+    break;
+  case MotionKind::Ambiguous:
+    state_ = State::Halted;
+    haltReason_ = HaltReason::LostAlignment;
+    result = outcome(Event::Halted, Ack::Hold);
+    result.haltReason = haltReason_;
+    break;
+  case MotionKind::Reverse:
+    state_ = State::Halted;
+    haltReason_ = HaltReason::MovedBackward;
+    result = outcome(Event::Halted, Ack::Hold);
+    result.haltReason = haltReason_;
+    break;
+  case MotionKind::Unmatchable:
+    state_ = State::Halted;
+    haltReason_ = HaltReason::Unmatchable;
+    result = outcome(Event::Halted, Ack::Hold);
+    result.haltReason = haltReason_;
+    break;
+  }
+  result.estimate = estimate;
+  return result;
+}
+
+AutoCapture::Outcome AutoCapture::continueAnyway() {
+  if (state_ != State::Paused || !pausedBestEffort_ || !accumulator_)
+    return outcome(Event::Paused, Ack::Hold);
+  QString error;
+  const ForwardMatchPath path = *pausedBestEffort_;
+  if (!accumulator_->pushForward(heldF1_, path.firstDelta, error) ||
+      !accumulator_->pushForward(heldF2_, path.secondDelta, error)) {
+    state_ = State::Halted;
+    haltReason_ = HaltReason::AppendFailed;
+    Outcome result = outcome(Event::Halted, Ack::Hold);
+    result.haltReason = haltReason_;
+    result.error = error;
+    return result;
+  }
+  kept_ += 2;
+  lastGray_ = heldF2Gray_;
+  ++unverifiedSeams_;
+  // An unverified seam never feeds the calibration.
+  lookahead_.reset();
+  heldF1_ = {};
+  heldF2_ = {};
+  pausedBestEffort_.reset();
+  Outcome result;
+  if (pausedReason_ == AutoProbeDecision::PauseReason::Stationary) {
+    state_ = State::EndReached;
+    result = outcome(Event::ReachedEnd, Ack::Hold);
+  } else {
+    state_ = State::Streaming;
+    consecutiveNoScroll_ = 0;
+    result = outcome(Event::Committed, Ack::Normal);
+  }
+  result.firstDelta = path.firstDelta;
+  result.secondDelta = path.secondDelta;
+  return result;
+}
+
+void AutoCapture::abandonPause() {
+  if (state_ != State::Paused)
+    return;
+  lookahead_.reset();
+  heldF1_ = {};
+  heldF2_ = {};
+  pausedBestEffort_.reset();
+  state_ = State::EndReached;
+}
+
+void AutoCapture::resumeFromEnd() {
+  if (state_ != State::EndReached)
+    return;
+  // The last committed frame stays the reference, so the next scroll appends
+  // to what is already there rather than starting a second capture.
+  lookahead_.reset();
+  heldF1_ = {};
+  heldF2_ = {};
+  pausedBestEffort_.reset();
+  consecutiveNoScroll_ = 0;
+  state_ = State::Streaming;
+}
+
+QImage AutoCapture::finish(QString &error) {
+  if (!accumulator_) {
+    error = QStringLiteral("no frames were captured");
+    return {};
+  }
+  return accumulator_->finish(error);
+}
+
+} // namespace stitch

--- a/src/auto-capture.cpp
+++ b/src/auto-capture.cpp
@@ -9,9 +9,9 @@
 namespace stitch {
 
 namespace {
-/// Poll granularity while the worker waits for an acknowledgement.
+/// Poll granularity while the worker waits for an acknowledgment.
 constexpr int kAckPollMs = 5;
-/// A solid-colour first frame is the copy racing the overlay's paint; it must
+/// A solid-color first frame is the copy racing the overlay's paint; it must
 /// never seed the stitcher.
 constexpr int kMaxBlankFirstFrames = 8;
 constexpr int kCalibrationWindow = 5;
@@ -63,7 +63,7 @@ void CaptureHandshake::acknowledgeWithNotches(std::uint64_t cycle, int notches) 
   const std::uint64_t published = readyCycle();
   const std::uint64_t clamped = std::min(cycle, published);
   const std::lock_guard lock(mutex_);
-  // The first acknowledgement of a cycle wins; duplicates are ignored so a
+  // The first acknowledgment of a cycle wins; duplicates are ignored so a
   // repeated UI event cannot double-scroll.
   if (clamped <= ackCycle_)
     return;

--- a/src/auto-capture.hpp
+++ b/src/auto-capture.hpp
@@ -1,0 +1,185 @@
+/** @fileoverview Automatic scroll capture: the pure decision loop that pairs
+ *  the injection worker's scroll ticks with captured frames, plus the
+ *  lock-step handshake between them. No compositor dependency, so every
+ *  decision runs in the offscreen smoke harness. */
+#pragma once
+
+#include "stitch.hpp"
+
+#include <QImage>
+#include <QString>
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace stitch {
+
+/// Consecutive stationary observations that confirm the end of content (a
+/// single one may be a delayed paint or a swallowed wheel event).
+inline constexpr int kAutoEndConfirmationProbes = 2;
+/// Wheel notches per normal automatic scroll tick and per alignment probe.
+inline constexpr int kNotchesPerTick = 3;
+inline constexpr int kProbeNotches = 1;
+
+/// Short history of fully verified normal auto-scroll steps. At a confirmed
+/// endpoint the final partial movement cannot exceed a stable full step,
+/// which rejects distant visual aliases in repeated content; unstable samples
+/// deliberately yield no bound, preserving the explicit pause over a guess.
+class AutoStepCalibration {
+public:
+  void recordVerifiedNormalStep(int delta);
+  [[nodiscard]] std::optional<int> endpointUpperBound() const;
+
+private:
+  std::vector<int> recent_;
+};
+
+/// The lock-step handshake between the injection worker and the capture loop.
+/// The worker publishes a monotonically increasing ready cycle (cycle 1 is
+/// the unscrolled first frame) and blocks until that exact cycle is
+/// acknowledged with the notch count for the NEXT scroll; the first
+/// acknowledgement of a cycle wins and each is consumed exactly once. There
+/// is deliberately no timeout: a slow grab blocks scrolling instead of racing
+/// past unrecorded content.
+class CaptureHandshake {
+public:
+  [[nodiscard]] std::uint64_t readyCycle() const {
+    return readyCycle_.load(std::memory_order_acquire);
+  }
+  /// Worker side: announce the next settled frame; returns its cycle.
+  std::uint64_t publishReady() {
+    return readyCycle_.fetch_add(1, std::memory_order_acq_rel) + 1;
+  }
+  void acknowledge(std::uint64_t cycle) {
+    acknowledgeWithNotches(cycle, kNotchesPerTick);
+  }
+  void acknowledgeWithNotches(std::uint64_t cycle, int notches);
+  /// Worker side: wait until `cycle` is acknowledged; empty when stopped.
+  [[nodiscard]] std::optional<int>
+  waitForCapture(std::uint64_t cycle, const std::atomic<bool> &stop);
+
+private:
+  std::atomic<std::uint64_t> readyCycle_{0};
+  mutable std::mutex mutex_;
+  std::uint64_t ackCycle_ = 0;
+  int ackNotches_ = kNotchesPerTick;
+  bool ackConsumed_ = true;
+};
+
+/// What one lookahead resolution means for the automatic scroller.
+struct AutoProbeDecision {
+  enum class Kind { Commit, ProbeAgain, End, Pause };
+  enum class PauseReason { StillAmbiguous, Stationary };
+  Kind kind = Kind::ProbeAgain;
+  ForwardMatchPath path;                          // Commit
+  bool periodic = false;                          // Commit via known-forward
+  std::optional<ForwardMatchCandidate> endCandidate; // End
+  PauseReason pauseReason = PauseReason::StillAmbiguous; // Pause
+  std::optional<ForwardMatchPath> bestEffort;     // Pause
+};
+[[nodiscard]] AutoProbeDecision
+autoProbeDecision(const ForwardLookaheadResolution &resolution,
+                  int priorStationaryProbes,
+                  std::optional<ForwardMatchCandidate> calibratedEnd);
+
+/// The automatic capture session: feed the cropped frame of each consumed
+/// ready cycle; the outcome says what happened and how to acknowledge the
+/// cycle. Frames are committed only once verified: an ambiguous pair is held
+/// while a one-notch probe resolves it against a third frame.
+class AutoCapture {
+public:
+  /// How the overlay must acknowledge the consumed cycle.
+  enum class Ack {
+    Normal, ///< acknowledge(cycle): next scroll is a full tick
+    Probe,  ///< acknowledgeWithNotches(cycle, 1): a one-notch probe follows
+    Hold,   ///< do not acknowledge: the worker stays parked on this cycle
+  };
+  enum class Event {
+    Blank,            ///< solid first frame refused (copy raced the overlay)
+    Seeded,           ///< first frame accepted
+    Appended,         ///< a verified forward step was committed
+    StillOnce,        ///< first stationary cycle (delayed paint?), retry
+    ReachedEnd,       ///< second stationary cycle: content cannot advance
+    ProbeStarted,     ///< ambiguous pair held; probing with one notch
+    ProbeAgain,       ///< first stationary probe; probing once more
+    Committed,        ///< probe resolved: both held frames committed
+    ReachedEndAtSeam, ///< end confirmed at an ambiguous seam; F1 committed
+    Paused,           ///< cannot verify; held frames kept for an explicit choice
+    Halted,           ///< unrecoverable; capture keeps only committed frames
+  };
+  enum class HaltReason {
+    None,
+    LostAlignment,
+    MovedBackward,
+    Unmatchable,
+    BlankFrames,
+    AppendFailed,
+    ReachedLimit, ///< the capture hit its size budget; finish it
+  };
+  struct Outcome {
+    Event event = Event::StillOnce;
+    Ack ack = Ack::Normal;
+    MotionEstimate estimate;
+    int firstDelta = 0;  ///< Committed / ReachedEndAtSeam
+    int secondDelta = 0; ///< Committed
+    HaltReason haltReason = HaltReason::None;
+    AutoProbeDecision::PauseReason pauseReason =
+        AutoProbeDecision::PauseReason::StillAmbiguous;
+    bool hasBestEffort = false; ///< Paused: continueAnyway() is available
+    QString error;
+  };
+
+  explicit AutoCapture(Axis axis);
+  [[nodiscard]] Outcome feed(const QImage &cropped);
+  /// Commit the paused best-effort path (an unverified seam the user chose to
+  /// keep); counts toward unverifiedSeams().
+  [[nodiscard]] Outcome continueAnyway();
+  /// Drop the held frames and end the capture with only verified content.
+  void abandonPause();
+  /// Takes a finished session back to streaming, keeping every band it has.
+  /// The end of a page and a capture that simply stopped scrolling look the
+  /// same from here, both being a still screen, so resuming is the caller's
+  /// call, and
+  /// a page that really had ended just concludes again.
+  void resumeFromEnd();
+  [[nodiscard]] QImage finish(QString &error);
+  [[nodiscard]] bool started() const { return accumulator_.has_value(); }
+  [[nodiscard]] bool reachedEnd() const { return state_ == State::EndReached; }
+  [[nodiscard]] bool halted() const { return state_ == State::Halted; }
+  [[nodiscard]] int keptFrames() const { return kept_; }
+  /// Whether the capture is already longer than most other software will
+  /// open. Advisory: capture continues and the result edits normally.
+  [[nodiscard]] bool exceedsWidelyOpenableEdge() const {
+    return accumulator_ && accumulator_->exceedsWidelyOpenableEdge();
+  }
+  [[nodiscard]] int unverifiedSeams() const { return unverifiedSeams_; }
+
+private:
+  enum class State { Streaming, Probing, Paused, EndReached, Halted };
+  Outcome outcome(Event event, Ack ack) const;
+
+  Axis axis_;
+  State state_ = State::Streaming;
+  std::optional<StitchAccumulator> accumulator_;
+  GrayView lastGray_; // last committed frame
+  std::optional<ForwardLookahead> lookahead_;
+  QImage heldF1_;
+  GrayView heldF1Gray_;
+  QImage heldF2_;
+  GrayView heldF2Gray_;
+  int stationaryProbes_ = 0;
+  std::optional<ForwardMatchPath> pausedBestEffort_;
+  AutoProbeDecision::PauseReason pausedReason_ =
+      AutoProbeDecision::PauseReason::StillAmbiguous;
+  AutoStepCalibration calibration_;
+  int blankFirstFrames_ = 0;
+  int consecutiveNoScroll_ = 0;
+  int kept_ = 0;
+  int unverifiedSeams_ = 0;
+  HaltReason haltReason_ = HaltReason::None;
+};
+
+} // namespace stitch

--- a/src/auto-capture.hpp
+++ b/src/auto-capture.hpp
@@ -41,7 +41,7 @@ private:
 /// The worker publishes a monotonically increasing ready cycle (cycle 1 is
 /// the unscrolled first frame) and blocks until that exact cycle is
 /// acknowledged with the notch count for the NEXT scroll; the first
-/// acknowledgement of a cycle wins and each is consumed exactly once. There
+/// acknowledgment of a cycle wins and each is consumed exactly once. There
 /// is deliberately no timeout: a slow grab blocks scrolling instead of racing
 /// past unrecorded content.
 class CaptureHandshake {

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -4,6 +4,7 @@
 #include "cut.hpp"
 
 #include <cstdint>
+#include <memory>
 
 #include <QPainterPath>
 #include <QColor>
@@ -134,6 +135,37 @@ enum class AnnotationLayer { Redaction, Default };
  *  has one; `start` is the baseline origin. */
 [[nodiscard]] QRectF annotationTextBounds(const Annotation &annotation);
 /** Captures the named output through ext-image-copy-capture. */
+/** A live native capture session for one output (`MonitorInfo::name`, e.g.
+ *  "DP-3") over its own Wayland connection: open once, then grab frames
+ *  repeatedly into the same buffer: a scroll capture takes many per second
+ *  and must not pay a process spawn or a session handshake for each. Frames
+ *  are captured without the cursor and returned upright in output pixels. */
+class OutputCapture {
+public:
+  OutputCapture();
+  ~OutputCapture();
+  OutputCapture(const OutputCapture &) = delete;
+  OutputCapture &operator=(const OutputCapture &) = delete;
+  [[nodiscard]] bool open(const QString &outputName, QString &error);
+  /// Grab the next frame. `timeoutMs` bounds the wait for the compositor to
+  /// deliver damage (a fully static output would otherwise block up to 2 s).
+  /// Returns false on timeout as well as on real failures, and `error` is set
+  /// either way; poll sessionStopped() to tell a dead session from a quiet
+  /// screen and simply retry the rest.
+  [[nodiscard]] bool grab(QImage &image, QString &error, int timeoutMs = 2000);
+  [[nodiscard]] bool isOpen() const;
+  /// True once the compositor has stopped the session (output gone, mode
+  /// change it will not resume from); further grabs cannot succeed.
+  [[nodiscard]] bool sessionStopped() const;
+  /** Pixel size the compositor announced for frames (empty until open). */
+  [[nodiscard]] QSize bufferSize() const;
+  void close();
+
+private:
+  struct State;
+  std::unique_ptr<State> state_;
+};
+
 [[nodiscard]] bool captureOutputSurface(const MonitorInfo &monitor,
                                         QImage &image, QString &error);
 [[nodiscard]] QString operationLogPath(const QString &imagePath);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1,6 +1,8 @@
 /** @fileoverview Handles screenshot selection, annotation, and editor drawing.
  */
 #include "editor.hpp"
+
+#include "stitch.hpp"
 #include "icons.hpp"
 #include "eyedropper.hpp"
 #include "palette-config.hpp"
@@ -455,6 +457,11 @@ void drawHotkeyLegend(QPainter &painter, const QRect &bounds,
   const QRectF other = cursorWantsLeft ? right : left;
   if (hiddenCount(panel) > hiddenCount(other))
     panel = other;
+  // A surface narrower than the card has nowhere for the flip to go: both
+  // positions span the whole width, so the card would sit on whatever is
+  // being pointed at. Step aside entirely; on any real monitor it fits.
+  if (right.left() < left.left())
+    return;
 
   painter.setPen(QPen(QColor(255, 255, 255, 34), 1));
   painter.setBrush(QColor(13, 15, 20, 224));
@@ -715,8 +722,20 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
       selection_ = QRectF(QPointF(), capture_.previewSize);
     else
       replayLog();
+    // A very long capture edits and saves here exactly as usual, so say what
+    // actually differs: other software may refuse to open the file. Said once,
+    // on opening, where it is useful, not as an alarm during capture.
+    const bool veryLong =
+        capture_.previewSize.width() > stitch::kWidelyOpenableEdge ||
+        capture_.previewSize.height() > stitch::kWidelyOpenableEdge;
     enterEdit(
-        mode == CaptureMode::File
+        veryLong
+            ? QStringLiteral("Very long capture (%1 × %2) · edits and saves "
+                             "here as usual, but many apps cannot open images "
+                             "this large · crop it if you need it elsewhere")
+                  .arg(capture_.previewSize.width())
+                  .arg(capture_.previewSize.height())
+        : mode == CaptureMode::File
             ? QStringLiteral("Editing image from file · Copy/Save to output")
             : QStringLiteral("Full screen selected · native resolution · "
                              "outer handles crop"));
@@ -2793,6 +2812,13 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
       chooseWindow(hoveredWindow_);
       return;
     }
+    if (event->key() == Qt::Key_S && !event->modifiers()) {
+      // Same tool, other mood: hand this over to scroll capture before any
+      // pixels are taken. Nothing has been captured yet, so nothing is lost.
+      switchedToScroll_ = true;
+      close();
+      return;
+    }
     if (event->key() == Qt::Key_Space) {
       windowMode_ = !windowMode_;
       dragging_ = false;
@@ -4193,6 +4219,7 @@ void CaptureEditor::paintSelect(QPainter &painter) {
                    {{QStringLiteral("Drag"), QStringLiteral("Area")},
                     {QStringLiteral("Space"), QStringLiteral("Window")},
                     {QStringLiteral("Ctrl+A"), QStringLiteral("Fullscreen")},
+                    {QStringLiteral("S"), QStringLiteral("Scroll capture")},
                     {QStringLiteral("Esc ×2"), QStringLiteral("Close")}});
   drawStatusPill(painter, rect(), status_);
   drawMeasureBadge(painter, rect(), cursor_, measurementText());

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -211,6 +211,10 @@ public:
   [[nodiscard]] int selectedCountForTest() const {
     return static_cast<int>(selectedAnnotations_.size());
   }
+  /// Whether the overlay was left by asking for a scroll capture instead:
+  /// the two kinds of capture swap with one key rather than making anyone
+  /// close this and launch the other.
+  [[nodiscard]] bool switchedToScroll() const { return switchedToScroll_; }
   /// Current status line. Test accessor.
   [[nodiscard]] QString statusForTest() const { return status_; }
   /// Whether the selection chrome is currently stepped back for an adjustment.
@@ -300,6 +304,9 @@ private:
   void duplicateSelectedAnnotation();
   [[nodiscard]] EditState editState() const;
   void enterEdit(QString status);
+public:
+
+private:
   void scheduleSnapshot();
   void startSnapshotRender();
   void pinSnapshot();
@@ -354,6 +361,7 @@ private:
   /// What to hand back to once a color has been sampled: taking a color is
   /// not a change of tool.
   Tool toolBeforeEyedropper_ = Tool::Select;
+  bool switchedToScroll_ = false;
   QRectF selection_;
   QPointF dragStart_;
   QRectF originalSelection_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 
 #include <LayerShellQt/Window>
 
+#include "scroll-capture.hpp"
+
 #include <QImageReader>
 #include <QApplication>
 #include <QCommandLineOption>
@@ -156,6 +158,11 @@ int main(int argc, char **argv) {
       QStringLiteral("Show an image as a pinned always-visible layer."),
       QStringLiteral("path"));
   parser.addOption(pinOption);
+  const QCommandLineOption scrollOption(
+      QStringLiteral("scroll"),
+      QStringLiteral("Capture a scrolling region and stitch it into one tall "
+                     "image, then open it in the editor."));
+  parser.addOption(scrollOption);
   parser.addPositionalArgument(
       QStringLiteral("target"),
       QStringLiteral("Capture mode (smart, region, windows, fullscreen) or the "
@@ -269,6 +276,39 @@ int main(int argc, char **argv) {
   CaptureData capture;
   OperationLog restoredLog;
   QString error;
+  bool scrollRequested = parser.isSet(scrollOption);
+  if (scrollRequested) {
+    // Learn the focused monitor (name and scale) for the output-capture
+    // session, run the overlay, then edit the stitched result. Leaving the
+    // overlay with A asks for an ordinary area capture instead, so the two
+    // kinds swap without anyone having to close one and launch the other.
+    CaptureData probe;
+    if (!captureFocusedMonitor(probe, false, error)) {
+      qCritical().noquote() << error;
+      return 1;
+    }
+    bool switchedToArea = false;
+    const QImage stitched =
+        runScrollCapture(probe.monitor, error, &switchedToArea);
+    if (switchedToArea) {
+      scrollRequested = false;
+      captureMode = CaptureEditor::CaptureMode::Region;
+    } else if (stitched.isNull()) {
+      if (!error.isEmpty()) {
+        qCritical().noquote() << error;
+        return 1;
+      }
+      return 0; // cancelled
+    } else {
+      capture.source = stitched;
+      capture.previewSize = stitched.size();
+      capture.monitor.scale = 1.0;
+      capture.monitor.pixelSize = stitched.size();
+      capture.monitor.geometry = QRect(QPoint(0, 0), stitched.size());
+      capture.monitor.name = probe.monitor.name;
+      captureMode = CaptureEditor::CaptureMode::File;
+    }
+  }
   if (editingImage) {
     QImage image;
     QString inputName;
@@ -310,7 +350,8 @@ int main(int argc, char **argv) {
                              .arg(inputName)
                              .arg(image.width())
                              .arg(image.height());
-  } else if (!probeFocusedMonitor(capture.monitor, error)) {
+  } else if (!scrollRequested &&
+             !probeFocusedMonitor(capture.monitor, error)) {
     qCritical().noquote() << error;
     sendCaptureNotification(QStringLiteral("Screenshot failed: %1").arg(error));
     return 1;
@@ -321,7 +362,7 @@ int main(int argc, char **argv) {
   const bool instantFullscreenOutput =
       !editingImage && captureMode == CaptureEditor::CaptureMode::Fullscreen &&
       quickOutputMode != QuickOutputMode::None;
-  if (!editingImage &&
+  if (!editingImage && !scrollRequested &&
       !captureMonitorPixels(capture.monitor, capture,
                             !instantFullscreenOutput, error)) {
     qCritical().noquote() << error;
@@ -364,32 +405,78 @@ int main(int argc, char **argv) {
                              .arg(capture.windows.size());
   }
 
-  CaptureEditor editor(std::move(capture), captureMode, quickOutputMode,
-                       restoredLog);
-  editor.setScreen(targetScreen);
-  editor.setGeometry(targetScreen->geometry());
-  editor.winId();
-  QWindow *window = editor.windowHandle();
-  LayerShellQt::Window *layerWindow = LayerShellQt::Window::get(window);
-  if (!window || !layerWindow) {
-    qCritical() << "Could not create capture overlay layer";
-    return 1;
-  }
-  layerWindow->setScope(QStringLiteral("omasnap"));
-  layerWindow->setScreen(targetScreen);
-  layerWindow->setLayer(LayerShellQt::Window::LayerOverlay);
-  LayerShellQt::Window::Anchors anchors;
-  anchors.setFlag(LayerShellQt::Window::AnchorTop);
-  anchors.setFlag(LayerShellQt::Window::AnchorBottom);
-  anchors.setFlag(LayerShellQt::Window::AnchorLeft);
-  anchors.setFlag(LayerShellQt::Window::AnchorRight);
-  layerWindow->setAnchors(anchors);
-  layerWindow->setExclusiveZone(-1);
-  layerWindow->setKeyboardInteractivity(
-      LayerShellQt::Window::KeyboardInteractivityExclusive);
-  layerWindow->setActivateOnShow(true);
-  editor.show();
-  editor.setFocus(Qt::ActiveWindowFocusReason);
+  // Area capture and scroll capture hand back and forth with one key, so the
+  // session is a loop rather than a sequence: each overlay runs to completion,
+  // says whether it handed over, and the other one takes it from there. As
+  // many times as anyone likes.
+  for (;;) {
+    CaptureEditor editor(std::move(capture), captureMode, quickOutputMode,
+                         restoredLog);
+    editor.setScreen(targetScreen);
+    editor.setGeometry(targetScreen->geometry());
+    editor.winId();
+    QWindow *window = editor.windowHandle();
+    LayerShellQt::Window *layerWindow = LayerShellQt::Window::get(window);
+    if (!window || !layerWindow) {
+      qCritical() << "Could not create capture overlay layer";
+      return 1;
+    }
+    layerWindow->setScope(QStringLiteral("omasnap"));
+    layerWindow->setScreen(targetScreen);
+    layerWindow->setLayer(LayerShellQt::Window::LayerOverlay);
+    LayerShellQt::Window::Anchors anchors;
+    anchors.setFlag(LayerShellQt::Window::AnchorTop);
+    anchors.setFlag(LayerShellQt::Window::AnchorBottom);
+    anchors.setFlag(LayerShellQt::Window::AnchorLeft);
+    anchors.setFlag(LayerShellQt::Window::AnchorRight);
+    layerWindow->setAnchors(anchors);
+    layerWindow->setExclusiveZone(-1);
+    layerWindow->setKeyboardInteractivity(
+        LayerShellQt::Window::KeyboardInteractivityExclusive);
+    layerWindow->setActivateOnShow(true);
+    editor.show();
+    editor.setFocus(Qt::ActiveWindowFocusReason);
 
-  return application.exec();
+    const int status = application.exec();
+    if (!editor.switchedToScroll())
+      return status;
+
+    // S handed this over to scroll capture. Run it on the same monitor; A
+    // there hands it straight back, which is why this is a loop. Whatever op
+    // log a file edit restored belongs to that file, not to the next capture.
+    restoredLog = OperationLog();
+    CaptureData probe;
+    if (!captureFocusedMonitor(probe, false, error)) {
+      qCritical().noquote() << error;
+      return 1;
+    }
+    bool backToArea = false;
+    const QImage stitched = runScrollCapture(probe.monitor, error, &backToArea);
+    if (backToArea) {
+      // Handed straight back: the loop puts the area overlay up again, and A
+      // and S can keep passing it between them for as long as anyone likes.
+      capture = CaptureData();
+      if (!captureMonitorPixels(probe.monitor, capture, true, error)) {
+        qCritical().noquote() << error;
+        return 1;
+      }
+      captureMode = CaptureEditor::CaptureMode::Region;
+      continue;
+    }
+    if (stitched.isNull()) {
+      if (!error.isEmpty()) {
+        qCritical().noquote() << error;
+        return 1;
+      }
+      return 0; // cancelled
+    }
+    capture = CaptureData();
+    capture.source = stitched;
+    capture.previewSize = stitched.size();
+    capture.monitor.scale = 1.0;
+    capture.monitor.pixelSize = stitched.size();
+    capture.monitor.geometry = QRect(QPoint(0, 0), stitched.size());
+    capture.monitor.name = probe.monitor.name;
+    captureMode = CaptureEditor::CaptureMode::File;
+  }
 }

--- a/src/overlay-chrome.cpp
+++ b/src/overlay-chrome.cpp
@@ -1,0 +1,112 @@
+/** @fileoverview Shared overlay chrome (see overlay-chrome.hpp). */
+#include "overlay-chrome.hpp"
+
+#include <QFontDatabase>
+#include <QPainter>
+
+#include <algorithm>
+
+QRectF drawModeBadge(QPainter &painter, const QRect &bounds,
+                     const QString &label, const QColor &accent,
+                     QRectF *closeRect) {
+  QFont badgeFont(QStringLiteral("Noto Sans"));
+  badgeFont.setBold(true);
+  badgeFont.setPixelSize(11);
+  painter.setFont(badgeFont);
+  const QString badge = label + QStringLiteral("  ×");
+  const int badgeWidth = painter.fontMetrics().horizontalAdvance(badge) + 24;
+  const QRectF badgeRect((bounds.width() - badgeWidth) / 2.0, 12, badgeWidth,
+                         32);
+  painter.setPen(QPen(QColor(255, 255, 255, 32), 1));
+  painter.setBrush(QColor(18, 18, 22, 235));
+  painter.drawRoundedRect(badgeRect, 10, 10);
+  painter.setPen(accent);
+  painter.drawText(badgeRect, Qt::AlignCenter, badge);
+  if (closeRect) {
+    // The × and a little around it, so the click that closes has a target
+    // rather than a pixel.
+    const qreal closeWidth =
+        painter.fontMetrics().horizontalAdvance(QStringLiteral("×")) + 18;
+    *closeRect = QRectF(badgeRect.right() - closeWidth, badgeRect.top(),
+                        closeWidth, badgeRect.height());
+  }
+  return badgeRect;
+}
+
+void drawHotkeyLegend(QPainter &painter, const QRect &bounds,
+                      const QPointF &cursor,
+                      const QVector<QPair<QString, QString>> &entries) {
+  if (entries.isEmpty())
+    return;
+  constexpr int columns = 2;
+  const int rows = (entries.size() + columns - 1) / columns;
+  QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
+  font.setPixelSize(11);
+  painter.setFont(font);
+  // Measured, not guessed: a fixed column width clipped the longer lines, and
+  // a guide that trails off is worse than no guide.
+  const QFontMetricsF metrics(font);
+  constexpr qreal keyGap = 12;      // between a key and what it does
+  constexpr qreal columnGap = 24;   // between the two columns
+  constexpr qreal padding = 12;     // panel edge to text
+  qreal keyWidth[columns] = {};
+  qreal textWidth[columns] = {};
+  for (int index = 0; index < entries.size(); ++index) {
+    const int column = std::min(index / rows, columns - 1);
+    keyWidth[column] =
+        std::max(keyWidth[column], metrics.horizontalAdvance(entries.at(index).first));
+    textWidth[column] = std::max(
+        textWidth[column], metrics.horizontalAdvance(entries.at(index).second));
+  }
+  qreal columnWidth[columns] = {};
+  qreal width = 2 * padding;
+  for (int column = 0; column < columns; ++column) {
+    if (keyWidth[column] <= 0 && textWidth[column] <= 0)
+      continue;
+    columnWidth[column] = keyWidth[column] + keyGap + textWidth[column];
+    width += columnWidth[column];
+    if (column > 0)
+      width += columnGap;
+  }
+  width = std::min(width, bounds.width() - 28.0);
+  const qreal height = rows * 19 + 24;
+  QRectF panel(bounds.width() - width - 14, 14, width, height);
+  if (panel.adjusted(-28, -28, 28, 28).contains(cursor))
+    panel.moveLeft(14);
+
+  painter.setPen(QPen(QColor(255, 255, 255, 34), 1));
+  painter.setBrush(QColor(13, 15, 20, 224));
+  painter.drawRoundedRect(panel, 11, 11);
+  painter.setFont(font);
+  for (int index = 0; index < entries.size(); ++index) {
+    const int column = std::min(index / rows, columns - 1);
+    const int row = index % rows;
+    qreal x = panel.left() + padding;
+    for (int before = 0; before < column; ++before)
+      x += columnWidth[before] + columnGap;
+    const qreal y = panel.top() + 12 + row * 19;
+    painter.setPen(QColor(QStringLiteral("#a9b6cb")));
+    painter.drawText(QRectF(x, y, keyWidth[column], 18),
+                     Qt::AlignLeft | Qt::AlignVCenter, entries.at(index).first);
+    painter.setPen(QColor(QStringLiteral("#f5f5f7")));
+    painter.drawText(QRectF(x + keyWidth[column] + keyGap, y, textWidth[column],
+                            18),
+                     Qt::AlignLeft | Qt::AlignVCenter,
+                     entries.at(index).second);
+  }
+}
+
+void drawStatusPill(QPainter &painter, const QRect &bounds,
+                    const QString &text) {
+  QFont font(QStringLiteral("Noto Sans"));
+  font.setPixelSize(13);
+  painter.setFont(font);
+  const int width = painter.fontMetrics().horizontalAdvance(text) + 28;
+  const QRectF pill((bounds.width() - width) / 2.0, bounds.height() - 42.0,
+                    width, 30);
+  painter.setPen(QPen(QColor(255, 255, 255, 32), 1));
+  painter.setBrush(QColor(18, 18, 22, 232));
+  painter.drawRoundedRect(pill, 10, 10);
+  painter.setPen(Qt::white);
+  painter.drawText(pill, Qt::AlignCenter, text);
+}

--- a/src/overlay-chrome.hpp
+++ b/src/overlay-chrome.hpp
@@ -1,0 +1,31 @@
+/** @fileoverview The chrome every full-screen overlay wears: the mode badge at
+ *  the top, the hotkey guide in the corner, and the status pill along the
+ *  bottom. Capture and scroll capture are the same tool in two moods, so they
+ *  are drawn by the same code rather than by two that drift apart. */
+#pragma once
+
+#include <QColor>
+#include <QPair>
+#include <QRect>
+#include <QRectF>
+#include <QString>
+#include <QVector>
+
+class QPainter;
+
+/// The badge naming what the overlay is doing, centered at the top, with the ×
+/// that leaves it. Returns the whole badge; `closeRect` is the × alone, for
+/// hit-testing the click that closes.
+QRectF drawModeBadge(QPainter &painter, const QRect &bounds,
+                     const QString &label, const QColor &accent,
+                     QRectF *closeRect = nullptr);
+
+/// The two-column key guide, pinned to the top-right corner, and moved to the
+/// left when the pointer is over it, so it never hides what is underneath.
+void drawHotkeyLegend(QPainter &painter, const QRect &bounds,
+                      const QPointF &cursor,
+                      const QVector<QPair<QString, QString>> &entries);
+
+/// The instruction line along the bottom.
+void drawStatusPill(QPainter &painter, const QRect &bounds,
+                    const QString &text);

--- a/src/scroll-capture.cpp
+++ b/src/scroll-capture.cpp
@@ -1,0 +1,1305 @@
+/** @fileoverview Manual scroll capture overlay (see scroll-capture.hpp). */
+#include "scroll-capture.hpp"
+
+#include "scroll-inject.hpp"
+
+#include <LayerShellQt/Window>
+
+#include <QtConcurrent/QtConcurrentRun>
+
+#include <QApplication>
+#include <QCursor>
+#include <QDebug>
+#include <QDir>
+#include <QEventLoop>
+#include <QFile>
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QWheelEvent>
+#include <QPainter>
+#include <QScreen>
+#include <QThread>
+#include <QTimer>
+#include <QWindow>
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+/// Poll cadence of the capture loop.
+constexpr int kCaptureIntervalMs = 100;
+/// How long one grab may wait for the compositor to deliver damage. The loop
+/// runs on a worker thread, so waiting is fine; a static screen simply yields
+/// no frame this round.
+constexpr int kGrabTimeoutMs = 400;
+constexpr int kMinRegion = 32; // logical px
+/// How far outside the region its grips and its draggable border reach. The
+/// region itself has to stay untouched: it is what the capture crops.
+constexpr int kGripBand = 16;
+/// How long to let the compositor show a frame with the chrome hidden before
+/// grabbing the first one. Two frames at 60 Hz, with room to spare.
+constexpr int kChromeSettleMs = 60;
+const QColor kDim(0, 0, 0, 150);
+const QColor kAccent(10, 132, 255);
+const QColor kWarn(255, 159, 10);
+
+struct ModeButton {
+  const char *label;
+  bool automatic;
+  stitch::Axis axis;
+};
+/// The Selected-phase mode choices (painted, hit-tested like the pills).
+constexpr ModeButton kModeButtons[] = {
+    {"Manual \u2193", false, stitch::Axis::Vertical},
+    {"Auto \u2193", true, stitch::Axis::Vertical},
+    {"Manual \u2192", false, stitch::Axis::Horizontal},
+    {"Auto \u2192", true, stitch::Axis::Horizontal},
+};
+constexpr int kModeButtonCount = 4;
+constexpr int kModeButtonWidth = 118;
+constexpr int kModeButtonHeight = 40;
+constexpr int kModeButtonGap = 10;
+
+const char *eventName(stitch::ManualCapture::Event event) {
+  using Event = stitch::ManualCapture::Event;
+  switch (event) {
+  case Event::Blank: return "Blank";
+  case Event::Seeded: return "Seeded";
+  case Event::Kept: return "Kept";
+  case Event::Pending: return "Pending";
+  case Event::Still: return "Still";
+  case Event::PendingDropped: return "PendingDropped";
+  case Event::ReSeeded: return "ReSeeded";
+  case Event::Ambiguous: return "Ambiguous";
+  case Event::Unmatchable: return "Unmatchable";
+  case Event::WrongDirection: return "WrongDirection";
+  case Event::Error: return "Error";
+  case Event::Full: return "Full";
+  }
+  return "?";
+}
+} // namespace
+
+struct ScrollCaptureOverlay::Worker {
+  explicit Worker(stitch::Axis axis) : session(axis), autoSession(axis) {}
+  OutputCapture output;
+  stitch::ManualCapture session;    // manual mode
+  stitch::AutoCapture autoSession;  // automatic mode
+  QRect regionPhysical;
+  int grabbed = 0;
+  int consecutiveFailures = 0;
+  std::uint64_t lastCycle = 0; // last consumed handshake cycle (auto)
+  QImage firstCrop;
+  QImage lastCrop;
+  QString debugDir;
+};
+
+ScrollCaptureOverlay::ScrollCaptureOverlay(MonitorInfo monitor, QWidget *parent)
+    : QWidget(parent), monitor_(std::move(monitor)) {
+  setMouseTracking(true);
+  setFocusPolicy(Qt::StrongFocus);
+  setCursor(Qt::CrossCursor); // choosing a region, like the region capture
+  setAttribute(Qt::WA_TranslucentBackground);
+  status_ = QStringLiteral(
+      "Drag to select a scroll region · A switches to area capture");
+}
+
+namespace {
+/// Beside the snapshots and the instance lock, in the private runtime dir.
+QString storedRegionPath() {
+  const QString runtime = secureRuntimeDirectory();
+  if (runtime.isEmpty())
+    return {};
+  return QDir(runtime).filePath(QStringLiteral("scroll-region"));
+}
+} // namespace
+
+ScrollCaptureOverlay::~ScrollCaptureOverlay() { stopWorker(); }
+
+void ScrollCaptureOverlay::setLayerWindow(LayerShellQt::Window *layer) {
+  layer_ = layer;
+}
+
+void ScrollCaptureOverlay::showEvent(QShowEvent *event) {
+  QWidget::showEvent(event);
+  // Read the last region now that the surface has its real size; one written
+  // for a different screen or monitor is ignored. The overlay still opens empty
+  // and inviting a drag, since most captures are of somewhere new, and R
+  // brings this one back to adjust with the grips.
+  const QString path = storedRegionPath();
+  if (path.isEmpty())
+    return;
+  QFile file(path);
+  if (!file.open(QIODevice::ReadOnly))
+    return;
+  storedRegion_ = parseStoredScrollRegion(
+      QString::fromUtf8(file.readLine(256)), monitor_.name, size());
+  if (!storedRegion_.isEmpty()) {
+    setStatus(QStringLiteral("Drag to select a scroll region · R brings back "
+                             "the last one"));
+  }
+}
+
+QRect ScrollCaptureOverlay::regionLogical() const {
+  return QRect(dragStart_, dragEnd_).normalized();
+}
+
+QRect ScrollCaptureOverlay::regionPhysical() const {
+  // Round the edges, not the extents: rounding x and width independently can
+  // shift the crop against the visible hole by a pixel at fractional scales,
+  // stitching a stationary overlay-edge column into every band.
+  const qreal scale = monitor_.scale > 0 ? monitor_.scale : 1.0;
+  const int left = qRound(region_.x() * scale);
+  const int top = qRound(region_.y() * scale);
+  const int right = qRound((region_.x() + region_.width()) * scale);
+  const int bottom = qRound((region_.y() + region_.height()) * scale);
+  return QRect(left, top, std::max(1, right - left), std::max(1, bottom - top));
+}
+
+void ScrollCaptureOverlay::setStatus(const QString &status, bool warning) {
+  status_ = status;
+  statusWarning_ = warning;
+  update();
+}
+
+void ScrollCaptureOverlay::postStalled() {
+  // Called from the worker thread when an auto capture stops before the end.
+  QMetaObject::invokeMethod(
+      this,
+      [this] {
+        if (phase_ != Phase::Capturing || mode_ != Mode::Auto)
+          return;
+        autoStalled_ = true;
+        applyInputRegion(); // the row grew by a pill
+        update();
+      },
+      Qt::QueuedConnection);
+}
+
+void ScrollCaptureOverlay::postStatus(const QString &status, bool warning) {
+  // Called from the worker thread; hop to the UI thread. A queued update can
+  // arrive after Done stopped the worker, and it must not overwrite the
+  // finishing/final status.
+  QMetaObject::invokeMethod(
+      this,
+      [this, status, warning] {
+        if (phase_ == Phase::Capturing)
+          setStatus(status, warning);
+      });
+}
+
+void ScrollCaptureOverlay::rememberRegion() const {
+  const QString path = storedRegionPath();
+  if (path.isEmpty() || region_.isEmpty())
+    return;
+  QFile file(path);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
+    return; // remembering is a convenience; failing to is not an error
+  file.write(
+      formatStoredScrollRegion(monitor_.name, size(), region_).toUtf8());
+}
+
+QVector<QRect> ScrollCaptureOverlay::chromeRects() const {
+  QVector<QRect> rects;
+  if (phase_ == Phase::Selected) {
+    for (int index = 0; index < kModeButtonCount; ++index)
+      rects.push_back(modeButtonRect(index));
+    rects.push_back(selectedCancelButtonRect());
+    for (const auto &[grip, which] : gripRects())
+      rects.push_back(grip);
+    return rects;
+  }
+  rects.push_back(doneButtonRect());
+  rects.push_back(backButtonRect());
+  rects.push_back(cancelButtonRect());
+  if (autoStalled_)
+    rects.push_back(continueButtonRect());
+  return rects;
+}
+
+void ScrollCaptureOverlay::applyInputRegion() {
+  if (!windowHandle())
+    return;
+  // The region is exposed from the moment it is chosen, so the page can be
+  // scrolled into place without losing it.
+  if (phase_ != Phase::Capturing && phase_ != Phase::Selected) {
+    windowHandle()->setMask(QRegion()); // whole surface takes input
+    return;
+  }
+  windowHandle()->setMask(
+      scrollOverlayInputRegion(rect(), region_, chromeRects()));
+}
+
+void ScrollCaptureOverlay::updateKeyboardZone(const QPoint &point) {
+  // The grab pins pointer focus to this layer, which is what stops the wheel
+  // reaching the page, so it is held only while the pointer is on our own
+  // chrome, and only once a real event has said so. Assuming the pointer was on
+  // the chrome is what broke scrolling before: a Wayland client cannot ask
+  // where the pointer is, so the answer here always comes from an event.
+  if (phase_ == Phase::Selecting) {
+    setKeyboardGrab(true);
+    return;
+  }
+  setKeyboardGrab(!region_.contains(point));
+}
+
+void ScrollCaptureOverlay::setKeyboardGrab(bool grab) {
+  // Hyprland pins pointer focus to a layer that holds an exclusive keyboard
+  // grab, even over an input-region hole, so while the grab is held the wheel
+  // never reaches the page. Once a region exists the page has to be
+  // scrollable, so the grab goes away for that whole phase instead of being
+  // handed back and forth as the pointer crosses the region's edge: that
+  // handoff depended on knowing where the pointer was, and a Wayland client
+  // cannot ask. Restoring a region put the pointer somewhere we had never
+  // seen it move, and the grab stayed on. The pills are the controls from
+  // then on.
+  if (!layer_ || keyboardGrabbed_ == grab)
+    return;
+  keyboardGrabbed_ = grab;
+  layer_->setKeyboardInteractivity(
+      grab ? LayerShellQt::Window::KeyboardInteractivityExclusive
+           : LayerShellQt::Window::KeyboardInteractivityNone);
+}
+
+// ---- capture -----------------------------------------------------------------
+
+void ScrollCaptureOverlay::startCapture(Mode mode, stitch::Axis axis) {
+  if (region_.width() < kMinRegion || region_.height() < kMinRegion)
+    return;
+  mode_ = mode;
+  axis_ = axis;
+  auto worker = std::make_unique<Worker>(axis_);
+  QString error;
+  if (!worker->output.open(monitor_.name, error)) {
+    setStatus(QStringLiteral("Output capture failed: %1").arg(error), true);
+    return;
+  }
+  worker->regionPhysical = regionPhysical().intersected(
+      QRect(QPoint(), worker->output.bufferSize()));
+  worker->debugDir = qEnvironmentVariable("OMASNAP_SCROLL_DEBUG_DIR");
+  worker_ = std::move(worker);
+  phase_ = Phase::Capturing;
+  applyInputRegion();
+  // The move puck lives inside the region, so the frame on screen right now
+  // still has it. Paint the phase change first and let it be shown: the
+  // capture reads the screen back, so it must not start until the screen no
+  // longer has any of our chrome on the part being captured.
+  repaint();
+  // Drop the exclusive keyboard grab for the whole capture. Hyprland pins
+  // pointer focus to a layer that holds an exclusive grab (even over an
+  // input-region hole), which stops the wheel reaching the page; with the grab
+  // released the pointer is never pinned, so scrolling the exposed page always
+  // works. Finish/cancel run off the on-screen buttons (mouse clicks, governed
+  // by the input region, not the keyboard).
+  setKeyboardGrab(false);
+  stopRequested_ = false;
+  if (mode_ == Mode::Manual) {
+    setStatus(QStringLiteral("Scroll the page · Done stitches it"));
+    // A couple of frames after the repaint above, so the compositor has
+    // presented the puck-less frame before the first grab reads it back.
+    QTimer::singleShot(kChromeSettleMs, this, [this] {
+      if (phase_ != Phase::Capturing)
+        return;
+      workerFuture_ = QtConcurrent::run([this] { captureLoop(); });
+    });
+    return;
+  }
+  // Automatic: the injection worker scrolls one acknowledged tick at a time.
+  injectorStop_ = std::make_shared<std::atomic<bool>>(false);
+  handshake_ = std::make_shared<stitch::CaptureHandshake>();
+  const qreal scale = monitor_.scale > 0 ? monitor_.scale : 1.0;
+  // Park low inside the selection so wheel events hit the page, clear of
+  // the region's bottom edge.
+  const int parkX = qRound((region_.x() + std::max(region_.width() - 30, 1)) * scale);
+  const int parkY = qRound((region_.y() + std::max(region_.height() - 60, 1)) * scale);
+  setStatus(QStringLiteral("Auto-scrolling… · move the pointer out of the "
+                           "frame to stop · Done stitches it"));
+  // Spawn after this frame's commit so the input-region hole and the released
+  // keyboard land before the pointer warp.
+  QTimer::singleShot(
+      kChromeSettleMs, this,
+      [this, parkX, parkY] {
+        if (phase_ != Phase::Capturing)
+          return;
+        QString spawnError;
+        if (!spawnScrollInjector(injectorStop_, handshake_, parkX, parkY,
+                                 axis_, monitor_.name, spawnError)) {
+          // Fall back to manual capture on the same region and axis.
+          qInfo().noquote()
+              << QStringLiteral("scroll: injector unavailable (%1)").arg(spawnError);
+          mode_ = Mode::Manual;
+          setStatus(QStringLiteral("Auto-scroll unavailable · scroll "
+                                   "manually · Done stitches"),
+                    true);
+          workerFuture_ = QtConcurrent::run([this] { captureLoop(); });
+          return;
+        }
+        workerFuture_ = QtConcurrent::run([this] { autoCaptureLoop(); });
+      });
+}
+
+void ScrollCaptureOverlay::stopWorker() {
+  stopRequested_ = true;
+  if (injectorStop_)
+    injectorStop_->store(true, std::memory_order_release);
+  if (workerFuture_.isRunning())
+    workerFuture_.waitForFinished();
+}
+
+void ScrollCaptureOverlay::captureLoop() {
+  using Event = stitch::ManualCapture::Event;
+  Worker &w = *worker_;
+  QString error;
+  bool captureFull = false;
+  while (!stopRequested_) {
+    QImage frame;
+    if (!w.output.grab(frame, error, kGrabTimeoutMs)) {
+      if (w.output.sessionStopped()) {
+        // The compositor ended the session (output disconnected, mode
+        // change); no retry can succeed. Leave what was captured for Done.
+        postStatus(QStringLiteral("Screen capture stopped · press Done to "
+                                  "stitch what was captured, or Cancel"),
+                   true);
+        break;
+      }
+      // A timeout means a quiet screen; an immediate failure (dead connection,
+      // repeated frame failures) must not busy-spin, so pace the retries and
+      // tell the user if it persists.
+      QThread::msleep(kCaptureIntervalMs);
+      if (++w.consecutiveFailures == 50)
+        postStatus(QStringLiteral("Screen capture is not delivering frames: "
+                                  "%1").arg(error),
+                   true);
+      continue;
+    }
+    w.consecutiveFailures = 0;
+    if (stopRequested_)
+      break;
+    ++w.grabbed;
+    const QImage cropped = frame.copy(w.regionPhysical)
+                               .convertToFormat(QImage::Format_RGBA8888);
+    if (!w.debugDir.isEmpty() && w.grabbed % 8 == 0)
+      cropped.save(w.debugDir + QStringLiteral("/grab-%1-crop.png")
+                                   .arg(w.grabbed, 3, 10, QChar('0')),
+                   "PNG");
+    const bool wasStarted = w.session.started();
+    const stitch::ManualCapture::Outcome out = w.session.feed(cropped);
+    if (!wasStarted && w.session.started())
+      w.firstCrop = cropped;
+    w.lastCrop = cropped;
+    if (!w.debugDir.isEmpty())
+      qInfo().noquote() << QStringLiteral("scroll grab %1: %2 motion=%3(%4) err=%5 conf=%6 kept=%7 pending=%8")
+                               .arg(w.grabbed).arg(QString::fromLatin1(eventName(out.event)))
+                               .arg(static_cast<int>(out.estimate.motion.kind))
+                               .arg(out.estimate.motion.delta)
+                               .arg(out.estimate.error, 0, 'f', 2)
+                               .arg(out.estimate.confidence, 0, 'f', 2)
+                               .arg(out.keptFrames).arg(out.pendingDelta);
+    const QString frames = QStringLiteral("%1 frame%2")
+                               .arg(out.keptFrames)
+                               .arg(out.keptFrames == 1 ? QString() : QStringLiteral("s"));
+    switch (out.event) {
+    case Event::Blank:
+      if (!out.error.isEmpty())
+        postStatus(QStringLiteral("Capture shows only a solid color · "
+                                  "Cancel and select a different region"),
+                   true);
+      break;
+    case Event::Seeded:
+      postStatus(QStringLiteral("Capturing · 1 frame · scroll the page · Done when finished"));
+      break;
+    case Event::Kept:
+    case Event::Pending:
+    case Event::PendingDropped:
+      // Past the advisory edge the capture keeps going; say so plainly and
+      // keep saying it, rather than firing an alert that the editor then
+      // contradicts by opening the result perfectly well.
+      postStatus(QStringLiteral("Capturing · %1%2 · Done when finished")
+                     .arg(frames)
+                     .arg(w.session.exceedsWidelyOpenableEdge()
+                              ? QStringLiteral(" · very long: fine here, "
+                                               "some apps may not open it")
+                              : QString()));
+      break;
+    case Event::Still:
+      break;
+    case Event::ReSeeded:
+      postStatus(QStringLiteral("Capturing · restarted from here (content changed in place) · scroll the page"));
+      break;
+    case Event::Ambiguous:
+      postStatus(QStringLiteral("Repeated content · keep scrolling to a distinctive part"), true);
+      break;
+    case Event::Unmatchable:
+      postStatus(QStringLiteral("Can't align · scroll back a little; moving content (video) can't be captured"), true);
+      break;
+    case Event::WrongDirection:
+      postStatus(QStringLiteral("Scroll the other way to continue this capture (or Done to stitch what you have)"), true);
+      break;
+    case Event::Error:
+      postStatus(QStringLiteral("Could not add frame: %1").arg(out.error), true);
+      break;
+    case Event::Full:
+      // A designed limit. Stop like a finished capture rather than refusing a
+      // frame every tick: what was captured is intact and Done stitches it.
+      postStatus(QStringLiteral("Capture is as long as it can get · press Done "
+                                "to stitch it, or Cancel"),
+                 true);
+      captureFull = true;
+      break;
+    }
+    if (captureFull)
+      break;
+    QThread::msleep(kCaptureIntervalMs);
+  }
+}
+
+void ScrollCaptureOverlay::autoCaptureLoop() {
+  using Event = stitch::AutoCapture::Event;
+  using Ack = stitch::AutoCapture::Ack;
+  Worker &w = *worker_;
+  QString error;
+  while (!stopRequested_) {
+    if (injectorStop_->load(std::memory_order_acquire) &&
+        !w.autoSession.reachedEnd() && !w.autoSession.halted()) {
+      postStatus(QStringLiteral("Auto-scroll stopped · Continue picks it back "
+                                "up, Done stitches it"),
+                 true);
+      postStalled();
+      break;
+    }
+    const std::uint64_t cycle = handshake_->readyCycle();
+    if (cycle == 0 || cycle == w.lastCycle) {
+      QThread::msleep(20);
+      continue;
+    }
+    QImage frame;
+    if (!w.output.grab(frame, error, kGrabTimeoutMs)) {
+      // Never acknowledge on a failed grab: the worker holds this cycle and
+      // the same stable screen is retried.
+      if (w.output.sessionStopped()) {
+        postStatus(QStringLiteral("Screen capture stopped · Done stitches "
+                                  "what was captured"),
+                   true);
+        break;
+      }
+      if (++w.consecutiveFailures >= 3)
+        postStatus(QStringLiteral("Screen capture is failing: %1").arg(error),
+                   true);
+      QThread::msleep(20);
+      continue;
+    }
+    w.consecutiveFailures = 0;
+    ++w.grabbed;
+    const QImage cropped = frame.copy(w.regionPhysical)
+                               .convertToFormat(QImage::Format_RGBA8888);
+    if (!w.debugDir.isEmpty())
+      cropped.save(w.debugDir + QStringLiteral("/grab-%1-crop.png")
+                                   .arg(w.grabbed, 3, 10, QChar('0')),
+                   "PNG");
+    const stitch::AutoCapture::Outcome out = w.autoSession.feed(cropped);
+    if (!w.firstCrop.isNull() || out.event == Event::Seeded)
+      w.lastCrop = cropped;
+    if (out.event == Event::Seeded)
+      w.firstCrop = cropped;
+    if (!w.debugDir.isEmpty())
+      qInfo().noquote() << QStringLiteral("auto grab %1 cycle %2: event=%3 ack=%4 kept=%5")
+                               .arg(w.grabbed).arg(cycle)
+                               .arg(static_cast<int>(out.event))
+                               .arg(static_cast<int>(out.ack))
+                               .arg(w.autoSession.keptFrames());
+    if (out.event == Event::Blank) {
+      // Not consumed: retry the same cycle once the overlay's paint settles.
+      QThread::msleep(20);
+      continue;
+    }
+    w.lastCycle = cycle;
+    switch (out.ack) {
+    case Ack::Normal:
+      handshake_->acknowledge(cycle);
+      break;
+    case Ack::Probe:
+      handshake_->acknowledgeWithNotches(cycle, 1);
+      break;
+    case Ack::Hold:
+      break;
+    }
+    switch (out.event) {
+    case Event::Seeded:
+    case Event::Appended:
+    case Event::Committed:
+      postStatus(QStringLiteral("Auto-scrolling · %1 frame%2%3 · Done stitches")
+                     .arg(w.autoSession.keptFrames())
+                     .arg(w.autoSession.keptFrames() == 1 ? QString()
+                                                          : QStringLiteral("s"))
+                     .arg(w.autoSession.exceedsWidelyOpenableEdge()
+                              ? QStringLiteral(" · very long: fine here, "
+                                               "some apps may not open it")
+                              : QString()));
+      break;
+    case Event::ProbeStarted:
+    case Event::ProbeAgain:
+      postStatus(QStringLiteral("Verifying scroll alignment…"));
+      break;
+    case Event::StillOnce:
+      postStatus(QStringLiteral("Confirming end of content…"));
+      break;
+    case Event::ReachedEnd:
+    case Event::ReachedEndAtSeam:
+      // A page that ended and a page that stopped moving because the pointer
+      // left the frame look the same from here, so this offers Continue
+      // either way: on a real end it simply concludes again.
+      injectorStop_->store(true, std::memory_order_release);
+      postStatus(QStringLiteral("End reached · %1 frames · Continue carries "
+                                "on, Done stitches it")
+                     .arg(w.autoSession.keptFrames()));
+      postStalled();
+      return;
+    case Event::Paused:
+      // Keep only verified content and hand control back. What is verified
+      // stays in the session, so Continue can pick it up from wherever the
+      // page is now.
+      injectorStop_->store(true, std::memory_order_release);
+      w.autoSession.abandonPause();
+      postStatus(QStringLiteral("Auto-scroll paused: capture lost alignment · "
+                                "Continue tries again, Done stitches what was "
+                                "verified"),
+                 true);
+      postStalled();
+      return;
+    case Event::Halted: {
+      injectorStop_->store(true, std::memory_order_release);
+      QString reason;
+      switch (out.haltReason) {
+      case stitch::AutoCapture::HaltReason::LostAlignment:
+        reason = QStringLiteral("Stopped: capture lost alignment");
+        break;
+      case stitch::AutoCapture::HaltReason::MovedBackward:
+        reason = QStringLiteral("Stopped: content moved backward");
+        break;
+      case stitch::AutoCapture::HaltReason::Unmatchable:
+        reason = QStringLiteral("Stopped: retry with slower scrolling");
+        break;
+      case stitch::AutoCapture::HaltReason::BlankFrames:
+        reason = QStringLiteral("Capture shows only a solid color: retry");
+        break;
+      case stitch::AutoCapture::HaltReason::ReachedLimit:
+        reason = QStringLiteral("Capture is as long as it can get");
+        break;
+      default:
+        reason = QStringLiteral("Capture failed: %1").arg(out.error);
+        break;
+      }
+      postStatus(reason + QStringLiteral(" · Done stitches what was captured"),
+                 true);
+      return;
+    }
+    case Event::Blank:
+      break;
+    }
+    QThread::msleep(20);
+  }
+}
+
+void ScrollCaptureOverlay::finishCapture() {
+  if (phase_ != Phase::Capturing)
+    return;
+  phase_ = Phase::Finishing;
+  setStatus(QStringLiteral("Stitching…"));
+  stopWorker();
+  Worker &w = *worker_;
+  QString error;
+  const bool started =
+      mode_ == Mode::Auto ? w.autoSession.started() : w.session.started();
+  if (!started) {
+    cancel();
+    return;
+  }
+  QImage stitched = mode_ == Mode::Auto ? w.autoSession.finish(error)
+                                        : w.session.finish(error);
+  if (stitched.isNull()) {
+    phase_ = Phase::Capturing;
+    setStatus(QStringLiteral("Stitch failed: %1").arg(error), true);
+    // The worker's state is intact; restart the (manual) loop so the user can
+    // continue, since an auto capture that failed to stitch has already
+    // stopped.
+    if (mode_ == Mode::Manual) {
+      stopRequested_ = false;
+      workerFuture_ = QtConcurrent::run([this] { captureLoop(); });
+    }
+    return;
+  }
+  if (mode_ == Mode::Auto && w.autoSession.unverifiedSeams() > 0)
+    qWarning().noquote()
+        << QStringLiteral("scroll: capture may contain %1 repeated or missing "
+                          "section(s)")
+               .arg(w.autoSession.unverifiedSeams());
+  result_ = stitched.convertToFormat(QImage::Format_ARGB32);
+  if (!w.debugDir.isEmpty()) {
+    result_.save(w.debugDir + QStringLiteral("/scroll-stitched.png"), "PNG");
+    if (!w.firstCrop.isNull())
+      w.firstCrop.save(w.debugDir + QStringLiteral("/scroll-first-frame.png"), "PNG");
+    if (!w.lastCrop.isNull())
+      w.lastCrop.save(w.debugDir + QStringLiteral("/scroll-last-frame.png"), "PNG");
+  }
+  const int kept = mode_ == Mode::Auto ? w.autoSession.keptFrames()
+                                       : w.session.keptFrames();
+  qInfo().noquote() << QStringLiteral("scroll: stitched %1 frames into %2x%3")
+                           .arg(kept).arg(result_.width()).arg(result_.height());
+  phase_ = Phase::Finished;
+  close();
+}
+
+void ScrollCaptureOverlay::switchMode(Mode mode) {
+  // Wrong mode is the same mistake as the wrong direction: keep the region,
+  // throw the frames away, start again the other way.
+  if (phase_ == Phase::Selected) {
+    startCapture(mode, axis_);
+    return;
+  }
+  if (phase_ != Phase::Capturing || mode == mode_)
+    return;
+  const stitch::Axis axis = axis_;
+  stopWorker();
+  worker_.reset();
+  injectorStop_.reset();
+  handshake_.reset();
+  stopRequested_ = false;
+  phase_ = Phase::Selected;
+  startCapture(mode, axis);
+}
+
+void ScrollCaptureOverlay::continueCapture() {
+  // Picks the same capture back up: the session keeps every band it already
+  // has, so this carries on from the last one rather than starting a second
+  // capture of the same page. Moving the pointer out is how it stopped, so the
+  // fresh injector parks it back inside the frame.
+  if (phase_ != Phase::Capturing || !worker_ || mode_ != Mode::Auto)
+    return;
+  autoStalled_ = false;
+  stopRequested_ = false;
+  // Pressing Continue means the pointer was on our chrome, which is where we
+  // hold the keyboard, and Hyprland pins pointer focus to a layer that holds
+  // it, so the injected wheel would land on us instead of the page. Let it go
+  // before parking the pointer back inside the frame.
+  setKeyboardGrab(false);
+  worker_->autoSession.resumeFromEnd(); // a stop looks just like an end
+  worker_->lastCycle = 0; // a new handshake counts from one again
+  injectorStop_ = std::make_shared<std::atomic<bool>>(false);
+  handshake_ = std::make_shared<stitch::CaptureHandshake>();
+  const qreal scale = monitor_.scale > 0 ? monitor_.scale : 1.0;
+  const int parkX =
+      qRound((region_.x() + std::max(region_.width() - 30, 1)) * scale);
+  const int parkY =
+      qRound((region_.y() + std::max(region_.height() - 60, 1)) * scale);
+  setStatus(QStringLiteral("Auto-scrolling… · move the pointer out of the "
+                           "frame to stop · Done stitches it"));
+  update();
+  QString spawnError;
+  if (!spawnScrollInjector(injectorStop_, handshake_, parkX, parkY, axis_,
+                           monitor_.name, spawnError)) {
+    autoStalled_ = true;
+    setStatus(QStringLiteral("Could not start auto-scroll again: %1")
+                  .arg(spawnError),
+              true);
+    return;
+  }
+  workerFuture_ = QtConcurrent::run([this] { autoCaptureLoop(); });
+}
+
+void ScrollCaptureOverlay::returnToModeChoice() {
+  // Throw the frames away and go back to the mode row with the region intact.
+  if (phase_ != Phase::Capturing)
+    return;
+  stopWorker();
+  worker_.reset();
+  injectorStop_.reset();
+  handshake_.reset();
+  stopRequested_ = false;
+  phase_ = Phase::Selected;
+  applyInputRegion();
+  setKeyboardGrab(false);
+  setStatus(QStringLiteral("The page inside is live · scroll it into position, "
+                           "then choose a mode"));
+  update();
+}
+
+void ScrollCaptureOverlay::cancel() {
+  stopWorker();
+  result_ = {};
+  phase_ = Phase::Finished;
+  close();
+}
+
+// ---- chrome ------------------------------------------------------------------
+
+int ScrollCaptureOverlay::capturePillCount() const {
+  return autoStalled_ ? 4 : 3;
+}
+
+QRect ScrollCaptureOverlay::doneButtonRect() const {
+  return scrollOverlayPillRect(rect(), region_, capturePillCount(), 0, 132, 40,
+                               12);
+}
+
+QRect ScrollCaptureOverlay::continueButtonRect() const {
+  if (!autoStalled_)
+    return {};
+  return scrollOverlayPillRect(rect(), region_, capturePillCount(), 1, 132, 40,
+                               12);
+}
+QVector<QPair<QString, QString>> ScrollCaptureOverlay::legendEntries() const {
+  if (phase_ == Phase::Selecting) {
+    QVector<QPair<QString, QString>> entries{
+        {QStringLiteral("Drag"), QStringLiteral("Scroll region")},
+        {QStringLiteral("A"), QStringLiteral("Area capture")},
+        {QStringLiteral("Esc"), QStringLiteral("Close")}};
+    if (!storedRegion_.isEmpty())
+      entries.insert(1, {QStringLiteral("R"), QStringLiteral("Last region")});
+    return entries;
+  }
+  // Once a region exists the keyboard belongs to the page, which is what makes
+  // it scrollable, so nothing here may promise a key. The buttons on screen
+  // are the controls, and they say so themselves.
+  return {};
+}
+
+QVector<QPair<QRect, ScrollCaptureOverlay::Grip>>
+ScrollCaptureOverlay::gripRects() const {
+  // Every grip lives in the band *outside* the region, never over it: the
+  // capture is that rectangle of the screen, so a bracket drawn inside it is a
+  // bracket stitched into the result. Each corner is two arms, which is what
+  // makes the bracket shape and keeps every rect clear of the region.
+  if (phase_ != Phase::Selected || region_.isEmpty())
+    return {};
+  const int arm = 34;
+  const int barLong = 62;
+  const QPoint center = region_.center();
+  const int outerTop = region_.top() - kGripBand;
+  const int outerLeft = region_.left() - kGripBand;
+  const int belowBottom = region_.bottom() + 1;
+  const int pastRight = region_.right() + 1;
+  const auto across = [&](int x, int y) { return QRect(x, y, arm, kGripBand); };
+  const auto down = [&](int x, int y) { return QRect(x, y, kGripBand, arm); };
+  return {
+      {across(outerLeft, outerTop), Grip::TopLeft},
+      {down(outerLeft, outerTop), Grip::TopLeft},
+      {across(region_.right() - arm + kGripBand + 1, outerTop),
+       Grip::TopRight},
+      {down(pastRight, outerTop), Grip::TopRight},
+      {across(region_.right() - arm + kGripBand + 1, belowBottom),
+       Grip::BottomRight},
+      {down(pastRight, region_.bottom() - arm + kGripBand + 1),
+       Grip::BottomRight},
+      {across(outerLeft, belowBottom), Grip::BottomLeft},
+      {down(outerLeft, region_.bottom() - arm + kGripBand + 1),
+       Grip::BottomLeft},
+      {QRect(center.x() - barLong / 2, outerTop, barLong, kGripBand),
+       Grip::Top},
+      {QRect(center.x() - barLong / 2, belowBottom, barLong, kGripBand),
+       Grip::Bottom},
+      {QRect(outerLeft, center.y() - barLong / 2, kGripBand, barLong),
+       Grip::Left},
+      {QRect(pastRight, center.y() - barLong / 2, kGripBand, barLong),
+       Grip::Right},
+      // The puck is the one grip that has to sit inside the region, because the
+      // middle is what it moves. It is drawn only while a mode is being chosen,
+      // and a capture does not start until a frame without it has been painted
+      // and shown, see startCapture.
+      {QRect(center.x() - 22, center.y() - 22, 44, 44), Grip::Move},
+  };
+}
+
+Qt::CursorShape ScrollCaptureOverlay::gripCursor(Grip grip) {
+  switch (grip) {
+  case Grip::TopLeft:
+  case Grip::BottomRight:
+    return Qt::SizeFDiagCursor;
+  case Grip::TopRight:
+  case Grip::BottomLeft:
+    return Qt::SizeBDiagCursor;
+  case Grip::Top:
+  case Grip::Bottom:
+    return Qt::SizeVerCursor;
+  case Grip::Left:
+  case Grip::Right:
+    return Qt::SizeHorCursor;
+  case Grip::Move:
+    return Qt::SizeAllCursor;
+  case Grip::None:
+    break;
+  }
+  return Qt::ArrowCursor;
+}
+
+ScrollCaptureOverlay::Grip
+ScrollCaptureOverlay::gripAt(const QPoint &point) const {
+  if (phase_ != Phase::Selected || region_.isEmpty())
+    return Grip::None;
+  // Corners are listed first and sides overlap them at the ends, so the first
+  // match wins: a corner is never stolen by the bar beside it.
+  for (const auto &[rect, grip] : gripRects()) {
+    if (rect.contains(point))
+      return grip;
+  }
+  // The border moves the region as well: the puck is the obvious way, the
+  // border is the one already under your hand after a resize.
+  const QRect band =
+      region_.adjusted(-kGripBand, -kGripBand, kGripBand, kGripBand);
+  if (band.contains(point) && !region_.contains(point))
+    return Grip::Move;
+  return Grip::None;
+}
+
+void ScrollCaptureOverlay::applyGrip(const QPoint &point) {
+  const QRect surface = rect();
+  const QPoint delta = point - gripStartPoint_;
+  QRect updated = gripStartRegion_;
+  if (activeGrip_ == Grip::Move) {
+    updated.moveTo(gripStartRegion_.topLeft() + delta);
+    // Clamped whole, so dragging past an edge slides along it instead of
+    // shrinking the region.
+    updated.moveLeft(std::clamp(updated.left(), surface.left(),
+                                surface.right() - updated.width() + 1));
+    updated.moveTop(std::clamp(updated.top(), surface.top(),
+                               surface.bottom() - updated.height() + 1));
+    region_ = updated;
+    return;
+  }
+  const bool movesLeft = activeGrip_ == Grip::TopLeft ||
+                         activeGrip_ == Grip::Left ||
+                         activeGrip_ == Grip::BottomLeft;
+  const bool movesRight = activeGrip_ == Grip::TopRight ||
+                          activeGrip_ == Grip::Right ||
+                          activeGrip_ == Grip::BottomRight;
+  const bool movesTop = activeGrip_ == Grip::TopLeft ||
+                        activeGrip_ == Grip::Top ||
+                        activeGrip_ == Grip::TopRight;
+  const bool movesBottom = activeGrip_ == Grip::BottomLeft ||
+                           activeGrip_ == Grip::Bottom ||
+                           activeGrip_ == Grip::BottomRight;
+  // Clamped against the edge that stays, so a region dragged through itself
+  // stops at the minimum rather than turning inside out.
+  if (movesLeft)
+    updated.setLeft(std::clamp(point.x(), surface.left(),
+                               gripStartRegion_.right() - kMinRegion));
+  if (movesRight)
+    updated.setRight(std::clamp(point.x(),
+                                gripStartRegion_.left() + kMinRegion,
+                                surface.right()));
+  if (movesTop)
+    updated.setTop(std::clamp(point.y(), surface.top(),
+                              gripStartRegion_.bottom() - kMinRegion));
+  if (movesBottom)
+    updated.setBottom(std::clamp(point.y(),
+                                 gripStartRegion_.top() + kMinRegion,
+                                 surface.bottom()));
+  region_ = updated;
+}
+
+QRect ScrollCaptureOverlay::backButtonRect() const {
+  return scrollOverlayPillRect(rect(), region_, capturePillCount(),
+                               autoStalled_ ? 2 : 1, 132, 40, 12);
+}
+QRect ScrollCaptureOverlay::cancelButtonRect() const {
+  return scrollOverlayPillRect(rect(), region_, capturePillCount(),
+                               autoStalled_ ? 3 : 2, 132, 40, 12);
+}
+QRect ScrollCaptureOverlay::selectedCancelButtonRect() const {
+  return modeButtonRect(kModeButtonCount);
+}
+QRect ScrollCaptureOverlay::modeButtonRect(int index) const {
+  // The mode pills plus an explicit Cancel: Esc alone cannot be the way out,
+  // because the keyboard belongs to the page whenever the pointer is over it.
+  return scrollOverlayPillRect(rect(), region_, kModeButtonCount + 1, index,
+                               kModeButtonWidth, kModeButtonHeight,
+                               kModeButtonGap);
+}
+int ScrollCaptureOverlay::modeButtonAt(const QPoint &point) const {
+  for (int index = 0; index < kModeButtonCount; ++index)
+    if (modeButtonRect(index).contains(point))
+      return index;
+  return -1;
+}
+
+void ScrollCaptureOverlay::paintEvent(QPaintEvent *) {
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing);
+  if (phase_ == Phase::Selecting) {
+    const QRect r = dragging_ ? regionLogical() : QRect();
+    painter.setCompositionMode(QPainter::CompositionMode_Source);
+    painter.fillRect(rect(), kDim);
+    if (!r.isEmpty()) {
+      painter.fillRect(r, Qt::transparent);
+      painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+      painter.setPen(QPen(kAccent, 2));
+      painter.setBrush(Qt::NoBrush);
+      painter.drawRect(r.adjusted(-2, -2, 2, 2));
+    } else {
+      // The same full-width crosshairs the region capture draws: they line the
+      // pointer up with what is on screen before the drag starts.
+      painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+      painter.setPen(QPen(QColor(255, 255, 255, 56), 1));
+      painter.drawLine(QPointF(cursor_.x(), 0), QPointF(cursor_.x(), height()));
+      painter.drawLine(QPointF(0, cursor_.y()), QPointF(width(), cursor_.y()));
+    }
+  } else {
+    painter.setCompositionMode(QPainter::CompositionMode_Source);
+    painter.fillRect(rect(), kDim);
+    painter.fillRect(region_, Qt::transparent);
+    painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+    painter.setPen(QPen(statusWarning_ ? kWarn : kAccent, 2));
+    painter.setBrush(Qt::NoBrush);
+    // Fully outside the region so no overlay pixel lands in the capture.
+    painter.drawRect(region_.adjusted(-3, -3, 3, 3));
+
+    // Grips live in the band outside the region: that rectangle is the
+    // capture, so anything drawn inside it would be captured.
+    if (phase_ == Phase::Selected) {
+      const int thickness = 4;
+      painter.setPen(Qt::NoPen);
+      painter.setBrush(QColor(255, 255, 255, 235));
+      for (const auto &[grip, which] : gripRects()) {
+        if (which == Grip::Move) {
+          const QPointF middle = grip.center();
+          painter.setBrush(QColor(20, 20, 26, 215));
+          painter.setPen(QPen(QColor(255, 255, 255, 235), 2));
+          painter.drawEllipse(middle, grip.width() / 2.0 - 2,
+                              grip.height() / 2.0 - 2);
+          painter.drawLine(middle + QPointF(-9, 0), middle + QPointF(9, 0));
+          painter.drawLine(middle + QPointF(0, -9), middle + QPointF(0, 9));
+          painter.setPen(Qt::NoPen);
+          painter.setBrush(QColor(255, 255, 255, 235));
+          continue;
+        }
+        if (grip.bottom() < region_.top())
+          painter.drawRect(QRect(grip.left(), grip.bottom() - thickness + 1,
+                                 grip.width(), thickness));
+        else if (grip.top() > region_.bottom())
+          painter.drawRect(
+              QRect(grip.left(), grip.top(), grip.width(), thickness));
+        else if (grip.right() < region_.left())
+          painter.drawRect(QRect(grip.right() - thickness + 1, grip.top(),
+                                 thickness, grip.height()));
+        else
+          painter.drawRect(
+              QRect(grip.left(), grip.top(), thickness, grip.height()));
+      }
+    }
+    QFont buttonFont = painter.font();
+    buttonFont.setPixelSize(15);
+    buttonFont.setBold(true);
+    painter.setFont(buttonFont);
+    if (phase_ == Phase::Selected) {
+      for (int index = 0; index < kModeButtonCount; ++index) {
+        const QRect button = modeButtonRect(index);
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(kModeButtons[index].automatic
+                             ? kAccent
+                             : QColor(40, 40, 48, 240));
+        painter.drawRoundedRect(button, 8, 8);
+        painter.setPen(Qt::white);
+        painter.drawText(button, Qt::AlignCenter,
+                         QString::fromUtf8(kModeButtons[index].label));
+      }
+      const QRect cancelSlot = selectedCancelButtonRect();
+      painter.setPen(Qt::NoPen);
+      painter.setBrush(QColor(40, 40, 48, 240));
+      painter.drawRoundedRect(cancelSlot, 8, 8);
+      painter.setPen(Qt::white);
+      painter.drawText(cancelSlot, Qt::AlignCenter, QStringLiteral("Cancel"));
+    } else {
+      const QRect done = doneButtonRect();
+      const QRect backRect = backButtonRect();
+      const QRect cancelRect = cancelButtonRect();
+      painter.setPen(Qt::NoPen);
+      painter.setBrush(kAccent);
+      painter.drawRoundedRect(done, 8, 8);
+      painter.setBrush(QColor(40, 40, 48, 240));
+      painter.drawRoundedRect(backRect, 8, 8);
+      painter.drawRoundedRect(cancelRect, 8, 8);
+      painter.setPen(Qt::white);
+      painter.drawText(done, Qt::AlignCenter, QStringLiteral("Done · stitch"));
+      painter.drawText(backRect, Qt::AlignCenter, QStringLiteral("Back"));
+      painter.drawText(cancelRect, Qt::AlignCenter, QStringLiteral("Cancel"));
+      if (autoStalled_) {
+        const QRect resume = continueButtonRect();
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(QColor(40, 40, 48, 240));
+        painter.drawRoundedRect(resume, 8, 8);
+        painter.setPen(Qt::white);
+        painter.drawText(resume, Qt::AlignCenter, QStringLiteral("Continue"));
+      }
+    }
+  }
+  // The same chrome the capture overlay wears. Once a capture is running the
+  // badge also names the direction, since the pills that said so are gone.
+  const QString badge =
+      phase_ != Phase::Capturing ? QStringLiteral("SCROLL")
+      : mode_ == Mode::Auto      ? QStringLiteral("SCROLL · AUTO")
+                                 : QStringLiteral("SCROLL · MANUAL");
+  drawModeBadge(painter, rect(), badge, QColor(QStringLiteral("#30d158")),
+                &modeBadgeClose_);
+  drawHotkeyLegend(painter, rect(), cursor_, legendEntries());
+  drawStatusPill(painter, rect(), status_);
+}
+
+void ScrollCaptureOverlay::wheelEvent(QWheelEvent *event) {
+  // The hole passes the wheel to the page; the overlay only sees wheel over its
+  // own chrome. Log it (debug runs), during capture a wheel event arriving with
+  // the pointer inside the region would mean the input-region hole is not in
+  // effect.
+  if (worker_ && !worker_->debugDir.isEmpty())
+    qInfo().noquote() << QStringLiteral("scroll: overlay wheel at %1,%2 phase=%3")
+                             .arg(event->position().x())
+                             .arg(event->position().y())
+                             .arg(static_cast<int>(phase_));
+  QWidget::wheelEvent(event);
+}
+
+void ScrollCaptureOverlay::enterEvent(QEnterEvent *event) {
+  updateKeyboardZone(event->position().toPoint());
+  if (worker_ && !worker_->debugDir.isEmpty())
+    qInfo().noquote() << QStringLiteral("scroll: pointer entered overlay at %1,%2")
+                             .arg(event->position().x())
+                             .arg(event->position().y());
+  QWidget::enterEvent(event);
+}
+
+void ScrollCaptureOverlay::leaveEvent(QEvent *event) {
+  // The pointer is off our input region entirely, over the page, or off the
+  // screen. Either way it is not on our chrome, so the keyboard goes back to
+  // whatever is under it and the page can be scrolled again.
+  if (phase_ != Phase::Selecting)
+    setKeyboardGrab(false);
+  if (worker_ && !worker_->debugDir.isEmpty())
+    qInfo().noquote() << QStringLiteral("scroll: pointer left overlay");
+  QWidget::leaveEvent(event);
+}
+
+void ScrollCaptureOverlay::mousePressEvent(QMouseEvent *event) {
+  if (event->button() == Qt::RightButton) {
+    cancel();
+    return;
+  }
+  if (event->button() != Qt::LeftButton)
+    return;
+  // The badge's × leaves, wherever the shared chrome laid it out this frame.
+  if (modeBadgeClose_.contains(event->position())) {
+    cancel();
+    return;
+  }
+  if (phase_ == Phase::Capturing) {
+    const QPoint point = event->position().toPoint();
+    if (doneButtonRect().contains(point))
+      finishCapture();
+    else if (autoStalled_ && continueButtonRect().contains(point))
+      continueCapture();
+    else if (backButtonRect().contains(point))
+      returnToModeChoice();
+    else if (cancelButtonRect().contains(point))
+      cancel();
+    return; // clicks elsewhere in the chrome do nothing
+  }
+  if (phase_ == Phase::Selected) {
+    const QPoint point = event->position().toPoint();
+    if (selectedCancelButtonRect().contains(point)) {
+      cancel();
+      return;
+    }
+    const int mode = modeButtonAt(point);
+    if (mode >= 0) {
+      startCapture(kModeButtons[mode].automatic ? Mode::Auto : Mode::Manual,
+                   kModeButtons[mode].axis);
+      update();
+      return;
+    }
+    if (const Grip grip = gripAt(point); grip != Grip::None) {
+      activeGrip_ = grip;
+      gripStartRegion_ = region_;
+      gripStartPoint_ = point;
+      return;
+    }
+    // A press inside the region belongs to the page, the input region should
+    // have sent it there. If one reaches the overlay anyway (a mask that has
+    // not been committed yet, or the pixel or two beneath the outline), it must
+    // not be read as "start over": losing the region to a click meant for the
+    // page is the one thing this phase cannot do.
+    if (region_.adjusted(-6, -6, 6, 6).contains(point)) {
+      applyInputRegion();
+      return;
+    }
+    // Anywhere else, that is, anywhere on the chrome, starts a fresh selection,
+    // which takes the whole surface and the keyboard back.
+    phase_ = Phase::Selecting;
+    dragStart_ = point;
+    dragEnd_ = point;
+    dragging_ = true;
+    applyInputRegion();
+    setCursor(Qt::CrossCursor);
+    setKeyboardGrab(true); // drawing a region again wants Esc and Enter back
+    setStatus(QStringLiteral("Drag to select a scroll region · A switches to "
+                             "area capture"));
+    update();
+    return;
+  }
+  if (phase_ != Phase::Selecting)
+    return;
+  dragStart_ = event->position().toPoint();
+  dragEnd_ = dragStart_;
+  dragging_ = true;
+  update();
+}
+
+void ScrollCaptureOverlay::mouseMoveEvent(QMouseEvent *event) {
+  const QPoint point = event->position().toPoint();
+  cursor_ = point;
+  if (phase_ == Phase::Selecting) {
+    setCursor(Qt::CrossCursor);
+    if (dragging_)
+      dragEnd_ = point;
+    update(); // the crosshairs follow the pointer
+    if (dragging_)
+      return;
+  }
+  updateKeyboardZone(point);
+  if (activeGrip_ != Grip::None) {
+    // The button is down, so motion keeps arriving even over the hole.
+    applyGrip(point);
+    dragStart_ = region_.topLeft();
+    dragEnd_ = region_.bottomRight();
+    applyInputRegion(); // the hole follows the region as it is dragged
+    update();
+    return;
+  }
+  if (phase_ == Phase::Selected)
+    setCursor(gripCursor(gripAt(point)));
+}
+
+void ScrollCaptureOverlay::mouseReleaseEvent(QMouseEvent *event) {
+  if (event->button() == Qt::LeftButton && activeGrip_ != Grip::None) {
+    activeGrip_ = Grip::None;
+    rememberRegion();
+    applyInputRegion();
+    update();
+    return;
+  }
+  if (event->button() != Qt::LeftButton || phase_ != Phase::Selecting ||
+      !dragging_)
+    return;
+  dragEnd_ = event->position().toPoint();
+  dragging_ = false;
+  region_ = regionLogical();
+  if (region_.width() < kMinRegion || region_.height() < kMinRegion) {
+    update();
+    return; // too small; stay in selection
+  }
+  // Reserve a strip of real chrome: inside the hole the buttons' clicks fall
+  // through and the chrome bakes into the capture, and a full-screen region
+  // would empty the input mask entirely.
+  constexpr int chromeStrip = 40 + 18 + 12;
+  if (region_.top() < chromeStrip && region_.bottom() > height() - chromeStrip)
+    region_.setBottom(height() - chromeStrip);
+  enterSelected();
+}
+
+void ScrollCaptureOverlay::enterSelected() {
+  phase_ = Phase::Selected;
+  dragging_ = false;
+  rememberRegion();
+  applyInputRegion();
+  setCursor(Qt::ArrowCursor); // the grips take it from here
+  setKeyboardGrab(false);
+  setStatus(QStringLiteral("The page inside is live · scroll it into position, "
+                           "then choose a mode"));
+  update();
+}
+
+void ScrollCaptureOverlay::keyPressEvent(QKeyEvent *event) {
+  if (event->key() == Qt::Key_Escape) {
+    cancel();
+    return;
+  }
+  // Enter stitches what has been captured so far, for when the pointer is
+  // already on the chrome and the buttons are a reach.
+  if (phase_ == Phase::Capturing &&
+      (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)) {
+    finishCapture();
+    return;
+  }
+  // Before a region exists there is no capture to switch the mode of, so A
+  // means the other kind of capture entirely: hand back to area capture, which
+  // relaunches rather than making anyone close this and start again.
+  if (phase_ == Phase::Selecting && event->key() == Qt::Key_A) {
+    switchedToArea_ = true;
+    stopWorker();
+    phase_ = Phase::Finished;
+    close();
+    return;
+  }
+  // A shortcut, never the advertised way: only the pointer being on our own
+  // chrome puts the keyboard here at all.
+  if ((phase_ == Phase::Selected || phase_ == Phase::Capturing) &&
+      (event->key() == Qt::Key_S || event->key() == Qt::Key_A)) {
+    switchMode(event->key() == Qt::Key_A ? Mode::Auto : Mode::Manual);
+    return;
+  }
+  // R brings back the last region as a normal selection, so the grips adjust
+  // it from there.
+  if (phase_ == Phase::Selecting && !storedRegion_.isEmpty() &&
+      event->key() == Qt::Key_R) {
+    region_ = storedRegion_;
+    dragStart_ = region_.topLeft();
+    dragEnd_ = region_.bottomRight();
+    enterSelected();
+    return;
+  }
+  // While capturing the layer holds no keyboard, so no key arrives here.
+  QWidget::keyPressEvent(event);
+}
+
+QImage runScrollCapture(const MonitorInfo &monitor, QString &error,
+                        bool *switchedToArea) {
+  QScreen *targetScreen = QGuiApplication::primaryScreen();
+  for (QScreen *screen : QGuiApplication::screens()) {
+    if (screen->name() == monitor.name) {
+      targetScreen = screen;
+      break;
+    }
+  }
+  ScrollCaptureOverlay overlay(monitor);
+  overlay.setScreen(targetScreen);
+  overlay.setGeometry(targetScreen->geometry());
+  overlay.winId();
+  QWindow *window = overlay.windowHandle();
+  LayerShellQt::Window *layer =
+      window ? LayerShellQt::Window::get(window) : nullptr;
+  if (!window || !layer) {
+    error = QStringLiteral("Could not create scroll-capture overlay layer");
+    return {};
+  }
+  layer->setScope(QStringLiteral("omasnap-scroll"));
+  layer->setScreen(targetScreen);
+  layer->setLayer(LayerShellQt::Window::LayerOverlay);
+  LayerShellQt::Window::Anchors anchors;
+  anchors.setFlag(LayerShellQt::Window::AnchorTop);
+  anchors.setFlag(LayerShellQt::Window::AnchorBottom);
+  anchors.setFlag(LayerShellQt::Window::AnchorLeft);
+  anchors.setFlag(LayerShellQt::Window::AnchorRight);
+  layer->setAnchors(anchors);
+  layer->setExclusiveZone(-1);
+  layer->setKeyboardInteractivity(
+      LayerShellQt::Window::KeyboardInteractivityExclusive);
+  layer->setActivateOnShow(true);
+  overlay.setLayerWindow(layer);
+  overlay.show();
+  overlay.setFocus(Qt::ActiveWindowFocusReason);
+
+  // Run until the overlay closes (WA_DeleteOnClose is off by default, so the
+  // widget survives close() and its result stays readable).
+  while (overlay.isVisible())
+    QApplication::processEvents(QEventLoop::WaitForMoreEvents);
+  if (switchedToArea)
+    *switchedToArea = overlay.switchedToArea();
+  return overlay.result();
+}

--- a/src/scroll-capture.hpp
+++ b/src/scroll-capture.hpp
@@ -1,0 +1,278 @@
+/** @fileoverview Manual scroll capture: an overlay that dims the screen around
+ *  a chosen region, lets the user scroll the page beneath it, grabs a frame
+ *  per scroll step through the live output-capture session, and stitches them
+ *  into one tall image with the pure stitcher. Ties together the keyboard-
+ *  interactivity zone, ext-image-copy-capture output capture, and stitch.hpp.
+ *  The capture loop (grab → crop → classify → accumulate) runs on a worker
+ *  thread so the overlay stays responsive. In manual mode small movements
+ *  are held as a replaceable pending frame until they grow
+ *  past a threshold, ambiguous small motion is recovered with a bounded
+ *  re-search, the direction locks on the first committed band, and a frame
+ *  that cannot be aligned keeps the last verified reference and warns instead
+ *  of silently continuing. */
+#pragma once
+
+#include "auto-capture.hpp"
+#include "capture.hpp"
+#include "overlay-chrome.hpp"
+#include "stitch.hpp"
+
+#include <QFuture>
+#include <QImage>
+#include <QRect>
+#include <QPair>
+#include <QRegion>
+#include <QSize>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+#include <QWidget>
+
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <optional>
+
+namespace LayerShellQt {
+class Window;
+}
+
+/// The overlay's input region whenever a page is exposed: the whole surface
+/// minus the chosen region, with the chrome added back so a button that
+/// overlaps the region still takes clicks. Pointer input inside the hole goes
+/// to the application underneath, which is what lets the page be scrolled into
+/// place, and, during capture, scrolled at all.
+[[nodiscard]] inline QRegion scrollOverlayInputRegion(
+    const QRect &surface, const QRect &page, const QVector<QRect> &chrome) {
+  QRegion region(surface);
+  region -= page;
+  for (const QRect &rect : chrome)
+    region += rect.intersected(surface);
+  return region;
+}
+
+/// One pill in a centered row of `count` pills, laid out just below `region`
+/// (above it when there is no room, and never over it), clamped inside
+/// `surface`. The chrome has to stay clear of the region: it would otherwise
+/// be captured, and its clicks would fall through the input-region hole.
+[[nodiscard]] inline QRect scrollOverlayPillRect(const QRect &surface,
+                                                 const QRect &region, int count,
+                                                 int index, int pillWidth,
+                                                 int pillHeight, int gap) {
+  const int totalW = count * pillWidth + (count - 1) * gap;
+  int x = region.center().x() - totalW / 2;
+  x = std::clamp(x, 12, std::max(12, surface.width() - totalW - 12));
+  int y = region.bottom() + 18;
+  if (y + pillHeight > surface.height() - 12)
+    y = region.top() - pillHeight - 18;
+  if (y < 12)
+    y = 12;
+  return QRect(x + index * (pillWidth + gap), y, pillWidth, pillHeight);
+}
+
+/// One line describing the region last captured on a monitor, for the runtime
+/// file that lets the next capture start from it. Session scratch, not
+/// configuration: it lives beside the snapshots and the instance lock in
+/// $XDG_RUNTIME_DIR, so it is gone at reboot, a region only means anything for
+/// the screen it was drawn on.
+[[nodiscard]] inline QString formatStoredScrollRegion(const QString &monitor,
+                                                      const QSize &surface,
+                                                      const QRect &region) {
+  return QStringLiteral("%1 %2 %3 %4 %5 %6 %7")
+      .arg(monitor.isEmpty() ? QStringLiteral("?") : monitor)
+      .arg(surface.width())
+      .arg(surface.height())
+      .arg(region.x())
+      .arg(region.y())
+      .arg(region.width())
+      .arg(region.height());
+}
+
+/// The region in `line`, or a null rect when it was written for a different
+/// monitor or a different screen size, does not fit, or is not what we wrote.
+/// Anything unreadable is simply not offered; there is nothing to migrate.
+[[nodiscard]] inline QRect parseStoredScrollRegion(const QString &line,
+                                                   const QString &monitor,
+                                                   const QSize &surface) {
+  const QStringList fields = line.trimmed().split(QLatin1Char(' '));
+  if (fields.size() != 7)
+    return {};
+  if (fields.at(0) != (monitor.isEmpty() ? QStringLiteral("?") : monitor))
+    return {};
+  bool ok = true;
+  int values[6] = {};
+  for (int index = 0; index < 6; ++index) {
+    bool field = false;
+    values[index] = fields.at(index + 1).toInt(&field);
+    ok = ok && field;
+  }
+  if (!ok || QSize(values[0], values[1]) != surface)
+    return {};
+  const QRect region(values[2], values[3], values[4], values[5]);
+  if (region.width() < 32 || region.height() < 32 ||
+      !QRect(QPoint(), surface).contains(region))
+    return {};
+  return region;
+}
+
+/// Overlay widget for one scroll capture on a single monitor: drag a region,
+/// choose a mode (manual or automatic, vertical or horizontal), scroll, or let
+/// the injection worker scroll, and stitch. Show it on an exclusive fullscreen
+/// layer surface; when it closes, result() holds the stitched image (null if
+/// cancelled).
+class ScrollCaptureOverlay final : public QWidget {
+public:
+  explicit ScrollCaptureOverlay(MonitorInfo monitor, QWidget *parent = nullptr);
+  ~ScrollCaptureOverlay() override;
+
+  /// The layer surface backing this widget; used to toggle keyboard
+  /// interactivity as the pointer crosses between chrome and the page.
+  void setLayerWindow(LayerShellQt::Window *layer);
+  /// The stitched capture, or a null image if the user cancelled.
+  [[nodiscard]] QImage result() const { return result_; }
+  /// Whether the overlay was left by asking for an ordinary area capture
+  /// instead. The two are the same tool in two moods, so A swaps between them
+  /// rather than making anyone close one and launch the other.
+  [[nodiscard]] bool switchedToArea() const { return switchedToArea_; }
+
+protected:
+  void paintEvent(QPaintEvent *event) override;
+  void showEvent(QShowEvent *event) override;
+  void wheelEvent(QWheelEvent *event) override;
+  void enterEvent(QEnterEvent *event) override;
+  void leaveEvent(QEvent *event) override;
+  void mousePressEvent(QMouseEvent *event) override;
+  void mouseMoveEvent(QMouseEvent *event) override;
+  void mouseReleaseEvent(QMouseEvent *event) override;
+  void keyPressEvent(QKeyEvent *event) override;
+
+private:
+  enum class Phase { Selecting, Selected, Capturing, Finishing, Finished };
+  enum class Mode { Manual, Auto };
+  /// What a press on the region's chrome does: the eight edges and corners
+  /// resize it, the puck in the middle moves it. The middle is otherwise the
+  /// page's, so moving needs a grip of its own.
+  enum class Grip {
+    None,
+    TopLeft,
+    Top,
+    TopRight,
+    Right,
+    BottomRight,
+    Bottom,
+    BottomLeft,
+    Left,
+    Move
+  };
+  /// Everything the worker thread owns; the UI thread only reads it after
+  /// the worker has stopped.
+  struct Worker;
+
+  void startCapture(Mode mode, stitch::Axis axis);
+  void stopWorker();
+  void finishCapture();
+  void cancel();
+  /// Region chosen (dragged or restored): remember it, expose the page, hand
+  /// the keyboard over by zone, and offer the modes.
+  void enterSelected();
+  void applyInputRegion();
+  /// Takes or releases the exclusive keyboard grab. Held only while a region
+  /// is being drawn; released for as long as one exists, because Hyprland
+  /// pins pointer focus to a layer that holds it and the page underneath has
+  /// to stay scrollable.
+  void setKeyboardGrab(bool grab);
+  /// Holds the grab only while the pointer is on the overlay's own chrome, and
+  /// only when an event has said where the pointer is.
+  void updateKeyboardZone(const QPoint &point);
+  /// Restarts the capture in the other mode, keeping the region.
+  void switchMode(Mode mode);
+  /// Rects the overlay must keep taking clicks in the current phase.
+  [[nodiscard]] QVector<QRect> chromeRects() const;
+  void setStatus(const QString &status, bool warning = false);
+  [[nodiscard]] QRect regionLogical() const;
+  [[nodiscard]] QRect regionPhysical() const;
+  [[nodiscard]] QRect doneButtonRect() const;
+  /// Leaves a capture in progress and returns to the mode row, keeping the
+  /// region: the way out of having picked the wrong direction.
+  void returnToModeChoice();
+  /// The grips drawn on a chosen region, with what each one does. Empty in
+  /// every phase but Selected: during a capture anything drawn inside the
+  /// region would be captured with it.
+  [[nodiscard]] QVector<QPair<QRect, Grip>> gripRects() const;
+  [[nodiscard]] Grip gripAt(const QPoint &point) const;
+  [[nodiscard]] static Qt::CursorShape gripCursor(Grip grip);
+  /// Applies a grip drag: `point` is where the pointer is now, measured
+  /// against where the region and the pointer started.
+  void applyGrip(const QPoint &point);
+  void rememberRegion() const;
+  /// What the key guide in the corner says, for the phase in hand.
+  [[nodiscard]] QVector<QPair<QString, QString>> legendEntries() const;
+  /// Resumes an auto capture that stopped short, keeping what it has.
+  void continueCapture();
+  /// How many pills the capture row holds: Continue only appears when there
+  /// is something to continue.
+  [[nodiscard]] int capturePillCount() const;
+  [[nodiscard]] QRect continueButtonRect() const;
+  [[nodiscard]] QRect backButtonRect() const;
+  [[nodiscard]] QRect cancelButtonRect() const;
+  /// Cancel shown beside the mode pills, so backing out never depends on a
+  /// key the page may be holding.
+  [[nodiscard]] QRect selectedCancelButtonRect() const;
+  /// Mode buttons shown in the Selected phase; index into kModeButtons.
+  [[nodiscard]] QRect modeButtonRect(int index) const;
+  [[nodiscard]] int modeButtonAt(const QPoint &point) const;
+  // Worker-thread bodies.
+  void captureLoop();     // manual: poll and classify
+  void autoCaptureLoop(); // automatic: consume ready cycles and acknowledge
+  void postStatus(const QString &status, bool warning = false);
+  /// Worker-thread notice that an auto capture stopped short of the end.
+  void postStalled();
+
+  MonitorInfo monitor_;
+  LayerShellQt::Window *layer_ = nullptr;
+  Phase phase_ = Phase::Selecting;
+  /// Last pointer position, for the crosshairs drawn while choosing a region.
+  QPoint cursor_;
+  QPoint dragStart_;
+  QPoint dragEnd_;
+  bool dragging_ = false;
+  QRect region_; // logical widget pixels, normalized
+  Mode mode_ = Mode::Manual;
+  stitch::Axis axis_ = stitch::Axis::Vertical;
+  QString status_;
+  bool statusWarning_ = false;
+  QImage result_;
+  bool switchedToArea_ = false;
+  /// Set when an auto capture stops before the end of the page, the pointer
+  /// left the frame, or the injector gave up. What has been captured is still
+  /// in the session, so it can be picked up again.
+  bool autoStalled_ = false;
+  /// The region this monitor was last captured with, if the runtime file had
+  /// one that still fits. Not shown until asked for: most captures are of
+  /// somewhere new, so the overlay opens empty and R brings this back.
+  QRect storedRegion_;
+  /// The badge's × , as the shared chrome laid it out this frame.
+  QRectF modeBadgeClose_;
+  /// The grip being dragged, and what the region and pointer were when it
+  /// started.
+  Grip activeGrip_ = Grip::None;
+  QRect gripStartRegion_;
+  QPoint gripStartPoint_;
+  /// Whether the layer currently holds the exclusive keyboard grab. It does
+  /// while a region is being drawn, and not once one exists.
+  bool keyboardGrabbed_ = true;
+
+  std::unique_ptr<Worker> worker_;
+  QFuture<void> workerFuture_;
+  std::atomic<bool> stopRequested_{false};
+  /// Auto mode: the injection worker's shared stop flag (it also sets this
+  /// itself on any exit) and the capture handshake.
+  std::shared_ptr<std::atomic<bool>> injectorStop_;
+  std::shared_ptr<stitch::CaptureHandshake> handshake_;
+};
+
+/// Runs a manual scroll capture on `monitor` (its own exclusive layer surface
+/// and event loop). Returns the stitched image, or a null image if cancelled
+/// or on error (with `error` set).
+[[nodiscard]] QImage runScrollCapture(const MonitorInfo &monitor,
+                                      QString &error, bool *switchedToArea);

--- a/src/scroll-inject.cpp
+++ b/src/scroll-inject.cpp
@@ -1,0 +1,424 @@
+/** @fileoverview Auto-scroll injection worker (see scroll-inject.hpp). */
+#include "scroll-inject.hpp"
+
+#include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
+
+#include <QDebug>
+#include <QProcess>
+
+#include <wayland-client.h>
+
+#include <linux/input-event-codes.h>
+#include <linux/uinput.h>
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <functional>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+using stitch::Axis;
+using stitch::CaptureHandshake;
+
+/// Time between injecting a wheel group and announcing its rendered frame:
+/// at 150 ms a 60 Hz client gets ~9 frames to paint while the handshake still
+/// prevents the next wheel event racing the screenshot.
+constexpr int kScrollSettleMs = 150;
+constexpr int kInputRegionSettleMs = 50;
+constexpr int kUinputDeviceSettleMs = 150;
+constexpr int kPointerNudgeSettleMs = 20;
+/// One logical wheel notch for the wlr virtual pointer.
+constexpr double kNotchValue = 10.0;
+
+void sleepMs(int ms) {
+  std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+/// Sleeps in short slices so a stop request interrupts the settle.
+bool sleepUnlessStopped(int ms, const std::atomic<bool> &stop) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (stop.load(std::memory_order_acquire))
+      return false;
+    sleepMs(5);
+  }
+  return !stop.load(std::memory_order_acquire);
+}
+
+/// The compositor applies the user's natural-scroll policy to a real kernel
+/// mouse, so uinput injection must pre-compensate, and is only safe when the
+/// policy is actually known.
+std::optional<bool> hyprlandNaturalScroll() {
+  if (qEnvironmentVariable("HYPRLAND_INSTANCE_SIGNATURE").isEmpty())
+    return std::nullopt;
+  QProcess process;
+  process.start(QStringLiteral("hyprctl"),
+                {QStringLiteral("getoption"), QStringLiteral("input:natural_scroll"),
+                 QStringLiteral("-j")});
+  if (!process.waitForFinished(2000) || process.exitCode() != 0)
+    return std::nullopt;
+  const QByteArray out = process.readAllStandardOutput();
+  const int key = out.indexOf("\"bool\"");
+  if (key < 0)
+    return std::nullopt;
+  const int colon = out.indexOf(':', key);
+  if (colon < 0)
+    return std::nullopt;
+  const QByteArray tail = out.mid(colon + 1).trimmed();
+  if (tail.startsWith("true"))
+    return true;
+  if (tail.startsWith("false"))
+    return false;
+  return std::nullopt;
+}
+
+// --- uinput kernel mouse ------------------------------------------------------
+class UinputMouse {
+public:
+  bool open(QString &error) {
+    fd_ = ::open("/dev/uinput", O_WRONLY | O_NONBLOCK);
+    if (fd_ < 0) {
+      error = QStringLiteral("could not open /dev/uinput");
+      return false;
+    }
+    ioctl(fd_, UI_SET_EVBIT, EV_REL);
+    for (const int axis : {REL_X, REL_Y, REL_WHEEL, REL_HWHEEL})
+      ioctl(fd_, UI_SET_RELBIT, axis);
+    // libinput requires a button before udev classifies the device as a
+    // mouse (so the natural-scroll policy applies); advertised, never
+    // emitted.
+    ioctl(fd_, UI_SET_EVBIT, EV_KEY);
+    ioctl(fd_, UI_SET_KEYBIT, BTN_LEFT);
+    uinput_setup setup{};
+    setup.id.bustype = BUS_USB;
+    setup.id.vendor = 0x1d6b;
+    setup.id.product = 0x0001;
+    std::strncpy(setup.name, "Omasnap Auto Scroll", sizeof(setup.name) - 1);
+    if (ioctl(fd_, UI_DEV_SETUP, &setup) < 0 || ioctl(fd_, UI_DEV_CREATE) < 0) {
+      error = QStringLiteral("uinput device setup failed");
+      close();
+      return false;
+    }
+    return true;
+  }
+  bool nudge() {
+    // ±1 px so the compositor re-hit-tests the surface under the pointer.
+    if (!emitEvent(EV_REL, REL_X, 1) || !emitEvent(EV_SYN, SYN_REPORT, 0))
+      return false;
+    sleepMs(kPointerNudgeSettleMs);
+    return emitEvent(EV_REL, REL_X, -1) && emitEvent(EV_SYN, SYN_REPORT, 0);
+  }
+  bool scroll(Axis axis, int notches, bool naturalScroll) {
+    // REL_WHEEL follows the physical wheel: negative = down; HWHEEL positive
+    // = right. The compositor then applies natural-scroll, so pre-negate.
+    const int code = axis == Axis::Vertical ? REL_WHEEL : REL_HWHEEL;
+    int amount = axis == Axis::Vertical ? -notches : notches;
+    if (naturalScroll)
+      amount = -amount;
+    return emitEvent(EV_REL, code, amount) && emitEvent(EV_SYN, SYN_REPORT, 0);
+  }
+  void close() {
+    if (fd_ >= 0) {
+      ioctl(fd_, UI_DEV_DESTROY);
+      ::close(fd_);
+      fd_ = -1;
+    }
+  }
+  ~UinputMouse() { close(); }
+
+private:
+  bool emitEvent(int type, int code, int value) {
+    input_event event{};
+    event.type = static_cast<std::uint16_t>(type);
+    event.code = static_cast<std::uint16_t>(code);
+    event.value = value;
+    return write(fd_, &event, sizeof(event)) == sizeof(event);
+  }
+  int fd_ = -1;
+};
+
+// --- wlr virtual pointer ------------------------------------------------------
+struct WlrPointer {
+  wl_display *display = nullptr;
+  wl_registry *registry = nullptr;
+  wl_seat *seat = nullptr;
+  zwlr_virtual_pointer_manager_v1 *manager = nullptr;
+  zwlr_virtual_pointer_v1 *pointer = nullptr;
+  struct Output {
+    wl_output *handle = nullptr;
+    std::string name;
+    int width = 0;
+    int height = 0;
+  };
+  std::vector<std::unique_ptr<Output>> outputs;
+  Output *target = nullptr;
+  std::chrono::steady_clock::time_point start =
+      std::chrono::steady_clock::now();
+
+  std::uint32_t timeMs() const {
+    return static_cast<std::uint32_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start)
+            .count());
+  }
+  void park(int x, int y) {
+    if (!pointer || !target)
+      return;
+    const auto width = static_cast<std::uint32_t>(std::max(1, target->width));
+    const auto height = static_cast<std::uint32_t>(std::max(1, target->height));
+    zwlr_virtual_pointer_v1_motion_absolute(
+        pointer, timeMs(),
+        static_cast<std::uint32_t>(std::clamp(x, 0, target->width)),
+        static_cast<std::uint32_t>(std::clamp(y, 0, target->height)), width,
+        height);
+    zwlr_virtual_pointer_v1_frame(pointer);
+    wl_display_flush(display);
+    sleepMs(kPointerNudgeSettleMs);
+    zwlr_virtual_pointer_v1_motion(pointer, timeMs(), wl_fixed_from_int(1), 0);
+    zwlr_virtual_pointer_v1_frame(pointer);
+    wl_display_flush(display);
+    sleepMs(kPointerNudgeSettleMs);
+    zwlr_virtual_pointer_v1_motion(pointer, timeMs(), wl_fixed_from_int(-1), 0);
+    zwlr_virtual_pointer_v1_frame(pointer);
+    wl_display_flush(display);
+  }
+  void scroll(Axis axis, int notches) {
+    if (!pointer)
+      return;
+    // One aggregate discrete event, axis_source AFTER axis_discrete
+    // (Hyprland ties the source to the most recent axis), one frame.
+    const std::uint32_t wlAxis = axis == Axis::Vertical ? 0 : 1;
+    zwlr_virtual_pointer_v1_axis_discrete(
+        pointer, timeMs(), wlAxis, wl_fixed_from_double(kNotchValue * notches),
+        notches);
+    zwlr_virtual_pointer_v1_axis_source(pointer, 0 /* wheel */);
+    zwlr_virtual_pointer_v1_frame(pointer);
+    wl_display_flush(display);
+  }
+  ~WlrPointer() {
+    if (pointer)
+      zwlr_virtual_pointer_v1_destroy(pointer);
+    for (const auto &output : outputs)
+      if (output->handle)
+        wl_output_release(output->handle);
+    if (manager)
+      zwlr_virtual_pointer_manager_v1_destroy(manager);
+    if (seat)
+      wl_seat_destroy(seat);
+    if (registry)
+      wl_registry_destroy(registry);
+    if (display) {
+      wl_display_flush(display);
+      wl_display_disconnect(display);
+    }
+  }
+};
+
+void injectOutputName(void *data, wl_output *, const char *name) {
+  static_cast<WlrPointer::Output *>(data)->name = name;
+}
+void injectOutputMode(void *data, wl_output *, std::uint32_t flags, int32_t w,
+                      int32_t h, int32_t) {
+  if (flags & WL_OUTPUT_MODE_CURRENT) {
+    auto *output = static_cast<WlrPointer::Output *>(data);
+    output->width = w;
+    output->height = h;
+  }
+}
+void injectOutputGeometry(void *, wl_output *, int32_t, int32_t, int32_t,
+                          int32_t, int32_t, const char *, const char *,
+                          int32_t) {}
+void injectOutputDone(void *, wl_output *) {}
+void injectOutputScale(void *, wl_output *, int32_t) {}
+void injectOutputDescription(void *, wl_output *, const char *) {}
+constexpr wl_output_listener kInjectOutputListener{
+    injectOutputGeometry, injectOutputMode,  injectOutputDone,
+    injectOutputScale,    injectOutputName,  injectOutputDescription};
+
+void injectRegistryGlobal(void *data, wl_registry *registry, std::uint32_t name,
+                          const char *interface, std::uint32_t version) {
+  auto &state = *static_cast<WlrPointer *>(data);
+  if (std::strcmp(interface, wl_seat_interface.name) == 0 && !state.seat) {
+    state.seat = static_cast<wl_seat *>(wl_registry_bind(
+        registry, name, &wl_seat_interface, std::min(version, 8u)));
+  } else if (std::strcmp(interface, wl_output_interface.name) == 0 &&
+             version >= 4) {
+    auto output = std::make_unique<WlrPointer::Output>();
+    output->handle = static_cast<wl_output *>(
+        wl_registry_bind(registry, name, &wl_output_interface, 4));
+    wl_output_add_listener(output->handle, &kInjectOutputListener,
+                           output.get());
+    state.outputs.push_back(std::move(output));
+  } else if (std::strcmp(interface,
+                         zwlr_virtual_pointer_manager_v1_interface.name) == 0) {
+    state.manager =
+        static_cast<zwlr_virtual_pointer_manager_v1 *>(wl_registry_bind(
+            registry, name, &zwlr_virtual_pointer_manager_v1_interface,
+            std::min(version, 2u)));
+  }
+}
+void injectRegistryRemove(void *, wl_registry *, std::uint32_t) {}
+constexpr wl_registry_listener kInjectRegistryListener{injectRegistryGlobal,
+                                                       injectRegistryRemove};
+
+std::unique_ptr<WlrPointer> connectWlrPointer(const QString &outputName,
+                                              QString &error) {
+  auto state = std::make_unique<WlrPointer>();
+  state->display = wl_display_connect(nullptr);
+  if (!state->display) {
+    error = QStringLiteral("could not connect to Wayland for injection");
+    return nullptr;
+  }
+  state->registry = wl_display_get_registry(state->display);
+  wl_registry_add_listener(state->registry, &kInjectRegistryListener,
+                           state.get());
+  wl_display_roundtrip(state->display); // globals
+  wl_display_roundtrip(state->display); // output names/modes
+  if (!state->manager) {
+    error = QStringLiteral("compositor does not expose the virtual pointer");
+    return nullptr;
+  }
+  const std::string wanted = outputName.toStdString();
+  for (const auto &output : state->outputs) {
+    if (wanted.empty() || output->name == wanted) {
+      state->target = output.get();
+      break;
+    }
+  }
+  if (!state->target) {
+    error = QStringLiteral("output %1 not found for injection").arg(outputName);
+    return nullptr;
+  }
+  // motion_absolute coordinates are physical pixels of the bound output; an
+  // unbound pointer maps across the whole layout and misses on multi-monitor.
+  if (zwlr_virtual_pointer_manager_v1_get_version(state->manager) >= 2) {
+    state->pointer = zwlr_virtual_pointer_manager_v1_create_virtual_pointer_with_output(
+        state->manager, state->seat, state->target->handle);
+  } else {
+    qInfo().noquote() << QStringLiteral(
+        "scroll-inject: virtual pointer v1 only; warps map to the whole layout");
+    state->pointer = zwlr_virtual_pointer_manager_v1_create_virtual_pointer(
+        state->manager, state->seat);
+  }
+  wl_display_roundtrip(state->display);
+  if (!state->pointer) {
+    error = QStringLiteral("could not create the virtual pointer");
+    return nullptr;
+  }
+  return state;
+}
+
+/// One tick per acknowledged cycle, forever until stopped.
+void runCaptureScrollLoop(const std::shared_ptr<std::atomic<bool>> &stop,
+                          const std::shared_ptr<CaptureHandshake> &handshake,
+                          const std::function<bool(int)> &inject) {
+  std::uint64_t cycle = handshake->publishReady(); // cycle 1: unscrolled frame
+  while (true) {
+    const std::optional<int> notches = handshake->waitForCapture(cycle, *stop);
+    if (!notches)
+      break;
+    if (stop->load(std::memory_order_acquire))
+      break;
+    // Parked once at the start and left alone after that. Re-parking every tick
+    // kept the wheel on the page, but it also meant the pointer could never be
+    // taken anywhere, and moving it away is how a person stops an auto scroll.
+    // Left alone, moving out of the region sends the injected wheel somewhere
+    // harmless, the scrolling stops, and the buttons and keys are reachable
+    // again.
+    if (!inject(*notches))
+      break;
+    if (!sleepUnlessStopped(kScrollSettleMs, *stop))
+      break;
+    cycle = handshake->publishReady();
+  }
+}
+} // namespace
+
+bool spawnScrollInjector(std::shared_ptr<std::atomic<bool>> stop,
+                         std::shared_ptr<stitch::CaptureHandshake> handshake,
+                         int parkX, int parkY, stitch::Axis axis,
+                         const QString &outputName, QString &error) {
+  // Validate the backends synchronously so the caller gets a useful error;
+  // the injection itself runs off the UI thread.
+  const std::optional<bool> naturalScroll = hyprlandNaturalScroll();
+  auto uinput = std::make_shared<UinputMouse>();
+  bool haveUinput = false;
+  if (naturalScroll) {
+    QString uinputError;
+    haveUinput = uinput->open(uinputError);
+    if (!haveUinput)
+      qInfo().noquote()
+          << QStringLiteral("scroll-inject: uinput unavailable (%1); using the "
+                            "virtual pointer")
+                 .arg(uinputError);
+  } else {
+    qInfo().noquote() << QStringLiteral(
+        "scroll-inject: natural-scroll policy unknown; using the virtual "
+        "pointer");
+  }
+  // The wlr pointer parks the cursor for both backends (and scrolls when
+  // uinput is unavailable).
+  QString wlrError;
+  std::shared_ptr<WlrPointer> wlr = connectWlrPointer(outputName, wlrError);
+  if (!wlr && !haveUinput) {
+    error = wlrError;
+    return false;
+  }
+  if (!wlr)
+    qInfo().noquote() << QStringLiteral(
+                             "scroll-inject: no virtual pointer (%1); cannot "
+                             "park · scrolling wherever the cursor is")
+                             .arg(wlrError);
+  qInfo().noquote() << QStringLiteral(
+                           "scroll-inject: backend=%1 natural=%2 park=%3,%4 on %5")
+                           .arg(haveUinput ? QStringLiteral("uinput")
+                                           : QStringLiteral("wlr-pointer"))
+                           .arg(naturalScroll ? (*naturalScroll ? "true" : "false")
+                                              : "unknown")
+                           .arg(parkX)
+                           .arg(parkY)
+                           .arg(outputName);
+
+  std::thread([stop, handshake, uinput, haveUinput, wlr, parkX, parkY, axis,
+               natural = naturalScroll.value_or(false)] {
+    // Let the overlay's input-region commit land, then settle the device and
+    // park inside the selection so wheel events hit the page.
+    sleepMs(kInputRegionSettleMs);
+    if (haveUinput)
+      sleepMs(kUinputDeviceSettleMs);
+    if (wlr)
+      wlr->park(parkX, parkY);
+    if (haveUinput && !uinput->nudge()) {
+      qWarning().noquote()
+          << QStringLiteral("scroll-inject: pointer nudge failed");
+      stop->store(true, std::memory_order_release);
+      return;
+    }
+    const std::function<bool(int)> inject = [&](int notches) {
+      qInfo().noquote() << QStringLiteral("scroll-inject: tick %1 notch%2")
+                               .arg(notches)
+                               .arg(notches == 1 ? QString() : QStringLiteral("es"));
+      if (haveUinput)
+        return uinput->scroll(axis, notches, natural);
+      if (wlr) {
+        wlr->scroll(axis, notches);
+        return true;
+      }
+      return false;
+    };
+    runCaptureScrollLoop(stop, handshake, inject);
+    // Worker death is always observable through the one flag.
+    stop->store(true, std::memory_order_release);
+    qInfo().noquote() << QStringLiteral("scroll-inject: worker exited");
+  }).detach();
+  return true;
+}

--- a/src/scroll-inject.hpp
+++ b/src/scroll-inject.hpp
@@ -1,0 +1,26 @@
+/** @fileoverview The auto-scroll injection worker: drives the application
+ *  under the capture region with real wheel input, one tick per acknowledged
+ *  capture cycle. Backend cascade (validated on Hyprland): a uinput kernel
+ *  mouse when the compositor's natural-scroll policy is known (its wheel
+ *  events are pre-compensated for it), else the wlr virtual-pointer protocol
+ *  bound to the target output. */
+#pragma once
+
+#include "auto-capture.hpp"
+#include "stitch.hpp"
+
+#include <QString>
+
+#include <atomic>
+#include <memory>
+
+/// Spawns the injection worker thread. `parkX/parkY` are physical pixels of
+/// `outputName` where the pointer is parked so wheel events hit the page
+/// inside the region. The worker publishes ready cycles on `handshake`
+/// (cycle 1 = the unscrolled first frame), scrolls the acknowledged notch
+/// count per cycle, and sets `stop` itself on any exit so its death is always
+/// observable. Returns false with `error` set when no backend is available.
+[[nodiscard]] bool spawnScrollInjector(
+    std::shared_ptr<std::atomic<bool>> stop,
+    std::shared_ptr<stitch::CaptureHandshake> handshake, int parkX, int parkY,
+    stitch::Axis axis, const QString &outputName, QString &error);

--- a/src/stitch-replay.cpp
+++ b/src/stitch-replay.cpp
@@ -1,0 +1,102 @@
+/** @fileoverview stitch-replay: offline scroll-capture stitcher harness, so
+ *  a recorded capture can be re-stitched without a compositor. Loads dumped
+ *  frames, classifies each adjacent pair (accepting only a decisive forward
+ *  match), stitches the accepted deltas, and writes the result.
+ *
+ *  Env: OMASNAP_STITCH_REPLAY_DIR (frames dir), OMASNAP_STITCH_REPLAY_OUT
+ *  (output PNG), OMASNAP_STITCH_REPLAY_AXIS (vertical|horizontal, default
+ *  vertical). With --classify it prints per-frame classifications instead. */
+#include "stitch.hpp"
+
+#include <QDir>
+#include <QImage>
+#include <QStringList>
+
+#include <cstdio>
+
+using namespace stitch;
+
+int main(int argc, char **argv) {
+  const bool classifyOnly = argc > 1 && QString::fromLocal8Bit(argv[1]) ==
+                                            QStringLiteral("--classify");
+  const QString dir = qEnvironmentVariable("OMASNAP_STITCH_REPLAY_DIR");
+  const QString out = qEnvironmentVariable("OMASNAP_STITCH_REPLAY_OUT");
+  const Axis axis = qEnvironmentVariable("OMASNAP_STITCH_REPLAY_AXIS") ==
+                            QStringLiteral("horizontal")
+                        ? Axis::Horizontal
+                        : Axis::Vertical;
+  if (dir.isEmpty()) {
+    std::fprintf(stderr, "OMASNAP_STITCH_REPLAY_DIR unset\n");
+    return 2;
+  }
+  QStringList files = QDir(dir).entryList({QStringLiteral("frame-*.png")},
+                                          QDir::Files, QDir::Name);
+  if (files.isEmpty()) {
+    std::fprintf(stderr, "no frames in %s\n", qPrintable(dir));
+    return 2;
+  }
+  std::fprintf(stderr, "replay: %lld frames from %s\n",
+               static_cast<long long>(files.size()), qPrintable(dir));
+
+  QImage prevImage(QDir(dir).filePath(files.first()));
+  prevImage = prevImage.convertToFormat(QImage::Format_RGBA8888);
+  GrayView prevGray = downsampleToGray(prevImage, axis);
+
+  QString accError;
+  bool accOk = false;
+  StitchAccumulator accumulator(prevImage, axis, accOk, accError);
+  if (!accOk) {
+    std::fprintf(stderr, "accumulator: %s\n", qPrintable(accError));
+    return 1;
+  }
+  int forward = 0, skipped = 0;
+  for (int i = 1; i < files.size(); ++i) {
+    QImage curImage(QDir(dir).filePath(files.at(i)));
+    curImage = curImage.convertToFormat(QImage::Format_RGBA8888);
+    const GrayView curGray = downsampleToGray(curImage, axis);
+    const MotionEstimate est = classifyMotion(prevGray, curGray, axis);
+    const char *kind = "?";
+    switch (est.motion.kind) {
+    case MotionKind::Stationary: kind = "Stationary"; break;
+    case MotionKind::Forward: kind = "Forward"; break;
+    case MotionKind::Reverse: kind = "Reverse"; break;
+    case MotionKind::Ambiguous: kind = "Ambiguous"; break;
+    case MotionKind::Unmatchable: kind = "Unmatchable"; break;
+    }
+    if (classifyOnly)
+      std::fprintf(stdout, "%s: %s(%d) err=%.3f conf=%.3f\n",
+                   qPrintable(files.at(i)), kind, est.motion.delta, est.error,
+                   est.confidence);
+    if (est.motion.kind == MotionKind::Forward) {
+      ++forward;
+      if (!classifyOnly && !accumulator.pushForward(curImage, est.motion.delta,
+                                                    accError)) {
+        std::fprintf(stderr, "push_forward: %s\n", qPrintable(accError));
+        return 1;
+      }
+      // Only an accepted frame advances the reference; a skipped frame keeps
+      // the last kept frame so the next comparison spans the gap.
+      prevGray = curGray;
+    } else {
+      ++skipped;
+    }
+  }
+  std::fprintf(stderr, "replay: %d forward, %d skipped\n", forward, skipped);
+  if (classifyOnly)
+    return 0;
+  const QImage stitched = accumulator.finish(accError);
+  if (stitched.isNull()) {
+    std::fprintf(stderr, "finish: %s\n", qPrintable(accError));
+    return 1;
+  }
+  std::fprintf(stderr, "replay: stitched %dx%d\n", stitched.width(),
+               stitched.height());
+  if (!out.isEmpty()) {
+    if (!stitched.save(out, "PNG")) {
+      std::fprintf(stderr, "could not save %s\n", qPrintable(out));
+      return 1;
+    }
+    std::fprintf(stderr, "replay: saved %s\n", qPrintable(out));
+  }
+  return 0;
+}

--- a/src/stitch.cpp
+++ b/src/stitch.cpp
@@ -1,0 +1,1383 @@
+/** @fileoverview Pure scroll-capture stitcher (see stitch.hpp). */
+#include "stitch.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+namespace stitch {
+
+int GrayView::sourceScale(Axis axis) const {
+  if (axis == Axis::Vertical)
+    return 1;
+  // Callers pass the motion axis, which downsampleToGray leaves at source
+  // resolution, so this is 1 by construction (width == sourceWidth for a
+  // horizontal view). The division only bites on very narrow frames, where the
+  // downsampler's clamp can leave the two out of step.
+  return std::max(1, sourceWidth / std::max(1, width));
+}
+
+GrayView GrayView::cropAxis(Axis axis, int start, int end) const {
+  start = std::clamp(start, 0, axisLen(axis));
+  end = std::clamp(std::max(end, start), start, axisLen(axis));
+  GrayView view;
+  if (axis == Axis::Vertical) {
+    view.width = width;
+    view.height = end - start;
+    view.sourceWidth = sourceWidth;
+    view.pixels.assign(pixels.begin() + static_cast<std::ptrdiff_t>(start) * width,
+                       pixels.begin() + static_cast<std::ptrdiff_t>(end) * width);
+  } else {
+    const int cropWidth = end - start;
+    view.width = cropWidth;
+    view.height = height;
+    view.sourceWidth = cropWidth * sourceScale(axis);
+    view.pixels.reserve(static_cast<std::size_t>(cropWidth) * height);
+    for (int row = 0; row < height; ++row) {
+      const auto base = static_cast<std::ptrdiff_t>(row) * width;
+      view.pixels.insert(view.pixels.end(), pixels.begin() + base + start,
+                         pixels.begin() + base + end);
+    }
+  }
+  return view;
+}
+
+GrayView downsampleToGray(const QImage &image, Axis axis) {
+  // Read the RGBA byte orders in place as well as the BGRA ones: scroll
+  // capture hands frames over as RGBA8888, and converting here copied every
+  // frame a second time. Only the channel order differs, which the two reads
+  // below account for; the luma weights are unchanged either way.
+  const bool rgbaOrder = image.format() == QImage::Format_RGBA8888 ||
+                         image.format() == QImage::Format_RGBA8888_Premultiplied;
+  const QImage rgb = rgbaOrder || image.format() == QImage::Format_RGB32 ||
+                             image.format() == QImage::Format_ARGB32
+                         ? image
+                         : image.convertToFormat(QImage::Format_ARGB32);
+  const int srcW = std::max(0, rgb.width());
+  const int srcH = std::max(0, rgb.height());
+  const int dstW = axis == Axis::Vertical
+                       ? std::min(std::max(1, srcW / kDownsampleCross),
+                                  std::max(1, srcW))
+                       : srcW;
+  const int dstH = axis == Axis::Horizontal
+                       ? std::min(std::max(1, srcH / kDownsampleCross),
+                                  std::max(1, srcH))
+                       : srcH;
+  GrayView view;
+  view.width = dstW;
+  view.height = dstH;
+  view.sourceWidth = srcW;
+  view.pixels.assign(static_cast<std::size_t>(dstW) * dstH, 0);
+  for (int gy = 0; gy < dstH; ++gy) {
+    const int srcY = axis == Axis::Vertical
+                         ? gy
+                         : std::min(gy * kDownsampleCross, std::max(0, srcH - 1));
+    const auto *srcRow = reinterpret_cast<const QRgb *>(rgb.constScanLine(srcY));
+    std::uint8_t *dstRow = view.pixels.data() + static_cast<std::size_t>(gy) * dstW;
+    for (int gx = 0; gx < dstW; ++gx) {
+      const int srcX = axis == Axis::Vertical
+                           ? std::min(gx * kDownsampleCross, std::max(0, srcW - 1))
+                           : gx;
+      const std::uint32_t px = static_cast<std::uint32_t>(srcRow[srcX]);
+      // BGRA in memory for the QRgb formats, RGBA for the 8888 ones.
+      const std::uint32_t r = rgbaOrder ? (px & 0xffu) : ((px >> 16) & 0xffu);
+      const std::uint32_t g = (px >> 8) & 0xffu;
+      const std::uint32_t b = rgbaOrder ? ((px >> 16) & 0xffu) : (px & 0xffu);
+      dstRow[gx] = static_cast<std::uint8_t>((r * 77 + g * 150 + b * 29) >> 8);
+    }
+  }
+  return view;
+}
+
+
+namespace {
+constexpr double kInf = std::numeric_limits<double>::infinity();
+
+// Rust total_cmp order: finite ascending, NaN last. Used for sorting samples.
+bool errorLess(double a, double b) {
+  if (std::isnan(a))
+    return false;
+  if (std::isnan(b))
+    return true;
+  return a < b;
+}
+
+struct SearchSample {
+  long shift;
+  double error;
+};
+
+int crossMargin(int crossLen) {
+  return std::min(crossLen / 12, std::max(0, crossLen - 1) / 2);
+}
+
+// unmatchable() sentinel.
+MotionEstimate unmatchable() {
+  return {{MotionKind::Unmatchable, 0}, kInf, 0.0};
+}
+
+double edgeLineError(const GrayView &prev, const GrayView &cur, Axis axis,
+                     int along) {
+  const int crossLen = prev.crossLen(axis);
+  const int margin = crossMargin(crossLen);
+  const int step = std::max(1, crossLen / 128);
+  std::uint64_t total = 0;
+  int count = 0;
+  for (int cross = margin; cross < crossLen - margin; cross += step) {
+    const int index = axis == Axis::Vertical ? along * prev.width + cross
+                                             : cross * prev.width + along;
+    total += static_cast<std::uint64_t>(
+        std::abs(static_cast<int>(prev.pixels[index]) -
+                 static_cast<int>(cur.pixels[index])));
+    ++count;
+  }
+  return count == 0 ? kInf : static_cast<double>(total) / count;
+}
+
+MotionEstimate classifyMotionCropped(const GrayView &prev, const GrayView &cur,
+                                     Axis axis,
+                                     std::optional<int> maxSourceDelta) {
+  const int axisLen = prev.axisLen(axis);
+  const int crossLen = prev.crossLen(axis);
+  if (axisLen < kMinOverlapPixels + kMinMotionPixels || crossLen < 2)
+    return unmatchable();
+
+  const int minOverlap = std::min(std::max(axisLen / kMinOverlapDen, kMinOverlapPixels),
+                                  std::max(0, axisLen - 1));
+  const int safeMaxShift = std::max(0, axisLen - minOverlap);
+  const int sourceScale = prev.sourceScale(axis);
+  int maxShift = safeMaxShift;
+  if (maxSourceDelta)
+    maxShift = std::min(*maxSourceDelta / sourceScale, safeMaxShift);
+  if (maxShift < kMinMotionPixels)
+    return unmatchable();
+
+  const int matchExtent = axisLen - maxShift;
+  const int coarseAxis = std::max(1, matchExtent / 32);
+  const int coarseCross = std::max(1, crossLen / 48);
+  const int fineAxis = std::max(1, matchExtent / 128);
+  const int fineCross = std::max(1, crossLen / 128);
+
+  const double zeroError =
+      scoreShift(prev, cur, axis, 0, maxShift, fineAxis, fineCross);
+  if (zeroError <= kStationaryError)
+    return {{MotionKind::Stationary, 0}, zeroError, kInf};
+
+  const long maxShiftSigned = maxShift;
+  std::vector<SearchSample> coarse;
+  coarse.reserve(static_cast<std::size_t>(maxShift) * 2 + 1);
+  for (long shift = -maxShiftSigned; shift <= maxShiftSigned; ++shift)
+    coarse.push_back({shift, scoreShift(prev, cur, axis, shift, maxShift,
+                                        coarseAxis, coarseCross)});
+  std::stable_sort(coarse.begin(), coarse.end(),
+                   [](const SearchSample &a, const SearchSample &b) {
+                     return errorLess(a.error, b.error);
+                   });
+
+  std::vector<SearchSample> fine;
+  const int peaksToRefine = std::min<int>(12, static_cast<int>(coarse.size()));
+  for (int i = 0; i < peaksToRefine; ++i) {
+    const long start = std::max(coarse[i].shift - 1, -maxShiftSigned);
+    const long end = std::min(coarse[i].shift + 1, maxShiftSigned);
+    for (long candidate = start; candidate <= end; ++candidate) {
+      if (std::any_of(fine.begin(), fine.end(),
+                      [&](const SearchSample &s) { return s.shift == candidate; }))
+        continue;
+      fine.push_back({candidate, scoreShift(prev, cur, axis, candidate, maxShift,
+                                            fineAxis, fineCross)});
+    }
+  }
+  std::stable_sort(fine.begin(), fine.end(),
+                   [](const SearchSample &a, const SearchSample &b) {
+                     return errorLess(a.error, b.error);
+                   });
+  if (fine.empty())
+    return unmatchable();
+  const SearchSample best = fine.front();
+
+  const long runnerNeighborhood = std::clamp(axisLen / 256, 6, 16);
+  double runnerError = kInf;
+  int taken = 0;
+  for (const SearchSample &sample : coarse) {
+    if (std::abs(sample.shift - best.shift) <= runnerNeighborhood)
+      continue;
+    runnerError = std::min(runnerError,
+                           scoreShift(prev, cur, axis, sample.shift, maxShift,
+                                      fineAxis, fineCross));
+    if (++taken >= 8)
+      break;
+  }
+
+  double confidence;
+  if (best.error <= std::numeric_limits<double>::epsilon())
+    confidence = runnerError <= std::numeric_limits<double>::epsilon() ? 1.0 : kInf;
+  else
+    confidence = runnerError / best.error;
+
+  const int sourceDelta =
+      static_cast<int>(std::abs(best.shift)) * sourceScale;
+  if (sourceDelta <= kMinMotionPixels && best.error <= kMaxStationaryError)
+    return {{MotionKind::Stationary, 0}, best.error, confidence};
+
+  const double margin = runnerError - best.error;
+  if (!std::isfinite(best.error) || best.error > kMaxMatchError)
+    return {{MotionKind::Unmatchable, 0}, best.error, confidence};
+
+  if (confidence < kMinConfidence || margin < kMinErrorMargin) {
+    if (best.error <= kMaxAmbiguousError) {
+      const int signed_ = best.shift > 0 ? sourceDelta : -sourceDelta;
+      return {{MotionKind::Ambiguous, signed_}, best.error, confidence};
+    }
+    return {{MotionKind::Unmatchable, 0}, best.error, confidence};
+  }
+  return {{best.shift > 0 ? MotionKind::Forward : MotionKind::Reverse,
+           sourceDelta},
+          best.error, confidence};
+}
+
+MotionEstimate classifyWithBound(const GrayView &prev, const GrayView &cur,
+                                 Axis axis, std::optional<int> maxSourceDelta) {
+  if (prev.width != cur.width || prev.height != cur.height ||
+      static_cast<int>(prev.pixels.size()) != prev.width * prev.height ||
+      static_cast<int>(cur.pixels.size()) != cur.width * cur.height)
+    return unmatchable();
+  const int axisLen = prev.axisLen(axis);
+  const int crossLen = prev.crossLen(axis);
+  if (axisLen < kMinOverlapPixels + kMinMotionPixels || crossLen < 2)
+    return unmatchable();
+  const StationaryEdges edges = stationaryScoringEdges(prev, cur, axis);
+  if (edges.lead + edges.trail > 0) {
+    const GrayView pc = prev.cropAxis(axis, edges.lead, axisLen - edges.trail);
+    const GrayView cc = cur.cropAxis(axis, edges.lead, axisLen - edges.trail);
+    return classifyMotionCropped(pc, cc, axis, maxSourceDelta);
+  }
+  return classifyMotionCropped(prev, cur, axis, maxSourceDelta);
+}
+} // namespace
+
+double scoreShift(const GrayView &prev, const GrayView &cur, Axis axis,
+                  long shift, int maxShift, int axisStep, int crossStep) {
+  const int axisLen = prev.axisLen(axis);
+  const int crossLen = prev.crossLen(axis);
+  const long magnitude = std::abs(shift);
+  if (magnitude > maxShift || maxShift >= axisLen)
+    return kInf;
+  const int matchExtent = axisLen - maxShift;
+  const long available = axisLen - magnitude;
+  if (available < matchExtent || matchExtent == 0)
+    return kInf;
+  const long centered = (available - matchExtent) / 2;
+  const long prevStart = shift >= 0 ? centered + magnitude : centered;
+  const long curStart = shift >= 0 ? centered : centered + magnitude;
+  const int margin = crossMargin(crossLen);
+  const int crossStart = margin;
+  const int crossEnd = crossLen - margin;
+  const int aStep = std::max(1, axisStep);
+  const int cStep = std::max(1, crossStep);
+  std::uint64_t total = 0;
+  std::uint64_t count = 0;
+  if (axis == Axis::Vertical) {
+    for (int along = 0; along < matchExtent; along += aStep) {
+      const long prevRow = (prevStart + along) * prev.width;
+      const long curRow = (curStart + along) * cur.width;
+      for (int cross = crossStart; cross < crossEnd; cross += cStep) {
+        total += static_cast<std::uint64_t>(
+            std::abs(static_cast<int>(prev.pixels[prevRow + cross]) -
+                     static_cast<int>(cur.pixels[curRow + cross])));
+        ++count;
+      }
+    }
+  } else {
+    for (int along = 0; along < matchExtent; along += aStep) {
+      const long prevCol = prevStart + along;
+      const long curCol = curStart + along;
+      for (int cross = crossStart; cross < crossEnd; cross += cStep) {
+        total += static_cast<std::uint64_t>(std::abs(
+            static_cast<int>(prev.pixels[static_cast<long>(cross) * prev.width + prevCol]) -
+            static_cast<int>(cur.pixels[static_cast<long>(cross) * cur.width + curCol])));
+        ++count;
+      }
+    }
+  }
+  return count == 0 ? kInf : static_cast<double>(total) / static_cast<double>(count);
+}
+
+double scoreShiftReference(const GrayView &prev, const GrayView &cur, Axis axis,
+                           long shift, int maxShift, int axisStep,
+                           int crossStep) {
+  // Independent naive implementation (the smoke oracle). Same math, no fused
+  // accumulation tricks.
+  const int axisLen = prev.axisLen(axis);
+  const int crossLen = prev.crossLen(axis);
+  const long magnitude = std::abs(shift);
+  if (magnitude > maxShift || maxShift >= axisLen)
+    return kInf;
+  const int matchExtent = axisLen - maxShift;
+  const long available = axisLen - magnitude;
+  if (available < matchExtent || matchExtent == 0)
+    return kInf;
+  const long centered = (available - matchExtent) / 2;
+  const long prevStart = shift >= 0 ? centered + magnitude : centered;
+  const long curStart = shift >= 0 ? centered : centered + magnitude;
+  const int margin = crossMargin(crossLen);
+  const int aStep = std::max(1, axisStep);
+  const int cStep = std::max(1, crossStep);
+  double total = 0.0;
+  long count = 0;
+  for (int along = 0; along < matchExtent; along += aStep) {
+    for (int cross = margin; cross < crossLen - margin; cross += cStep) {
+      int a, b;
+      if (axis == Axis::Vertical) {
+        a = prev.pixels[(prevStart + along) * prev.width + cross];
+        b = cur.pixels[(curStart + along) * cur.width + cross];
+      } else {
+        a = prev.pixels[static_cast<long>(cross) * prev.width + (prevStart + along)];
+        b = cur.pixels[static_cast<long>(cross) * cur.width + (curStart + along)];
+      }
+      total += std::abs(a - b);
+      ++count;
+    }
+  }
+  return count == 0 ? kInf : total / static_cast<double>(count);
+}
+
+StationaryEdges stationaryScoringEdges(const GrayView &prev, const GrayView &cur,
+                                       Axis axis) {
+  const int axisLen = prev.axisLen(axis);
+  const int maxEdge = axisLen / kMaxStationaryScoringEdgeDen;
+  StationaryEdges edges;
+  while (edges.lead < maxEdge &&
+         edgeLineError(prev, cur, axis, edges.lead) <= kStationaryEdgeError)
+    ++edges.lead;
+  while (edges.trail < maxEdge &&
+         edgeLineError(prev, cur, axis, axisLen - 1 - edges.trail) <=
+             kStationaryEdgeError)
+    ++edges.trail;
+  return edges;
+}
+
+MotionEstimate classifyMotion(const GrayView &prev, const GrayView &cur,
+                              Axis axis) {
+  return classifyWithBound(prev, cur, axis, std::nullopt);
+}
+
+MotionEstimate classifyMotionBounded(const GrayView &prev, const GrayView &cur,
+                                     Axis axis, int maxSourceDelta) {
+  return classifyWithBound(prev, cur, axis, std::optional<int>(maxSourceDelta));
+}
+
+// --- Accumulator ------------------------------------------------------------
+namespace {
+// A frame the accumulator can read as tight RGBA8888: returns bytes-per-line
+// and a pointer, converting if needed (kept alive by `owned`).
+struct RgbaFrame {
+  QImage owned;
+  const std::uint8_t *bits = nullptr;
+  int stride = 0;
+  int width = 0;
+  int height = 0;
+};
+RgbaFrame asRgba(const QImage &image) {
+  RgbaFrame frame;
+  frame.owned = image.format() == QImage::Format_RGBA8888
+                    ? image
+                    : image.convertToFormat(QImage::Format_RGBA8888);
+  frame.bits = frame.owned.constBits();
+  frame.stride = static_cast<int>(frame.owned.bytesPerLine());
+  frame.width = frame.owned.width();
+  frame.height = frame.owned.height();
+  return frame;
+}
+
+bool validateFrame(const RgbaFrame &frame, int expectedW, int expectedH,
+                   QString &error) {
+  if (frame.width <= 0 || frame.height <= 0) {
+    error = QStringLiteral("frames have invalid dimensions");
+    return false;
+  }
+  if ((expectedW || expectedH) &&
+      (frame.width != expectedW || frame.height != expectedH)) {
+    error = QStringLiteral("frames have inconsistent dimensions");
+    return false;
+  }
+  return true;
+}
+
+// Reflect tight row-major RGBA pixels across the axis, in place.
+void reverseRgbaAxisInPlace(std::vector<std::uint8_t> &pixels, int width,
+                            int height, Axis axis) {
+  const int rowBytes = width * 4;
+  if (axis == Axis::Vertical) {
+    std::vector<std::uint8_t> tmp(rowBytes);
+    for (int top = 0; top < height / 2; ++top) {
+      const int bottom = height - top - 1;
+      std::uint8_t *topRow = pixels.data() + static_cast<std::size_t>(top) * rowBytes;
+      std::uint8_t *bottomRow = pixels.data() + static_cast<std::size_t>(bottom) * rowBytes;
+      std::memcpy(tmp.data(), topRow, rowBytes);
+      std::memcpy(topRow, bottomRow, rowBytes);
+      std::memcpy(bottomRow, tmp.data(), rowBytes);
+    }
+  } else {
+    for (int row = 0; row < height; ++row) {
+      std::uint8_t *r = pixels.data() + static_cast<std::size_t>(row) * rowBytes;
+      for (int left = 0; left < width / 2; ++left) {
+        const int right = width - left - 1;
+        for (int c = 0; c < 4; ++c)
+          std::swap(r[left * 4 + c], r[right * 4 + c]);
+      }
+    }
+  }
+}
+
+// Tight (no row padding) RGBA copy.
+std::vector<std::uint8_t> copyFrameTight(const RgbaFrame &frame) {
+  const int rowBytes = frame.width * 4;
+  std::vector<std::uint8_t> tight(static_cast<std::size_t>(rowBytes) * frame.height);
+  for (int y = 0; y < frame.height; ++y)
+    std::memcpy(tight.data() + static_cast<std::size_t>(y) * rowBytes,
+                frame.bits + static_cast<std::size_t>(y) * frame.stride, rowBytes);
+  return tight;
+}
+} // namespace
+
+StitchAccumulator::StitchAccumulator(const QImage &first, Axis axis, bool &ok,
+                                     QString &error)
+    : axis_(axis) {
+  const RgbaFrame frame = asRgba(first);
+  if (!validateFrame(frame, 0, 0, error)) {
+    ok = false;
+    return;
+  }
+  width_ = frame.width;
+  height_ = frame.height;
+  axisLen_ = axis == Axis::Vertical ? height_ : width_;
+  crossLen_ = axis == Axis::Vertical ? width_ : height_;
+  maxEdge_ = std::min(axisLen_ / 8, kMaxStationaryEdge);
+  firstRgba_ = copyFrameTight(frame);
+  edgeSums_.assign(maxEdge_, 0);
+  edgeCounts_.assign(maxEdge_, 0);
+  alignedSums_.assign(maxEdge_, 0);
+  alignedCounts_.assign(maxEdge_, 0);
+  valid_ = true;
+  ok = true;
+}
+
+bool StitchAccumulator::pushForward(const QImage &image, int delta,
+                                    QString &error) {
+  if (direction_ == Direction::Reverse) {
+    error = QStringLiteral(
+        "cannot mix forward and reverse frames in one scroll capture");
+    return false;
+  }
+  if (!pushOriented(image, delta, error))
+    return false;
+  direction_ = Direction::Forward;
+  return true;
+}
+
+bool StitchAccumulator::pushReverse(const QImage &image, int delta,
+                                    QString &error) {
+  if (direction_ == Direction::Forward) {
+    error = QStringLiteral(
+        "cannot mix forward and reverse frames in one scroll capture");
+    return false;
+  }
+  // Reverse input is reflected along the stitch axis, turning it into the same
+  // forward composition; the finished buffer is reflected back at finish().
+  const QImage reflected = axis_ == Axis::Vertical
+                               ? image.flipped(Qt::Vertical)
+                               : image.flipped(Qt::Horizontal);
+  const bool firstReverse = direction_ == Direction::None;
+  if (firstReverse)
+    reverseRgbaAxisInPlace(firstRgba_, width_, height_, axis_);
+  if (!pushOriented(reflected, delta, error)) {
+    if (firstReverse)
+      reverseRgbaAxisInPlace(firstRgba_, width_, height_, axis_);
+    return false;
+  }
+  direction_ = Direction::Reverse;
+  return true;
+}
+
+bool StitchAccumulator::pushOriented(const QImage &image, int delta,
+                                     QString &error) {
+  if (!valid_) {
+    error = QStringLiteral("accumulator is not initialized");
+    return false;
+  }
+  const RgbaFrame frame = asRgba(image);
+  if (!validateFrame(frame, width_, height_, error))
+    return false;
+  if (delta <= 0 || delta >= axisLen_) {
+    error = QStringLiteral("invalid stitch delta %1 for frame extent %2")
+                .arg(delta)
+                .arg(axisLen_);
+    return false;
+  }
+  const long newTotal = static_cast<long>(totalDelta_) + delta;
+  if (axisLen_ + newTotal > 2147483647L) {
+    error = QStringLiteral("stitched image extent exceeds the supported size");
+    return false;
+  }
+  // Refuse before mutating, so the capture so far stays intact and can still
+  // be finished: the caller reports this and the user stitches what they have.
+  if (exceedsStitchBudget(crossLen_, axisLen_ + newTotal)) {
+    error = QStringLiteral("scroll capture reached its maximum length "
+                           "(%1 MB); finish to keep what was captured")
+                .arg(kMaxStitchedBytes / (1024 * 1024));
+    return false;
+  }
+
+  // Compute everything before mutating so a bad frame leaves no partial state.
+  const int retainedExtent = delta + maxEdge_;
+  const int sourceAxisStart = std::max(0, axisLen_ - retainedExtent);
+  const int crossStep = std::max(1, crossLen_ / 512);
+
+  // Retained tail band.
+  TailBand band;
+  band.delta = delta;
+  band.sourceAxisStart = sourceAxisStart;
+  if (axis_ == Axis::Vertical) {
+    const int rowBytes = width_ * 4;
+    band.rgba.reserve(static_cast<std::size_t>(rowBytes) * (height_ - sourceAxisStart));
+    for (int y = sourceAxisStart; y < height_; ++y)
+      band.rgba.insert(band.rgba.end(), frame.bits + static_cast<std::size_t>(y) * frame.stride,
+                       frame.bits + static_cast<std::size_t>(y) * frame.stride + rowBytes);
+  } else {
+    const int bandWidth = width_ - sourceAxisStart;
+    band.rgba.reserve(static_cast<std::size_t>(bandWidth) * 4 * height_);
+    for (int y = 0; y < height_; ++y) {
+      const std::uint8_t *rowStart =
+          frame.bits + static_cast<std::size_t>(y) * frame.stride + sourceAxisStart * 4;
+      band.rgba.insert(band.rgba.end(), rowStart, rowStart + bandWidth * 4);
+    }
+  }
+
+  // Edge observation: trailing depth vs the SAME position in the first frame.
+  std::vector<std::uint64_t> edgeSums(maxEdge_, 0), edgeCounts(maxEdge_, 0);
+  for (int depth = 0; depth < maxEdge_; ++depth) {
+    const int position = axisLen_ - depth - 1;
+    for (int cross = 0; cross < crossLen_; cross += crossStep) {
+      const int x = axis_ == Axis::Vertical ? cross : position;
+      const int y = axis_ == Axis::Vertical ? position : cross;
+      const std::size_t firstOff = (static_cast<std::size_t>(y) * width_ + x) * 4;
+      const std::size_t otherOff = static_cast<std::size_t>(y) * frame.stride + x * 4;
+      for (int c = 0; c < 3; ++c) {
+        edgeSums[depth] += static_cast<std::uint64_t>(
+            std::abs(static_cast<int>(firstRgba_[firstOff + c]) -
+                     static_cast<int>(frame.bits[otherOff + c])));
+        ++edgeCounts[depth];
+      }
+    }
+  }
+
+  // Aligned observation: previous trailing rows vs the same document rows in
+  // this frame (shifted by delta).
+  std::vector<std::uint64_t> alignedSums(maxEdge_, 0), alignedCounts(maxEdge_, 0);
+  const std::vector<std::uint8_t> &previous =
+      bands_.empty() ? firstRgba_ : bands_.back().rgba;
+  const int previousStart = bands_.empty() ? 0 : bands_.back().sourceAxisStart;
+  const int previousRowBytes =
+      bands_.empty() ? width_ * 4
+      : axis_ == Axis::Vertical
+          ? width_ * 4
+          : (axisLen_ - bands_.back().sourceAxisStart) * 4;
+  for (int depth = 0; depth < maxEdge_; ++depth) {
+    const int position = axisLen_ - depth - 1;
+    const int aligned = position - delta;
+    if (aligned < 0 || position < previousStart)
+      continue;
+    for (int cross = 0; cross < crossLen_; cross += crossStep) {
+      std::size_t prevOff, otherOff;
+      if (axis_ == Axis::Vertical) {
+        prevOff = static_cast<std::size_t>(position - previousStart) * previousRowBytes + cross * 4;
+        otherOff = static_cast<std::size_t>(aligned) * frame.stride + cross * 4;
+      } else {
+        prevOff = static_cast<std::size_t>(cross) * previousRowBytes + (position - previousStart) * 4;
+        otherOff = static_cast<std::size_t>(cross) * frame.stride + aligned * 4;
+      }
+      for (int c = 0; c < 3; ++c) {
+        alignedSums[depth] += static_cast<std::uint64_t>(
+            std::abs(static_cast<int>(previous[prevOff + c]) -
+                     static_cast<int>(frame.bits[otherOff + c])));
+        ++alignedCounts[depth];
+      }
+    }
+  }
+
+  // Commit.
+  for (int depth = 0; depth < maxEdge_; ++depth) {
+    edgeSums_[depth] += edgeSums[depth];
+    edgeCounts_[depth] += edgeCounts[depth];
+    alignedSums_[depth] += alignedSums[depth];
+    alignedCounts_[depth] += alignedCounts[depth];
+  }
+  bands_.push_back(std::move(band));
+  totalDelta_ = static_cast<int>(newTotal);
+  return true;
+}
+
+int StitchAccumulator::stationaryTrailingStrip() const {
+  if (bands_.empty())
+    return 0;
+  int strip = 0;
+  for (int depth = 0; depth < maxEdge_; ++depth) {
+    const double error = edgeCounts_[depth] == 0
+                             ? kInf
+                             : static_cast<double>(edgeSums_[depth]) / edgeCounts_[depth];
+    if (error > kStationaryEdgeError)
+      break;
+    ++strip;
+  }
+  return strip;
+}
+
+int StitchAccumulator::nearStationaryTrailingZone(int strip) const {
+  if (bands_.empty())
+    return 0;
+  int zone = 0;
+  for (int depth = strip; depth < maxEdge_; ++depth) {
+    const double error = alignedCounts_[depth] == 0
+                             ? 0.0
+                             : static_cast<double>(alignedSums_[depth]) / alignedCounts_[depth];
+    if (error <= kNearStationaryError)
+      break;
+    ++zone;
+  }
+  return zone;
+}
+
+bool StitchAccumulator::wouldExceedBudget(int delta) const {
+  if (!valid_ || delta <= 0)
+    return false;
+  return exceedsStitchBudget(crossLen_,
+                             axisLen_ + static_cast<long long>(totalDelta_) + delta);
+}
+
+bool StitchAccumulator::exceedsWidelyOpenableEdge() const {
+  if (!valid_)
+    return false;
+  const long long motion = static_cast<long long>(axisLen_) + totalDelta_;
+  return motion > kWidelyOpenableEdge || crossLen_ > kWidelyOpenableEdge;
+}
+
+long StitchAccumulator::retainedRgbaBytes() const {
+  long total = static_cast<long>(firstRgba_.size());
+  for (const TailBand &band : bands_)
+    total += static_cast<long>(band.rgba.size());
+  return total;
+}
+
+QImage StitchAccumulator::finish(QString &error) {
+  if (!valid_) {
+    error = QStringLiteral("accumulator is not initialized");
+    return {};
+  }
+  const int strip = stationaryTrailingStrip();
+  const int trailing = strip + nearStationaryTrailingZone(strip);
+  const int contentExtent = std::max(0, axisLen_ - trailing);
+  if (contentExtent == 0) {
+    error = QStringLiteral("stationary trailing edge covers the entire capture");
+    return {};
+  }
+  for (const TailBand &band : bands_) {
+    if (band.delta >= contentExtent) {
+      error = QStringLiteral("invalid stitch delta %1 for content extent %2")
+                  .arg(band.delta)
+                  .arg(contentExtent);
+      return {};
+    }
+  }
+
+  if (axis_ == Axis::Vertical) {
+    const int contentBottom = height_ - trailing;
+    const int totalHeight = height_ + totalDelta_;
+    const int rowBytes = width_ * 4;
+    // Rows go straight into the image. Assembling into a vector first and
+    // copying would hold the finished image twice, which is the difference
+    // between fitting and being OOM-killed on a very long capture. A reverse
+    // capture is emitted back-to-front rather than reversed afterwards.
+    QImage image(width_, totalHeight, QImage::Format_RGBA8888);
+    if (image.isNull()) {
+      error = QStringLiteral("could not allocate the stitched image (%1x%2)")
+                  .arg(width_)
+                  .arg(totalHeight);
+      return {};
+    }
+    const bool reverse = direction_ == Direction::Reverse;
+    int row = 0;
+    const auto emitRows = [&](const std::vector<std::uint8_t> &source,
+                              std::size_t byteStart, int rows) {
+      for (int i = 0; i < rows; ++i, ++row) {
+        const int destination = reverse ? totalHeight - 1 - row : row;
+        std::memcpy(image.scanLine(destination),
+                    source.data() + byteStart +
+                        static_cast<std::size_t>(i) * rowBytes,
+                    rowBytes);
+      }
+    };
+    // First frame's content rows.
+    emitRows(firstRgba_, 0, contentBottom);
+    // Each band's delta rows.
+    for (const TailBand &band : bands_) {
+      const int sourceStart = contentBottom - band.delta;
+      const int localStart = sourceStart - band.sourceAxisStart;
+      emitRows(band.rgba, static_cast<std::size_t>(localStart) * rowBytes,
+               band.delta);
+    }
+    // One trailing strip from the last band.
+    if (trailing > 0) {
+      const TailBand &last = bands_.back();
+      const int localStart = contentBottom - last.sourceAxisStart;
+      emitRows(last.rgba, static_cast<std::size_t>(localStart) * rowBytes,
+               trailing);
+    }
+    return image;
+  }
+
+  // Horizontal.
+  const int contentRight = width_ - trailing;
+  const int totalWidth = width_ + totalDelta_;
+  QImage image(totalWidth, height_, QImage::Format_RGBA8888);
+  for (int y = 0; y < height_; ++y) {
+    std::uint8_t *dst = image.scanLine(y);
+    std::size_t cursor = 0;
+    const std::size_t firstRow = static_cast<std::size_t>(y) * width_ * 4;
+    std::memcpy(dst, firstRgba_.data() + firstRow, static_cast<std::size_t>(contentRight) * 4);
+    cursor += static_cast<std::size_t>(contentRight) * 4;
+    for (const TailBand &band : bands_) {
+      const int bandWidth = width_ - band.sourceAxisStart;
+      const int sourceStart = contentRight - band.delta;
+      const int localStart = sourceStart - band.sourceAxisStart;
+      const std::size_t byteStart = (static_cast<std::size_t>(y) * bandWidth + localStart) * 4;
+      std::memcpy(dst + cursor, band.rgba.data() + byteStart, static_cast<std::size_t>(band.delta) * 4);
+      cursor += static_cast<std::size_t>(band.delta) * 4;
+    }
+    if (trailing > 0) {
+      const TailBand &last = bands_.back();
+      const int bandWidth = width_ - last.sourceAxisStart;
+      const int localStart = contentRight - last.sourceAxisStart;
+      const std::size_t byteStart = (static_cast<std::size_t>(y) * bandWidth + localStart) * 4;
+      std::memcpy(dst + cursor, last.rgba.data() + byteStart, static_cast<std::size_t>(trailing) * 4);
+    }
+  }
+  if (direction_ == Direction::Reverse)
+    image = image.flipped(Qt::Horizontal);
+  return image;
+}
+
+QImage stitchWithDeltas(const QVector<QImage> &frames, const QVector<int> &deltas,
+                        Axis axis, QString &error) {
+  if (frames.isEmpty()) {
+    error = QStringLiteral("no frames to stitch");
+    return {};
+  }
+  if (deltas.size() != frames.size() - 1) {
+    error = QStringLiteral("deltas must have one entry per frame gap");
+    return {};
+  }
+  bool ok = false;
+  StitchAccumulator accumulator(frames.first(), axis, ok, error);
+  if (!ok)
+    return {};
+  for (int i = 1; i < frames.size(); ++i)
+    if (!accumulator.pushForward(frames.at(i), deltas.at(i - 1), error))
+      return {};
+  return accumulator.finish(error);
+}
+
+// --- Forward lookahead (auto-scroll alignment verification) -----------------
+namespace {
+double plausibleErrorLimit(double best) {
+  return std::max(best * kMinConfidence, best + kMinErrorMargin);
+}
+
+bool errorsAreDistinct(double best, double runner) {
+  if (!std::isfinite(best) || !std::isfinite(runner))
+    return std::isinf(runner) && std::isfinite(best);
+  double confidence;
+  if (best <= std::numeric_limits<double>::epsilon())
+    confidence = runner <= std::numeric_limits<double>::epsilon() ? 1.0 : kInf;
+  else
+    confidence = runner / best;
+  return confidence >= kMinConfidence && runner - best >= kMinErrorMargin;
+}
+
+bool forwardCandidateLess(const ForwardMatchCandidate &a,
+                          const ForwardMatchCandidate &b) {
+  if (a.error != b.error || std::isnan(a.error) || std::isnan(b.error))
+    return errorLess(a.error, b.error);
+  return a.delta < b.delta;
+}
+
+bool forwardPathLess(const ForwardMatchPath &a, const ForwardMatchPath &b) {
+  if (a.totalError != b.totalError || std::isnan(a.totalError) ||
+      std::isnan(b.totalError))
+    return errorLess(a.totalError, b.totalError);
+  if (a.firstDelta != b.firstDelta)
+    return a.firstDelta < b.firstDelta;
+  return a.secondDelta < b.secondDelta;
+}
+
+bool matcherGradeCandidate(const ForwardMatchCandidate &candidate) {
+  return std::isfinite(candidate.error) && candidate.error <= kMaxMatchError;
+}
+
+/// The automatic worker uses 3 wheel notches followed by a 1-notch probe, or
+/// its keyboard fallback of 5 arrows followed by 2. Cadence is only a soft
+/// tie-breaker.
+double autoCadencePriorScore(const ForwardMatchPath &path) {
+  const double ratio =
+      static_cast<double>(path.firstDelta) / static_cast<double>(path.secondDelta);
+  return std::min(std::abs(ratio - 3.0), std::abs(ratio - 2.5));
+}
+
+bool autoPeriodicPathLess(const ForwardMatchPath &a, const ForwardMatchPath &b) {
+  if (a.totalError != b.totalError || std::isnan(a.totalError) ||
+      std::isnan(b.totalError))
+    return errorLess(a.totalError, b.totalError);
+  const double cadenceA = autoCadencePriorScore(a);
+  const double cadenceB = autoCadencePriorScore(b);
+  if (cadenceA != cadenceB)
+    return errorLess(cadenceA, cadenceB);
+  if (a.firstDelta != b.firstDelta)
+    return a.firstDelta < b.firstDelta;
+  return a.secondDelta < b.secondDelta;
+}
+
+std::vector<ForwardMatchPath>
+consistentForwardPaths(const ForwardCandidateSet &first,
+                       const ForwardCandidateSet &second,
+                       const ForwardCandidateSet &cumulative) {
+  std::vector<ForwardMatchPath> paths;
+  for (const ForwardMatchCandidate &a : first.candidates) {
+    for (const ForwardMatchCandidate &b : second.candidates) {
+      const long sum = static_cast<long>(a.delta) + b.delta;
+      const ForwardMatchCandidate *total = nullptr;
+      for (const ForwardMatchCandidate &c : cumulative.candidates) {
+        if (std::abs(static_cast<long>(c.delta) - sum) > kPathDeltaTolerance)
+          continue;
+        if (!total || forwardCandidateLess(c, *total))
+          total = &c;
+      }
+      if (!total)
+        continue;
+      const double consistencyError =
+          static_cast<double>(std::abs(static_cast<long>(total->delta) - sum));
+      paths.push_back(
+          {a.delta, b.delta, a.error + b.error + total->error + consistencyError});
+    }
+  }
+  return paths;
+}
+
+ForwardCandidateSet matcherGradeSet(const ForwardCandidateSet &set) {
+  ForwardCandidateSet graded;
+  graded.truncated = set.truncated;
+  graded.searchMaxDelta = set.searchMaxDelta;
+  for (const ForwardMatchCandidate &candidate : set.candidates)
+    if (matcherGradeCandidate(candidate))
+      graded.candidates.push_back(candidate);
+  return graded;
+}
+
+/// Cumulatively consistent path for known-forward automatic capture; each
+/// candidate is error-filtered individually so a very good pair cannot mask
+/// a poor seam in the summed score.
+std::optional<ForwardMatchPath>
+bestMatcherGradeAutoPath(const ForwardCandidateSet &first,
+                         const ForwardCandidateSet &second,
+                         const ForwardCandidateSet &cumulative) {
+  std::vector<ForwardMatchPath> paths = consistentForwardPaths(
+      matcherGradeSet(first), matcherGradeSet(second), matcherGradeSet(cumulative));
+  if (paths.empty())
+    return std::nullopt;
+  std::stable_sort(paths.begin(), paths.end(), autoPeriodicPathLess);
+  return paths.front();
+}
+
+/// If both adjacent seams are sound but their sum exceeds the largest F0→F2
+/// displacement retaining minimum overlap, the absent cumulative candidate is
+/// not contradictory evidence.
+std::optional<ForwardMatchPath>
+bestUnverifiableAutoPath(const ForwardCandidateSet &first,
+                         const ForwardCandidateSet &second,
+                         const ForwardCandidateSet &cumulative) {
+  if (!cumulative.searchMaxDelta)
+    return std::nullopt;
+  std::vector<ForwardMatchPath> paths;
+  for (const ForwardMatchCandidate &a : first.candidates) {
+    if (!matcherGradeCandidate(a))
+      continue;
+    for (const ForwardMatchCandidate &b : second.candidates) {
+      if (!matcherGradeCandidate(b))
+        continue;
+      const long sum = static_cast<long>(a.delta) + b.delta;
+      if (sum <= *cumulative.searchMaxDelta)
+        continue;
+      paths.push_back({a.delta, b.delta, a.error + b.error});
+    }
+  }
+  if (paths.empty())
+    return std::nullopt;
+  std::stable_sort(paths.begin(), paths.end(), autoPeriodicPathLess);
+  return paths.front();
+}
+
+std::optional<ForwardMatchPath>
+bestIndependentPath(const ForwardCandidateSet &first,
+                    const ForwardCandidateSet &second) {
+  if (first.candidates.empty() || second.candidates.empty())
+    return std::nullopt;
+  const ForwardMatchCandidate &a = first.candidates.front();
+  const ForwardMatchCandidate &b = second.candidates.front();
+  return ForwardMatchPath{a.delta, b.delta, a.error + b.error};
+}
+} // namespace
+
+ForwardCandidateSet forwardCandidateSet(const GrayView &prev,
+                                        const GrayView &cur, Axis axis) {
+  ForwardCandidateSet result;
+  if (prev.width != cur.width || prev.height != cur.height ||
+      static_cast<int>(prev.pixels.size()) != prev.width * prev.height ||
+      static_cast<int>(cur.pixels.size()) != cur.width * cur.height)
+    return result;
+  const int axisLen = prev.axisLen(axis);
+  const int crossLen = prev.crossLen(axis);
+  if (axisLen < kMinOverlapPixels + kMinMotionPixels || crossLen < 2)
+    return result;
+
+  const int minOverlap = std::min(
+      std::max(axisLen / kMinOverlapDen, kMinOverlapPixels), std::max(0, axisLen - 1));
+  const int maxShift = std::max(0, axisLen - minOverlap);
+  const int sourceScale = prev.sourceScale(axis);
+  result.searchMaxDelta = maxShift * sourceScale;
+  const int minShift = kMinMotionPixels / sourceScale + 1;
+  if (minShift > maxShift)
+    return result;
+
+  const int matchExtent = axisLen - maxShift;
+  const int coarseAxis = std::max(1, matchExtent / 32);
+  const int coarseCross = std::max(1, crossLen / 48);
+  const int fineAxis = std::max(1, matchExtent / 256);
+  const int fineCross = std::max(1, crossLen / 256);
+
+  // Search only the physically possible direction; every forward shift that
+  // preserves the global minimum overlap remains eligible.
+  std::vector<SearchSample> coarse;
+  coarse.reserve(static_cast<std::size_t>(maxShift - minShift) + 1);
+  for (long shift = minShift; shift <= maxShift; ++shift)
+    coarse.push_back({shift, scoreShift(prev, cur, axis, shift, maxShift,
+                                        coarseAxis, coarseCross)});
+  std::stable_sort(coarse.begin(), coarse.end(),
+                   [](const SearchSample &a, const SearchSample &b) {
+                     return errorLess(a.error, b.error);
+                   });
+  if (coarse.empty())
+    return result;
+  const SearchSample coarseBest = coarse.front();
+  if (!std::isfinite(coarseBest.error) || coarseBest.error > kMaxMatchError)
+    return result;
+
+  const double coarseLimit =
+      std::min(plausibleErrorLimit(coarseBest.error), kMaxMatchError);
+  const long peakNeighborhood = std::clamp(axisLen / 256, 6, 16);
+  std::vector<SearchSample> peaks;
+  for (const SearchSample &sample : coarse) {
+    if (sample.error > coarseLimit)
+      break;
+    if (std::any_of(peaks.begin(), peaks.end(), [&](const SearchSample &peak) {
+          return std::abs(peak.shift - sample.shift) <= peakNeighborhood;
+        }))
+      continue;
+    if (static_cast<int>(peaks.size()) == kMaxForwardCandidates) {
+      result.truncated = true;
+      break;
+    }
+    peaks.push_back(sample);
+  }
+
+  std::vector<ForwardMatchCandidate> refined;
+  refined.reserve(peaks.size());
+  for (const SearchSample &peak : peaks) {
+    const long start = std::max<long>(peak.shift - 1, minShift);
+    const long end = std::min<long>(peak.shift + 1, maxShift);
+    SearchSample best{peak.shift, kInf};
+    for (long shift = start; shift <= end; ++shift) {
+      const double error =
+          scoreShift(prev, cur, axis, shift, maxShift, fineAxis, fineCross);
+      if (error < best.error)
+        best = {shift, error};
+    }
+    const int delta = static_cast<int>(std::abs(best.shift)) * sourceScale;
+    if (delta <= kMinMotionPixels || best.error > kMaxMatchError)
+      continue;
+    auto existing = std::find_if(
+        refined.begin(), refined.end(), [&](const ForwardMatchCandidate &c) {
+          return std::abs(static_cast<long>(c.delta) - delta) <= peakNeighborhood;
+        });
+    if (existing != refined.end()) {
+      if (best.error < existing->error)
+        *existing = {delta, best.error};
+    } else {
+      refined.push_back({delta, best.error});
+    }
+  }
+
+  std::stable_sort(refined.begin(), refined.end(), forwardCandidateLess);
+  if (!refined.empty()) {
+    const ForwardMatchCandidate best = refined.front();
+    refined.erase(std::remove_if(refined.begin(), refined.end(),
+                                 [&](const ForwardMatchCandidate &c) {
+                                   return !(c == best) &&
+                                          errorsAreDistinct(best.error, c.error);
+                                 }),
+                  refined.end());
+  }
+  result.candidates = std::move(refined);
+  return result;
+}
+
+ForwardMatch classifyForwardWithLookahead(const GrayView &prev,
+                                          const GrayView &cur, Axis axis) {
+  const MotionEstimate estimate = classifyMotion(prev, cur, axis);
+  const bool matcherGradeAmbiguity =
+      estimate.motion.kind == MotionKind::Unmatchable &&
+      std::isfinite(estimate.error) && estimate.error <= kMaxMatchError;
+  const bool needsLookahead = estimate.motion.kind == MotionKind::Ambiguous ||
+                              estimate.motion.kind == MotionKind::Reverse ||
+                              matcherGradeAmbiguity;
+  ForwardMatch match;
+  match.classified = estimate;
+  if (!needsLookahead)
+    return match;
+  ForwardCandidateSet first = forwardCandidateSet(prev, cur, axis);
+  if (first.candidates.empty() ||
+      first.candidates.front().error > kMaxMatchError)
+    return match;
+  match.tag = ForwardMatch::Tag::Ambiguous;
+  match.ambiguous.emplace(prev, cur, axis, std::move(first), estimate);
+  return match;
+}
+
+ForwardLookaheadResolution
+resolveForwardCandidateSets(const ForwardCandidateSet &first,
+                            const ForwardCandidateSet &second,
+                            const ForwardCandidateSet &cumulative,
+                            bool allowPhysicalPrior) {
+  std::vector<ForwardMatchPath> paths =
+      consistentForwardPaths(first, second, cumulative);
+  std::stable_sort(paths.begin(), paths.end(), forwardPathLess);
+  const std::optional<ForwardMatchPath> bestConsistent =
+      paths.empty() ? std::nullopt : std::optional(paths.front());
+  std::optional<ForwardMatchPath> fallback = bestConsistent;
+  if (!fallback)
+    fallback = bestIndependentPath(first, second);
+
+  ForwardLookaheadResolution resolution;
+  if (!bestConsistent) {
+    if (allowPhysicalPrior) {
+      if (std::optional<ForwardMatchPath> path =
+              bestUnverifiableAutoPath(first, second, cumulative)) {
+        resolution.tag = ForwardLookaheadResolution::Tag::LowErrorPeriodic;
+        resolution.path = path;
+        return resolution;
+      }
+    }
+    resolution.tag = ForwardLookaheadResolution::Tag::Unresolved;
+    resolution.path = fallback;
+    return resolution;
+  }
+
+  const bool unique =
+      paths.size() < 2 ||
+      errorsAreDistinct(bestConsistent->totalError, paths[1].totalError);
+  if (unique && !first.truncated && !second.truncated && !cumulative.truncated) {
+    resolution.tag = ForwardLookaheadResolution::Tag::Resolved;
+    resolution.path = bestConsistent;
+    return resolution;
+  }
+  if (allowPhysicalPrior) {
+    if (std::optional<ForwardMatchPath> path =
+            bestMatcherGradeAutoPath(first, second, cumulative)) {
+      resolution.tag = ForwardLookaheadResolution::Tag::LowErrorPeriodic;
+      resolution.path = path;
+      return resolution;
+    }
+  }
+  resolution.tag = ForwardLookaheadResolution::Tag::Unresolved;
+  resolution.path = bestConsistent;
+  return resolution;
+}
+
+std::optional<ForwardMatchCandidate>
+ForwardLookahead::uniqueCandidateAtMost(int maxSourceDelta) const {
+  if (first_.truncated)
+    return std::nullopt;
+  std::optional<ForwardMatchCandidate> match;
+  for (const ForwardMatchCandidate &candidate : first_.candidates) {
+    if (candidate.delta > maxSourceDelta)
+      continue;
+    if (match)
+      return std::nullopt;
+    match = candidate;
+  }
+  return match;
+}
+
+ForwardLookaheadResolution
+ForwardLookahead::resolve(const GrayView &lookahead) const {
+  return resolveWithPhysicalPrior(lookahead, false);
+}
+
+ForwardLookaheadResolution
+ForwardLookahead::resolveAuto(const GrayView &lookahead) const {
+  return resolveWithPhysicalPrior(lookahead, true);
+}
+
+ForwardLookaheadResolution
+ForwardLookahead::resolveWithPhysicalPrior(const GrayView &lookahead,
+                                           bool allowPhysicalPrior) const {
+  // A probe can legitimately capture the pending viewport again (end of page,
+  // wheel not yet applied, paint not advanced). The forward-only search
+  // excludes zero and would find a periodic non-zero alias, fabricating a
+  // second band, so classify zero motion first and keep only the first
+  // match.
+  const MotionEstimate probe = classifyMotion(pending_, lookahead, axis_);
+  if (probe.motion.kind == MotionKind::Stationary) {
+    ForwardLookaheadResolution resolution;
+    resolution.tag = ForwardLookaheadResolution::Tag::StationaryProbe;
+    StationaryProbeFirstMatch firstMatch;
+    const std::optional<ForwardMatchCandidate> best =
+        first_.candidates.empty() ? std::nullopt
+                                  : std::optional(first_.candidates.front());
+    if (!first_.truncated && first_.candidates.size() == 1) {
+      firstMatch.tag = StationaryProbeFirstMatch::Tag::Unique;
+      firstMatch.candidate = best;
+    } else {
+      firstMatch.tag = StationaryProbeFirstMatch::Tag::Ambiguous;
+      firstMatch.candidate = best;
+    }
+    resolution.firstMatch = firstMatch;
+    return resolution;
+  }
+  const ForwardCandidateSet second =
+      forwardCandidateSet(pending_, lookahead, axis_);
+  const ForwardCandidateSet cumulative =
+      forwardCandidateSet(origin_, lookahead, axis_);
+  return resolveForwardCandidateSets(first_, second, cumulative,
+                                     allowPhysicalPrior);
+}
+
+// --- Live manual capture session ------------------------------------------------
+namespace {
+constexpr double kAmbiguousMaxError = 2.0;       // MANUAL_AMBIGUOUS_MAX_ERROR
+constexpr double kAmbiguousMinConfidence = 1.02; // MANUAL_AMBIGUOUS_MIN_CONFIDENCE
+constexpr int kMaxBlankFirstFrames = 8;          // MAX_CONSECUTIVE_BLANK_FRAMES
+
+bool imageIsUniform(const QImage &image) {
+  if (image.isNull())
+    return true;
+  const QRgb first = image.pixel(0, 0);
+  const int stepX = std::max(1, image.width() / 64);
+  const int stepY = std::max(1, image.height() / 64);
+  for (int y = 0; y < image.height(); y += stepY)
+    for (int x = 0; x < image.width(); x += stepX)
+      if (image.pixel(x, y) != first)
+        return false;
+  return true;
+}
+} // namespace
+
+int ManualCapture::coalesceThreshold(int axisLen) {
+  return std::min(std::clamp(axisLen / 8, 16, 128), std::max(1, axisLen - 1));
+}
+
+int ManualCapture::manualSearchBound(int axisLen) {
+  return std::min(std::clamp(axisLen / 8, 128, 512), std::max(1, axisLen - 1));
+}
+
+ManualCapture::ManualCapture(Axis axis) : axis_(axis) {}
+
+ManualCapture::Outcome ManualCapture::outcome(Event event,
+                                              const MotionEstimate &estimate,
+                                              QString error) const {
+  Outcome result;
+  result.event = event;
+  result.estimate = estimate;
+  result.keptFrames = kept_;
+  result.pendingDelta = pending_ ? pending_->delta : 0;
+  result.error = std::move(error);
+  return result;
+}
+
+ManualCapture::Outcome ManualCapture::feed(const QImage &input) {
+  const QImage cropped = input.format() == QImage::Format_RGBA8888
+                             ? input
+                             : input.convertToFormat(QImage::Format_RGBA8888);
+  QString error;
+  const GrayView gray = downsampleToGray(cropped, axis_);
+  const int axisLen = gray.axisLen(axis_);
+
+  if (!accumulator_) {
+    if (imageIsUniform(cropped)) {
+      ++blankFirstFrames_;
+      return outcome(Event::Blank, {},
+                     blankFirstFrames_ >= kMaxBlankFirstFrames
+                         ? QStringLiteral("capture shows only a solid colour")
+                         : QString());
+    }
+    bool ok = false;
+    accumulator_.emplace(cropped, axis_, ok, error);
+    if (!ok) {
+      accumulator_.reset();
+      return outcome(Event::Error, {}, error);
+    }
+    lastGray_ = gray;
+    previousGray_ = gray;
+    havePrevious_ = true;
+    kept_ = 1;
+    return outcome(Event::Seeded);
+  }
+
+  MotionEstimate est = classifyMotion(lastGray_, gray, axis_);
+  if (est.motion.kind == MotionKind::Ambiguous) {
+    // Repeated content: re-search close to the small motion a hand scroll
+    // makes and take a clean nearby peak (recover_bounded_manual_motion).
+    const int bound = manualSearchBound(axisLen);
+    const MotionEstimate bounded =
+        classifyMotionBounded(lastGray_, gray, axis_, bound);
+    int signedDelta = 0;
+    switch (bounded.motion.kind) {
+    case MotionKind::Forward: signedDelta = bounded.motion.delta; break;
+    case MotionKind::Reverse: signedDelta = -bounded.motion.delta; break;
+    case MotionKind::Ambiguous: signedDelta = bounded.motion.delta; break;
+    default: break;
+    }
+    if (signedDelta != 0 && std::abs(signedDelta) <= bound &&
+        std::isfinite(bounded.error) && bounded.error <= kAmbiguousMaxError &&
+        bounded.confidence >= kAmbiguousMinConfidence)
+      est = bounded;
+  }
+
+  // Motion since the previous grab tells "at rest but looks different" (a
+  // video or hover UI changed in place) from real scrolling when the
+  // reference cannot be matched.
+  const bool atRest =
+      havePrevious_ &&
+      classifyMotion(previousGray_, gray, axis_).motion.kind ==
+          MotionKind::Stationary;
+  previousGray_ = gray;
+  havePrevious_ = true;
+
+  switch (est.motion.kind) {
+  case MotionKind::Forward:
+    return recordMotion(cropped, gray, Direction::Forward, est.motion.delta, est);
+  case MotionKind::Reverse:
+    return recordMotion(cropped, gray, Direction::Reverse, est.motion.delta, est);
+  case MotionKind::Stationary:
+    if (pending_) {
+      // Stationary relative to the committed reference: the small pending
+      // movement was reversed; drop it and re-arm.
+      pending_.reset();
+      if (accumulator_->frameCount() == 1)
+        direction_ = Direction::None;
+      return outcome(Event::PendingDropped, est);
+    }
+    return outcome(Event::Still, est);
+  case MotionKind::Ambiguous: {
+    // A small, clean ambiguous candidate may be held as the pending frame; a
+    // large or noisy one asks the user to keep scrolling.
+    const int delta = std::abs(est.motion.delta);
+    const Direction direction =
+        est.motion.delta > 0 ? Direction::Forward : Direction::Reverse;
+    if (delta > 0 && delta < coalesceThreshold(axisLen) &&
+        std::isfinite(est.error) && est.error <= kAmbiguousMaxError &&
+        est.confidence >= kAmbiguousMinConfidence)
+      return recordMotion(cropped, gray, direction, delta, est);
+    return outcome(Event::Ambiguous, est);
+  }
+  case MotionKind::Unmatchable:
+    if (accumulator_->frameCount() == 1 && !pending_ && atRest) {
+      // Nothing committed yet and the page is at rest but no longer matches
+      // the first frame: its content changed in place. Re-seed from the
+      // current appearance, and nothing captured is lost.
+      bool ok = false;
+      QString seedError;
+      accumulator_.emplace(cropped, axis_, ok, seedError);
+      if (!ok)
+        return outcome(Event::Error, est, seedError);
+      lastGray_ = gray;
+      direction_ = Direction::None;
+      return outcome(Event::ReSeeded, est);
+    }
+    // Keep the last verified reference; a later frame that overlaps it
+    // (scroll back a little) resumes the capture.
+    return outcome(Event::Unmatchable, est);
+  }
+  return outcome(Event::Still, est);
+}
+
+ManualCapture::Outcome ManualCapture::recordMotion(const QImage &cropped,
+                                                   const GrayView &gray,
+                                                   Direction direction,
+                                                   int delta,
+                                                   const MotionEstimate &estimate) {
+  const bool hasBand = accumulator_->frameCount() > 1;
+  if (direction_ != Direction::None && direction_ != direction) {
+    // One stitch is one direction; before any band is committed the user may
+    // still choose it (crossing back over the first viewport).
+    if (hasBand)
+      return outcome(Event::WrongDirection, estimate);
+    pending_.reset();
+    direction_ = direction;
+  } else if (direction_ == Direction::None) {
+    direction_ = direction;
+  }
+  const int axisLen = gray.axisLen(axis_);
+  if (delta < coalesceThreshold(axisLen)) {
+    // Hold small movement back; it is replaced as it grows and committed by
+    // the next large step or by finish().
+    pending_ = PendingFrame{cropped, delta, direction};
+    return outcome(Event::Pending, estimate);
+  }
+  if (accumulator_->wouldExceedBudget(delta)) {
+    // A designed limit, not a failure: the capture so far is intact and the
+    // caller stops here rather than refusing a frame every tick.
+    return outcome(Event::Full, estimate);
+  }
+  QString error;
+  const bool pushed = direction == Direction::Forward
+                          ? accumulator_->pushForward(cropped, delta, error)
+                          : accumulator_->pushReverse(cropped, delta, error);
+  if (!pushed)
+    return outcome(Event::Error, estimate, error);
+  lastGray_ = gray;
+  pending_.reset();
+  ++kept_;
+  return outcome(Event::Kept, estimate);
+}
+
+QImage ManualCapture::finish(QString &error) {
+  if (!accumulator_) {
+    error = QStringLiteral("no frames were captured");
+    return {};
+  }
+  if (pending_) {
+    const PendingFrame pending = *pending_;
+    const bool pushed =
+        pending.direction == Direction::Forward
+            ? accumulator_->pushForward(pending.frame, pending.delta, error)
+            : accumulator_->pushReverse(pending.frame, pending.delta, error);
+    if (!pushed)
+      return {};
+    pending_.reset();
+    ++kept_;
+  }
+  return accumulator_->finish(error);
+}
+
+} // namespace stitch

--- a/src/stitch.cpp
+++ b/src/stitch.cpp
@@ -1227,7 +1227,7 @@ ManualCapture::Outcome ManualCapture::feed(const QImage &input) {
       ++blankFirstFrames_;
       return outcome(Event::Blank, {},
                      blankFirstFrames_ >= kMaxBlankFirstFrames
-                         ? QStringLiteral("capture shows only a solid colour")
+                         ? QStringLiteral("capture shows only a solid color")
                          : QString());
     }
     bool ok = false;

--- a/src/stitch.hpp
+++ b/src/stitch.hpp
@@ -1,0 +1,382 @@
+/** @fileoverview Pure scroll-capture stitcher: classifies inter-frame motion
+ *  and assembles overlapping frames into one tall (or wide) image. Operates
+ *  on QImage with no compositor or windowing dependency, so it runs in the
+ *  offscreen smoke harness. */
+#pragma once
+
+#include <QImage>
+#include <QString>
+#include <QVector>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace stitch {
+
+/// Downsample factor across the direction of travel. The motion axis stays at
+/// source resolution so deltas are exact; the cross axis is /4.
+inline constexpr int kDownsampleCross = 4;
+// Classifier/matcher thresholds, validated against the capture corpus.
+inline constexpr int kMinOverlapDen = 3;
+inline constexpr int kMinOverlapPixels = 32;
+inline constexpr int kMinMotionPixels = 3;
+/// Largest stitched image a capture may grow to, as RGBA bytes. The retained
+/// bands already hold roughly the finished image, so peak memory is about
+/// twice this. It exists because Linux overcommits: an unbounded capture is
+/// not refused at allocation time, it is OOM-killed part-way through
+/// assembly, after the user has spent a minute scrolling.
+/// Longest edge that image software can be relied on to open. Many renderers
+/// address pixels with signed 16-bit coordinates, so 32767 is a common wall
+/// (Firefox refuses images past it). Nothing here breaks at this size, since
+/// our own editor opens and saves them, so it is advisory rather than a
+/// limit.
+inline constexpr int kWidelyOpenableEdge = 32767;
+inline constexpr long long kMaxStitchedBytes = 512LL * 1024 * 1024;
+inline constexpr long long kMaxStitchedPixels = kMaxStitchedBytes / 4;
+/// Whether growing a capture of `crossLen` by `axisExtent` along the motion
+/// axis would pass that budget.
+[[nodiscard]] constexpr bool exceedsStitchBudget(long long crossLen,
+                                                 long long axisExtent) {
+  return crossLen > 0 && axisExtent > 0 &&
+         crossLen * axisExtent > kMaxStitchedPixels;
+}
+inline constexpr double kStationaryError = 1.0;
+inline constexpr double kMaxStationaryError = 8.0;
+inline constexpr double kMaxAmbiguousError = 2.0;
+inline constexpr double kMaxMatchError = 24.0;
+inline constexpr double kMinConfidence = 1.10;
+inline constexpr double kMinErrorMargin = 0.75;
+inline constexpr int kMaxForwardCandidates = 64;
+inline constexpr int kPathDeltaTolerance = 2;
+inline constexpr int kMaxStationaryEdge = 128;       // accumulator
+inline constexpr double kStationaryEdgeError = 1.0;
+inline constexpr int kMaxStationaryScoringEdgeDen = 4;
+inline constexpr double kNearStationaryError = 1.0;  // accumulator
+
+enum class Axis { Vertical, Horizontal };
+
+/// Classification of the second frame relative to the first. Forward is
+/// down (vertical) or right (horizontal); deltas are source-frame pixels.
+enum class MotionKind { Stationary, Forward, Reverse, Ambiguous, Unmatchable };
+
+struct Motion {
+  MotionKind kind = MotionKind::Unmatchable;
+  /// Forward/Reverse: magnitude ≥ 0. Ambiguous: signed (>0 forward,
+  /// <0 reverse). Stationary/Unmatchable: 0.
+  int delta = 0;
+};
+
+/// Motion plus diagnostics. `error` is mean absolute grayscale error per
+/// sampled pixel; `confidence` is the ratio of the best distinct competing
+/// peak to the chosen peak.
+struct MotionEstimate {
+  Motion motion;
+  double error = 0.0;
+  double confidence = 0.0;
+};
+
+/// Downsampled grayscale frame used by the motion matcher. Pixels are
+/// row-major, `width * height`. The motion axis is at full source resolution;
+/// the cross axis is downsampled by kDownsampleCross. `sourceWidth` records
+/// the pre-downsample width so horizontal source pixels can be recovered.
+class GrayView {
+public:
+  std::vector<std::uint8_t> pixels;
+  int width = 0;
+  int height = 0;
+  int sourceWidth = 0;
+
+  [[nodiscard]] int axisLen(Axis axis) const {
+    return axis == Axis::Vertical ? height : width;
+  }
+  [[nodiscard]] int crossLen(Axis axis) const {
+    return axis == Axis::Vertical ? width : height;
+  }
+  /// Source pixels each downsampled unit along `axis` represents: 1 on the
+  /// motion axis (kept at source resolution so recovered deltas, and so the
+  /// seams, are exact), kDownsampleCross on the cross axis.
+  [[nodiscard]] int sourceScale(Axis axis) const;
+  /// Sub-view spanning [start, end) along `axis`, cross axis untouched.
+  [[nodiscard]] GrayView cropAxis(Axis axis, int start, int end) const;
+};
+
+/// Grayscale downsample of `image` for motion along `axis`
+/// (Rec.601-ish luma: (r*77 + g*150 + b*29) >> 8).
+[[nodiscard]] GrayView downsampleToGray(const QImage &image, Axis axis);
+
+/// Classify signed motion between two downsampled frames.
+[[nodiscard]] MotionEstimate classifyMotion(const GrayView &prev,
+                                            const GrayView &cur, Axis axis);
+/// Like classifyMotion but caps the search at `maxSourceDelta` source pixels.
+[[nodiscard]] MotionEstimate classifyMotionBounded(const GrayView &prev,
+                                                   const GrayView &cur,
+                                                   Axis axis, int maxSourceDelta);
+
+// --- Correlation core (exposed for the smoke's bit-exact scoring check) -----
+/// Mean absolute grayscale error for aligning `cur` onto `prev` at `shift`
+/// along `axis`, sampling every `axisStep`/`crossStep` pixel over a fixed
+/// window `axisLen - maxShift`. +inf on any geometry guard.
+[[nodiscard]] double scoreShift(const GrayView &prev, const GrayView &cur,
+                                Axis axis, long shift, int maxShift,
+                                int axisStep, int crossStep);
+/// Naive per-pixel reference for scoreShift (smoke oracle only).
+[[nodiscard]] double scoreShiftReference(const GrayView &prev,
+                                         const GrayView &cur, Axis axis,
+                                         long shift, int maxShift, int axisStep,
+                                         int crossStep);
+/// Leading/trailing edge counts unchanged at shift 0 (viewport-fixed chrome),
+/// each capped at axisLen/kMaxStationaryScoringEdgeDen.
+struct StationaryEdges {
+  int lead = 0;
+  int trail = 0;
+};
+[[nodiscard]] StationaryEdges stationaryScoringEdges(const GrayView &prev,
+                                                     const GrayView &cur,
+                                                     Axis axis);
+
+// --- Forward lookahead (auto-scroll alignment verification) -----------------
+/// One forward-only alignment candidate retained for lookahead resolution.
+/// Deltas are source pixels; error is mean absolute grayscale error.
+struct ForwardMatchCandidate {
+  int delta = 0;
+  double error = 0.0;
+  bool operator==(const ForwardMatchCandidate &) const = default;
+};
+/// Two adjacent forward deltas supported by a three-frame alignment path.
+struct ForwardMatchPath {
+  int firstDelta = 0;
+  int secondDelta = 0;
+  double totalError = 0.0;
+  bool operator==(const ForwardMatchPath &) const = default;
+};
+/// The distinct forward correlation basins of one frame pair, best first.
+struct ForwardCandidateSet {
+  std::vector<ForwardMatchCandidate> candidates;
+  bool truncated = false;
+  /// Largest source-pixel delta whose fixed comparison extent was searched;
+  /// empty means the frame geometry itself was not searchable.
+  std::optional<int> searchMaxDelta;
+};
+/// What the known-forward matcher can establish about F0→F1 when a probe is
+/// stationary relative to F1: a unique non-truncated basin is safe to commit
+/// automatically; Ambiguous preserves a best-effort candidate for an explicit
+/// user choice.
+struct StationaryProbeFirstMatch {
+  enum class Tag { Unique, Ambiguous };
+  Tag tag = Tag::Ambiguous;
+  std::optional<ForwardMatchCandidate> candidate; // Unique: the basin;
+                                                  // Ambiguous: best effort
+  bool operator==(const StationaryProbeFirstMatch &) const = default;
+};
+/// Result of resolving an ambiguous forward pair with one lookahead frame.
+struct ForwardLookaheadResolution {
+  enum class Tag {
+    Resolved,        ///< all three comparisons agree on a distinct path
+    LowErrorPeriodic,///< accepted using the auto worker's known direction
+    StationaryProbe, ///< the probe did not move relative to the pending frame
+    Unresolved,      ///< only an explicit "continue anyway" may use bestEffort
+  };
+  Tag tag = Tag::Unresolved;
+  std::optional<ForwardMatchPath> path;       // Resolved / LowErrorPeriodic /
+                                              // Unresolved best-effort
+  std::optional<StationaryProbeFirstMatch> firstMatch; // StationaryProbe
+};
+/// A pending forward alignment: the ambiguous pair's frames plus its retained
+/// candidates, immutable while a lookahead frame resolves it.
+class ForwardLookahead {
+public:
+  ForwardLookahead(GrayView origin, GrayView pending, Axis axis,
+                   ForwardCandidateSet first, MotionEstimate estimate)
+      : origin_(std::move(origin)), pending_(std::move(pending)), axis_(axis),
+        first_(std::move(first)), estimate_(estimate) {}
+  [[nodiscard]] MotionEstimate estimate() const { return estimate_; }
+  [[nodiscard]] const std::vector<ForwardMatchCandidate> &candidates() const {
+    return first_.candidates;
+  }
+  /// The only retained candidate no larger than a trusted physical bound
+  /// (e.g. a previously observed full auto step); never narrows a truncated
+  /// search.
+  [[nodiscard]] std::optional<ForwardMatchCandidate>
+  uniqueCandidateAtMost(int maxSourceDelta) const;
+  /// Strict three-frame resolution (no physical-motion prior).
+  [[nodiscard]] ForwardLookaheadResolution resolve(const GrayView &lookahead) const;
+  /// Known-forward automatic resolution: additionally accepts matcher-grade
+  /// periodic paths using the worker's known direction (cadence only breaks
+  /// ties).
+  [[nodiscard]] ForwardLookaheadResolution resolveAuto(const GrayView &lookahead) const;
+
+private:
+  [[nodiscard]] ForwardLookaheadResolution
+  resolveWithPhysicalPrior(const GrayView &lookahead, bool allowPhysicalPrior) const;
+
+  GrayView origin_;
+  GrayView pending_;
+  Axis axis_;
+  ForwardCandidateSet first_;
+  MotionEstimate estimate_;
+};
+/// Result of the first automatic-scroll comparison.
+struct ForwardMatch {
+  enum class Tag { Classified, Ambiguous };
+  Tag tag = Tag::Classified;
+  MotionEstimate classified;                 // Tag::Classified
+  std::optional<ForwardLookahead> ambiguous; // Tag::Ambiguous
+};
+/// All distinct forward basins of the pair (positive shifts only).
+[[nodiscard]] ForwardCandidateSet
+forwardCandidateSet(const GrayView &prev, const GrayView &cur, Axis axis);
+/// Classify the pair; an ambiguous-but-matcher-grade result carries the
+/// frames needed to resolve it against one lookahead frame.
+[[nodiscard]] ForwardMatch classifyForwardWithLookahead(const GrayView &prev,
+                                                        const GrayView &cur,
+                                                        Axis axis);
+/// Resolve three candidate sets into a path (exposed for the smoke's
+/// literal-set checks).
+[[nodiscard]] ForwardLookaheadResolution
+resolveForwardCandidateSets(const ForwardCandidateSet &first,
+                            const ForwardCandidateSet &second,
+                            const ForwardCandidateSet &cumulative,
+                            bool allowPhysicalPrior);
+
+// --- Accumulator (pixel assembly) ------------------------------------------
+/// Assembles overlapping forward frames into one tall/wide image. A trailing
+/// stationary strip (window borders, fixed footers) plus a near-stationary
+/// zone (footer drop shadows) is excluded from every incremental slice and
+/// copied once from the final frame. Frames must be RGBA (Format_RGBA8888).
+class StitchAccumulator {
+public:
+  /// Begins a capture from its first frame. `ok` is set false and `error`
+  /// filled on an invalid frame.
+  StitchAccumulator(const QImage &first, Axis axis, bool &ok, QString &error);
+  /// Retains one validated forward frame; `delta` is source pixels along the
+  /// axis. Returns false with `error` set on failure (state unchanged).
+  [[nodiscard]] bool pushForward(const QImage &frame, int delta, QString &error);
+  /// Retain one reverse (scrolled-up/left) frame while keeping the final image
+  /// in document order. Cannot be mixed with pushForward.
+  [[nodiscard]] bool pushReverse(const QImage &frame, int delta, QString &error);
+  /// Assembles the final image; returns a null QImage with `error` set on
+  /// failure. Consumes the accumulator's buffers.
+  [[nodiscard]] QImage finish(QString &error);
+  [[nodiscard]] int frameCount() const { return static_cast<int>(bands_.size()) + 1; }
+  /// Whether growing by `delta` along the motion axis would pass the budget.
+  [[nodiscard]] bool wouldExceedBudget(int delta) const;
+  /// Whether the finished image would be longer than most other software will
+  /// open. Advisory only; see kWidelyOpenableEdge.
+  [[nodiscard]] bool exceedsWidelyOpenableEdge() const;
+  // Test accessors.
+  [[nodiscard]] long retainedRgbaBytes() const;
+  [[nodiscard]] int stationaryTrailingStripForTest() const {
+    return stationaryTrailingStrip();
+  }
+  [[nodiscard]] int nearStationaryTrailingZoneForTest() const {
+    return nearStationaryTrailingZone(stationaryTrailingStrip());
+  }
+
+private:
+  struct TailBand {
+    int delta = 0;
+    int sourceAxisStart = 0;
+    std::vector<std::uint8_t> rgba; // tight RGBA
+  };
+  [[nodiscard]] int stationaryTrailingStrip() const;
+  [[nodiscard]] int nearStationaryTrailingZone(int strip) const;
+  [[nodiscard]] bool pushOriented(const QImage &frame, int delta, QString &error);
+
+  enum class Direction { None, Forward, Reverse };
+  Direction direction_ = Direction::None;
+
+  Axis axis_;
+  bool valid_ = false;
+  int width_ = 0, height_ = 0, axisLen_ = 0, crossLen_ = 0, maxEdge_ = 0;
+  std::vector<std::uint8_t> firstRgba_;
+  std::vector<TailBand> bands_;
+  int totalDelta_ = 0;
+  std::vector<std::uint64_t> edgeSums_, edgeCounts_, alignedSums_, alignedCounts_;
+};
+
+// --- Live manual capture session ------------------------------------------------
+/// The decision loop of a manual scroll capture, independent of any window or
+/// compositor: feed it the cropped region from each grab and it classifies the
+/// motion against the last committed frame and grows the stitch. In manual
+/// mode small movements are held as one replaceable pending frame until they
+/// grow past a threshold (or finish), ambiguous small motion
+/// on repeated content is recovered with a bounded re-search, the direction
+/// locks once a band is committed, a frame that cannot be aligned keeps the
+/// last verified reference (a later overlapping frame resumes), and, only
+/// while nothing has been committed, a page that is at rest but no longer
+/// matches the first frame (an autoplaying video, hover UI) re-seeds it.
+class ManualCapture {
+public:
+  enum class Event {
+    Blank,          ///< solid-colour first frame; not seeded (copy raced the overlay)
+    Seeded,         ///< first frame accepted
+    Kept,           ///< a band was committed
+    Pending,        ///< small movement held as the pending frame
+    Still,          ///< no movement
+    PendingDropped, ///< a pending movement was reversed
+    ReSeeded,       ///< first frame replaced (content changed in place, nothing committed)
+    Ambiguous,      ///< repeated content; keep scrolling
+    Unmatchable,    ///< no reliable overlap with the reference; keep it and warn
+    WrongDirection, ///< motion against the locked direction after a band exists
+    Error,          ///< accumulator refused the frame (see `error`)
+    Full,           ///< the capture reached its size budget; finish it
+  };
+  struct Outcome {
+    Event event = Event::Still;
+    MotionEstimate estimate;
+    int keptFrames = 0;
+    int pendingDelta = 0;
+    QString error;
+  };
+  explicit ManualCapture(Axis axis);
+  /// Consume one cropped grab (RGBA8888 or convertible).
+  [[nodiscard]] Outcome feed(const QImage &cropped);
+  /// Commit any pending frame and assemble the result (null + `error` on
+  /// failure; the session stays usable).
+  [[nodiscard]] QImage finish(QString &error);
+  [[nodiscard]] bool started() const { return accumulator_.has_value(); }
+  [[nodiscard]] int keptFrames() const { return kept_; }
+  /// Whether the capture is already longer than most other software will
+  /// open. Advisory: capture continues and the result edits normally.
+  [[nodiscard]] bool exceedsWidelyOpenableEdge() const {
+    return accumulator_ && accumulator_->exceedsWidelyOpenableEdge();
+  }
+  [[nodiscard]] Axis axis() const { return axis_; }
+  /// Small movements below this are held back (axisLen/8, clamped 16..128).
+  [[nodiscard]] static int coalesceThreshold(int axisLen);
+  /// Bounded re-search radius for ambiguous manual motion (axisLen/8,
+  /// clamped 128..512).
+  [[nodiscard]] static int manualSearchBound(int axisLen);
+
+private:
+  enum class Direction { None, Forward, Reverse };
+  struct PendingFrame {
+    QImage frame;
+    int delta = 0;
+    Direction direction = Direction::None;
+  };
+  Outcome recordMotion(const QImage &cropped, const GrayView &gray,
+                       Direction direction, int delta,
+                       const MotionEstimate &estimate);
+  Outcome outcome(Event event, const MotionEstimate &estimate = {},
+                  QString error = {}) const;
+
+  Axis axis_;
+  std::optional<StitchAccumulator> accumulator_;
+  GrayView lastGray_;     // last committed frame
+  GrayView previousGray_; // previous grab, kept or not
+  bool havePrevious_ = false;
+  std::optional<PendingFrame> pending_;
+  Direction direction_ = Direction::None;
+  int blankFirstFrames_ = 0;
+  int kept_ = 0;
+};
+
+/// Stitch already-validated forward frames using the measured per-pair delta
+/// (deltas.size() must equal frames.size()-1).
+[[nodiscard]] QImage stitchWithDeltas(const QVector<QImage> &frames,
+                                      const QVector<int> &deltas, Axis axis,
+                                      QString &error);
+
+} // namespace stitch

--- a/src/stitch.hpp
+++ b/src/stitch.hpp
@@ -309,7 +309,7 @@ private:
 class ManualCapture {
 public:
   enum class Event {
-    Blank,          ///< solid-colour first frame; not seeded (copy raced the overlay)
+    Blank,          ///< solid-color first frame; not seeded (copy raced the overlay)
     Seeded,         ///< first frame accepted
     Kept,           ///< a band was committed
     Pending,        ///< small movement held as the pending frame

--- a/src/surface-capture.cpp
+++ b/src/surface-capture.cpp
@@ -23,7 +23,9 @@
 #include <unistd.h>
 #include <vector>
 
-namespace {
+// Named (not anonymous) so OutputCapture::State can derive from it without
+// giving an exported type internal-linkage members.
+namespace capture_detail {
 struct OutputInfo {
   wl_output *output = nullptr;
   std::string name;
@@ -45,11 +47,23 @@ struct CaptureState {
   uint32_t width = 0;
   uint32_t height = 0;
   uint32_t format = 0;
+  /// Geometry/format the current shm buffer was actually created with. The
+  /// session can re-announce width/height/formats at any dispatch (mode or
+  /// scale change), even in the same batch as a frame's ready event, so
+  /// everything that touches the mapped buffer must use these, not the live
+  /// session values above.
+  uint32_t bufferWidth = 0;
+  uint32_t bufferHeight = 0;
+  uint32_t bufferFormat = 0;
   uint32_t transform = WL_OUTPUT_TRANSFORM_NORMAL;
   bool constraintsDone = false;
+  /// Set when the session re-announces its constraints (buffer_size after the
+  /// first done); the next frame needs a fresh buffer.
+  bool constraintsChanged = false;
   bool stopped = false;
   bool frameDone = false;
   bool frameReady = false;
+  uint32_t failureReason = 0;
   int fd = -1;
   void *memory = MAP_FAILED;
   std::size_t memorySize = 0;
@@ -139,12 +153,22 @@ constexpr wl_registry_listener kRegistryListener{registryGlobal,
 void sessionBufferSize(void *data, ext_image_copy_capture_session_v1 *,
                        uint32_t width, uint32_t height) {
   auto &state = *static_cast<CaptureState *>(data);
+  if (state.constraintsDone &&
+      (width != state.width || height != state.height)) {
+    state.constraintsChanged = true;
+    // A re-announcement replaces the constraint set; drop the old formats so
+    // the rebuild chooses from the current ones.
+    state.shmFormats.clear();
+  }
   state.width = width;
   state.height = height;
 }
 void sessionShmFormat(void *data, ext_image_copy_capture_session_v1 *,
                       uint32_t format) {
-  static_cast<CaptureState *>(data)->shmFormats.push_back(format);
+  auto &state = *static_cast<CaptureState *>(data);
+  if (state.constraintsDone)
+    state.constraintsChanged = true;
+  state.shmFormats.push_back(format);
 }
 void sessionDmabufDevice(void *, ext_image_copy_capture_session_v1 *,
                          wl_array *) {}
@@ -176,8 +200,11 @@ void frameReady(void *data, ext_image_copy_capture_frame_v1 *) {
   state.frameReady = true;
   state.frameDone = true;
 }
-void frameFailed(void *data, ext_image_copy_capture_frame_v1 *, uint32_t) {
-  static_cast<CaptureState *>(data)->frameDone = true;
+void frameFailed(void *data, ext_image_copy_capture_frame_v1 *,
+                 uint32_t reason) {
+  auto &state = *static_cast<CaptureState *>(data);
+  state.failureReason = reason;
+  state.frameDone = true;
 }
 constexpr ext_image_copy_capture_frame_v1_listener kFrameListener{
     frameTransform, frameDamage, framePresentation, frameReady, frameFailed};
@@ -250,8 +277,12 @@ bool createShmBuffer(CaptureState &state, QString &error) {
     return false;
   }
 
-  const std::size_t stride = static_cast<std::size_t>(state.width) * 4;
-  state.memorySize = stride * state.height;
+  state.bufferWidth = state.width;
+  state.bufferHeight = state.height;
+  state.bufferFormat = state.format;
+
+  const std::size_t stride = static_cast<std::size_t>(state.bufferWidth) * 4;
+  state.memorySize = stride * state.bufferHeight;
   if (state.memorySize >
       static_cast<std::size_t>(std::numeric_limits<int32_t>::max())) {
     error = QStringLiteral("Surface capture buffer is too large");
@@ -285,9 +316,9 @@ bool createShmBuffer(CaptureState &state, QString &error) {
     return false;
   }
   state.buffer = wl_shm_pool_create_buffer(
-      state.pool, 0, static_cast<int32_t>(state.width),
-      static_cast<int32_t>(state.height), static_cast<int32_t>(stride),
-      state.format);
+      state.pool, 0, static_cast<int32_t>(state.bufferWidth),
+      static_cast<int32_t>(state.bufferHeight), static_cast<int32_t>(stride),
+      state.bufferFormat);
   if (!state.buffer) {
     error = QStringLiteral("Could not create Wayland surface capture buffer");
     return false;
@@ -295,9 +326,50 @@ bool createShmBuffer(CaptureState &state, QString &error) {
   return true;
 }
 
+/** Releases the shm buffer so createShmBuffer() can size a new one. */
+void destroyShmBuffer(CaptureState &state) {
+  if (state.buffer)
+    wl_buffer_destroy(state.buffer);
+  if (state.pool)
+    wl_shm_pool_destroy(state.pool);
+  if (state.memory != MAP_FAILED)
+    munmap(state.memory, state.memorySize);
+  if (state.fd >= 0)
+    close(state.fd);
+  state.buffer = nullptr;
+  state.pool = nullptr;
+  state.memory = MAP_FAILED;
+  state.memorySize = 0;
+  state.fd = -1;
+}
+
+/** Captures one frame from the open session into the shm buffer. */
+bool captureFrame(CaptureState &state, QString &error, int timeoutMs) {
+  if (!state.buffer) {
+    error = QStringLiteral("No capture buffer is available");
+    return false;
+  }
+  state.frameDone = false;
+  state.frameReady = false;
+  state.failureReason = 0;
+  state.transform = WL_OUTPUT_TRANSFORM_NORMAL;
+  state.frame = ext_image_copy_capture_session_v1_create_frame(state.session);
+  ext_image_copy_capture_frame_v1_add_listener(state.frame, &kFrameListener,
+                                               &state);
+  ext_image_copy_capture_frame_v1_attach_buffer(state.frame, state.buffer);
+  ext_image_copy_capture_frame_v1_damage_buffer(
+      state.frame, 0, 0, static_cast<int32_t>(state.bufferWidth),
+      static_cast<int32_t>(state.bufferHeight));
+  ext_image_copy_capture_frame_v1_capture(state.frame);
+  const bool done = dispatchUntil(state, &state.frameDone, timeoutMs, error);
+  ext_image_copy_capture_frame_v1_destroy(state.frame);
+  state.frame = nullptr;
+  return done && state.frameReady;
+}
+
 QImage copyCapturedImage(const CaptureState &state) {
   QImage::Format imageFormat = QImage::Format_Invalid;
-  switch (state.format) {
+  switch (state.bufferFormat) {
   case WL_SHM_FORMAT_ARGB8888:
     imageFormat = QImage::Format_ARGB32_Premultiplied;
     break;
@@ -313,13 +385,15 @@ QImage copyCapturedImage(const CaptureState &state) {
   default:
     return {};
   }
-  const int stride = static_cast<int>(state.width * 4);
+  const int stride = static_cast<int>(state.bufferWidth * 4);
   return QImage(static_cast<uchar *>(state.memory),
-                static_cast<int>(state.width), static_cast<int>(state.height),
-                stride, imageFormat)
+                static_cast<int>(state.bufferWidth),
+                static_cast<int>(state.bufferHeight), stride, imageFormat)
       .copy();
 }
-} // namespace
+} // namespace capture_detail
+
+using namespace capture_detail;
 
 QImage normalizeWaylandCapture(const QImage &image, std::uint32_t transform) {
   const auto rotated = [&image](qreal degrees) {
@@ -350,11 +424,11 @@ QImage normalizeWaylandCapture(const QImage &image, std::uint32_t transform) {
   }
 }
 
-static bool captureCurrentSource(CaptureState &state, QImage &image, QString &error,
-                          const QString &stoppedError,
-                          const QString &failedError,
-                          const QString &decodeError,
-                          const QString &transformError) {
+/** Opens the copy-capture session on `state.source` and sizes its buffer.
+ *  Frames are captured without the cursor: scroll-capture frames are
+ *  stitched, and a painted cursor would become a moving artefact. */
+static bool openCaptureSession(CaptureState &state, QString &error,
+                               const QString &stoppedError) {
   state.session = ext_image_copy_capture_manager_v1_create_session(
       state.captureManager, state.source, 0);
   ext_image_copy_capture_session_v1_add_listener(state.session,
@@ -365,20 +439,20 @@ static bool captureCurrentSource(CaptureState &state, QImage &image, QString &er
     error = stoppedError;
     return false;
   }
-  if (!createShmBuffer(state, error))
-    return false;
+  return createShmBuffer(state, error);
+}
 
-  state.frame = ext_image_copy_capture_session_v1_create_frame(state.session);
-  ext_image_copy_capture_frame_v1_add_listener(state.frame, &kFrameListener,
-                                               &state);
-  ext_image_copy_capture_frame_v1_attach_buffer(state.frame, state.buffer);
-  ext_image_copy_capture_frame_v1_damage_buffer(
-      state.frame, 0, 0, static_cast<int32_t>(state.width),
-      static_cast<int32_t>(state.height));
-  ext_image_copy_capture_frame_v1_capture(state.frame);
-  if (!dispatchUntil(state, &state.frameDone, 2000, error) ||
-      !state.frameReady) {
-    if (error.isEmpty())
+static bool captureCurrentSource(CaptureState &state, QImage &image, QString &error,
+                          const QString &stoppedError,
+                          const QString &failedError,
+                          const QString &decodeError,
+                          const QString &transformError) {
+  if (!openCaptureSession(state, error, stoppedError))
+    return false;
+  if (!captureFrame(state, error, 2000)) {
+    if (state.stopped)
+      error = stoppedError;
+    else if (error.isEmpty())
       error = failedError;
     return false;
   }
@@ -395,14 +469,8 @@ static bool captureCurrentSource(CaptureState &state, QImage &image, QString &er
   return true;
 }
 
-bool captureOutputSurface(const MonitorInfo &monitor, QImage &image,
-                          QString &error) {
-  if (monitor.name.isEmpty()) {
-    error = QStringLiteral("Focused monitor has no output name");
-    return false;
-  }
-
-  CaptureState state;
+/** Connects to the display and binds the output-capture globals. */
+static bool connectOutputCaptureDisplay(CaptureState &state, QString &error) {
   state.display = wl_display_connect(nullptr);
   if (!state.display) {
     error = QStringLiteral("Could not connect to Wayland for output capture");
@@ -420,6 +488,19 @@ bool captureOutputSurface(const MonitorInfo &monitor, QImage &image,
         "Compositor does not expose ext-image-copy-capture output capture");
     return false;
   }
+  return true;
+}
+
+bool captureOutputSurface(const MonitorInfo &monitor, QImage &image,
+                          QString &error) {
+  if (monitor.name.isEmpty()) {
+    error = QStringLiteral("Focused monitor has no output name");
+    return false;
+  }
+
+  CaptureState state;
+  if (!connectOutputCaptureDisplay(state, error))
+    return false;
 
   const auto match =
       std::ranges::find_if(state.outputs, [&](const auto &output) {
@@ -440,3 +521,100 @@ bool captureOutputSurface(const MonitorInfo &monitor, QImage &image,
       QStringLiteral("Could not decode native output capture"),
       QStringLiteral("Unsupported transform in native output capture"));
 }
+
+struct OutputCapture::State : capture_detail::CaptureState {};
+
+OutputCapture::OutputCapture() = default;
+OutputCapture::~OutputCapture() = default;
+
+bool OutputCapture::open(const QString &outputName, QString &error) {
+  close();
+  auto state = std::make_unique<State>();
+  if (!connectOutputCaptureDisplay(*state, error))
+    return false;
+  const std::string wanted = outputName.toStdString();
+  const auto match =
+      std::ranges::find_if(state->outputs, [&](const auto &output) {
+        return output->name == wanted;
+      });
+  if (match == state->outputs.end()) {
+    error = QStringLiteral("Output %1 is not available for native capture")
+                .arg(outputName);
+    return false;
+  }
+  state->source = ext_output_image_capture_source_manager_v1_create_source(
+      state->outputSourceManager, (*match)->output);
+  if (!openCaptureSession(
+          *state, error,
+          QStringLiteral("Compositor stopped native output capture")))
+    return false;
+  state_ = std::move(state);
+  return true;
+}
+
+bool OutputCapture::grab(QImage &image, QString &error, int timeoutMs) {
+  if (!state_) {
+    error = QStringLiteral("Output capture is not open");
+    return false;
+  }
+  State &state = *state_;
+  // The buffer is reused frame after frame; only a constraint change (mode or
+  // format switch, announced by the session or reported by a failed frame)
+  // sizes a new one.
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    if (state.constraintsChanged) {
+      state.constraintsChanged = false;
+      destroyShmBuffer(state);
+      if (!createShmBuffer(state, error)) {
+        // The next grab must retry the rebuild; without this it would attach
+        // a null buffer.
+        state.constraintsChanged = true;
+        return false;
+      }
+    }
+    if (captureFrame(state, error, timeoutMs))
+      break;
+    if (state.stopped) {
+      error = QStringLiteral("Compositor stopped native output capture");
+      return false;
+    }
+    if (state.failureReason ==
+            EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS &&
+        attempt == 0) {
+      state.constraintsChanged = true;
+      continue;
+    }
+    if (error.isEmpty())
+      error = QStringLiteral("Compositor could not capture the output");
+    return false;
+  }
+  if (!state.frameReady) {
+    if (error.isEmpty())
+      error = QStringLiteral("Compositor could not capture the output");
+    return false;
+  }
+  const QImage captured = copyCapturedImage(state);
+  if (captured.isNull()) {
+    error = QStringLiteral("Could not decode native output capture");
+    return false;
+  }
+  image = normalizeWaylandCapture(captured, state.transform);
+  if (image.isNull()) {
+    error = QStringLiteral("Unsupported transform in native output capture");
+    return false;
+  }
+  return true;
+}
+
+bool OutputCapture::isOpen() const { return state_ != nullptr; }
+
+bool OutputCapture::sessionStopped() const { return state_ && state_->stopped; }
+
+QSize OutputCapture::bufferSize() const {
+  if (!state_)
+    return {};
+  return {static_cast<int>(state_->bufferWidth),
+          static_cast<int>(state_->bufferHeight)};
+}
+
+void OutputCapture::close() { state_.reset(); }

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -9,6 +9,7 @@
 #include "palette-config-smoke.hpp"
 #include "pin-layout-smoke.hpp"
 #include "stitch-smoke.hpp"
+#include "stitch.hpp"
 #include "pin-lifecycle-smoke.hpp"
 #include "transform-smoke.hpp"
 #include "eyedropper.hpp"
@@ -4852,6 +4853,30 @@ int main(int argc, char **argv) {
           << QStringLiteral("A horizontal notch stepped only one way: up=") +
                  up + QStringLiteral(" down=") + down;
       return 116;
+    }
+    editor.close();
+  }
+  {
+    // A capture past the advisory edge still opens and edits; the only
+    // difference is that it says so.
+    CaptureData tall;
+    tall.monitor.name = QStringLiteral("TEST");
+    tall.monitor.scale = 1.0;
+    tall.monitor.pixelSize = {8, stitch::kWidelyOpenableEdge + 2};
+    tall.source = QImage(8, stitch::kWidelyOpenableEdge + 2,
+                         QImage::Format_ARGB32_Premultiplied);
+    tall.source.fill(QColor(QStringLiteral("#203040")));
+    tall.previewSize = tall.source.size();
+    CaptureEditor editor(std::move(tall), CaptureEditor::CaptureMode::File);
+    editor.resize(400, 300);
+    editor.show();
+    application.processEvents();
+    if (!editor.statusForTest().contains(QStringLiteral("Very long capture")) ||
+        !editor.statusForTest().contains(QStringLiteral("edits and saves"))) {
+      qWarning().noquote()
+          << QStringLiteral("Oversized capture did not explain itself: ")
+          << editor.statusForTest();
+      return 112;
     }
     editor.close();
   }

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4711,6 +4711,47 @@ int main(int argc, char **argv) {
   QApplication application(argc, argv);
   if (!loadCaptureFonts())
     return 17;
+
+  // Live output capture against a real compositor (the smoke's own Wayland
+  // connection; Qt's platform does not matter): open a session on the named
+  // output and grab several frames through the same buffer, timing them,
+  // since scroll capture needs many per second.
+  const QString liveOutputName = qEnvironmentVariable("OMASNAP_SMOKE_OUTPUT");
+  if (!liveOutputName.isEmpty()) {
+    OutputCapture output;
+    QString outputError;
+    if (!output.open(liveOutputName, outputError)) {
+      qWarning().noquote() << outputError;
+      return 105;
+    }
+    QImage frame;
+    QElapsedTimer stopwatch;
+    for (int index = 0; index < 5; ++index) {
+      stopwatch.start();
+      if (!output.grab(frame, outputError)) {
+        qWarning().noquote() << outputError;
+        return 105;
+      }
+      if (frame.isNull() || frame.size() != output.bufferSize()) {
+        qWarning().noquote() << QStringLiteral(
+            "Output frame size does not match the announced buffer");
+        return 105;
+      }
+      qInfo().noquote() << QStringLiteral("output %1 frame %2: %3x%4 in %5 ms")
+                               .arg(liveOutputName)
+                               .arg(index + 1)
+                               .arg(frame.width())
+                               .arg(frame.height())
+                               .arg(stopwatch.elapsed());
+    }
+    const QString liveRoot =
+        argc > 1 ? QString::fromLocal8Bit(argv[1])
+                 : QDir(QDir::tempPath())
+                       .filePath(QStringLiteral("omasnap-native-smoke"));
+    if (!frame.save(liveRoot + QStringLiteral("-native-output.png"), "PNG"))
+      return 105;
+    return 0;
+  }
   QString snapshotError;
   if (!runPositionalImageTargetCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -8,6 +8,7 @@
 #include "instance-lock-smoke.hpp"
 #include "palette-config-smoke.hpp"
 #include "pin-layout-smoke.hpp"
+#include "stitch-smoke.hpp"
 #include "pin-lifecycle-smoke.hpp"
 #include "transform-smoke.hpp"
 #include "eyedropper.hpp"
@@ -5022,6 +5023,10 @@ int main(int argc, char **argv) {
       return 115;
     }
     editor.close();
+  }
+  if (!runStitchChecks()) {
+    qWarning().noquote() << QStringLiteral("Stitcher checks failed");
+    return 104;
   }
   if (!runSpotlightWheelSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/tests/stitch-smoke.cpp
+++ b/tests/stitch-smoke.cpp
@@ -1,0 +1,783 @@
+/** @fileoverview Unit checks for the pure scroll-capture stitcher. Synthetic
+ *  frames with known deltas exercise the classifier and accumulator; replaying
+ *  real captured frames is what the stitch-replay tool is for. */
+#include "stitch-smoke.hpp"
+#include "auto-capture.hpp"
+#include "stitch.hpp"
+
+#include <QImage>
+#include <QPainter>
+
+#include <cmath>
+#include <utility>
+#include <cstring>
+#include <atomic>
+#include <initializer_list>
+#include <QDebug>
+#include <cstdint>
+
+using namespace stitch;
+
+namespace {
+// A deterministic textured strip so shifts have something to correlate.
+QImage makeTexture(int width, int height) {
+  QImage image(width, height, QImage::Format_ARGB32);
+  image.fill(Qt::white);
+  for (int y = 0; y < height; ++y) {
+    QRgb *row = reinterpret_cast<QRgb *>(image.scanLine(y));
+    // Aperiodic along both axes so a shift has a unique correlation peak.
+    const std::uint32_t rowHash = static_cast<std::uint32_t>(y) * 2654435761u;
+    for (int x = 0; x < width; ++x) {
+      const std::uint32_t h =
+          (static_cast<std::uint32_t>(x) * 40503u) ^ rowHash ^ (rowHash >> 15);
+      const int v = static_cast<int>(h >> 24) & 0xff;
+      row[x] = qRgb(v, (v * 3) & 0xff, (v * 7) & 0xff);
+    }
+  }
+  return image;
+}
+} // namespace
+
+
+namespace {
+// Synthetic fixtures for the lookahead resolver's ambiguous cases.
+GrayView exactlyPeriodicGray(int documentY) {
+  constexpr int kWidth = 96, kHeight = 360, kPeriod = 72;
+  GrayView view;
+  view.width = kWidth;
+  view.height = kHeight;
+  view.sourceWidth = kWidth;
+  view.pixels.reserve(static_cast<std::size_t>(kWidth) * kHeight);
+  for (int screenY = 0; screenY < kHeight; ++screenY) {
+    const std::uint64_t row = static_cast<std::uint64_t>((documentY + screenY) % kPeriod);
+    for (int x = 0; x < kWidth; ++x) {
+      std::uint64_t value = row * 0x9E3779B1ull + static_cast<std::uint64_t>(x) * 0x85EBCA77ull;
+      value ^= value >> 17;
+      view.pixels.push_back(static_cast<std::uint8_t>(24 + value % 210));
+    }
+  }
+  return view;
+}
+
+GrayView periodicTerminalGray(int documentY) {
+  constexpr int kWidth = 96, kHeight = 360, kBlockHeight = 144, kBackgroundPeriod = 48;
+  GrayView view;
+  view.width = kWidth;
+  view.height = kHeight;
+  view.sourceWidth = kWidth;
+  view.pixels.reserve(static_cast<std::size_t>(kWidth) * kHeight);
+  for (int screenY = 0; screenY < kHeight; ++screenY) {
+    const int docY = documentY + screenY;
+    const int block = docY / kBlockHeight;
+    const int inBlock = docY % kBlockHeight;
+    const int line = inBlock / 12;
+    const bool glyphRow = inBlock % 12 >= 2 && inBlock % 12 < 7;
+    for (int x = 0; x < kWidth; ++x) {
+      const int backgroundPhase = (screenY / 6 + x / 12) % (kBackgroundPeriod / 12);
+      std::uint8_t value = static_cast<std::uint8_t>(20 + backgroundPhase);
+      const int glyphStart = 8 + (line * 7) % 28;
+      const int glyphEnd = std::min(glyphStart + 28 + (line * 5) % 34, kWidth - 8);
+      if (glyphRow && x >= glyphStart && x < glyphEnd && (x + line) % 5 != 0)
+        value = static_cast<std::uint8_t>(150 + (line % 6) * 8);
+      if (inBlock >= 4 && inBlock < 8 && x >= 12 && x < 36)
+        value = static_cast<std::uint8_t>(72 + (block % 4) * 5);
+      view.pixels.push_back(value);
+    }
+  }
+  return view;
+}
+
+GrayView periodicTerminalWithUniqueGray(int documentY) {
+  constexpr int kUniqueTop = 328, kUniqueBottom = 344;
+  GrayView view = periodicTerminalGray(documentY);
+  for (int screenY = 0; screenY < view.height; ++screenY) {
+    const int absoluteY = documentY + screenY;
+    if (absoluteY < kUniqueTop || absoluteY >= kUniqueBottom)
+      continue;
+    for (int x = 14; x < view.width - 10; ++x) {
+      const std::uint64_t value =
+          static_cast<std::uint64_t>(absoluteY) * 0x9E3779B1ull +
+          static_cast<std::uint64_t>(x) * 0x85EBCA77ull;
+      view.pixels[static_cast<std::size_t>(screenY) * view.width + x] =
+          static_cast<std::uint8_t>(48 + value % 190);
+    }
+  }
+  return view;
+}
+
+GrayView uniqueDocumentGray(int documentY) {
+  constexpr int kWidth = 96, kHeight = 360;
+  GrayView view;
+  view.width = kWidth;
+  view.height = kHeight;
+  view.sourceWidth = kWidth;
+  view.pixels.reserve(static_cast<std::size_t>(kWidth) * kHeight);
+  for (int screenY = 0; screenY < kHeight; ++screenY) {
+    const std::uint64_t absoluteY = static_cast<std::uint64_t>(documentY + screenY);
+    for (int x = 0; x < kWidth; ++x) {
+      std::uint64_t value = absoluteY * 0x9E3779B1ull + static_cast<std::uint64_t>(x) * 0x85EBCA77ull;
+      value ^= value >> 15;
+      value *= 0xC2B2AE3Dull;
+      view.pixels.push_back(static_cast<std::uint8_t>(16 + value % 220));
+    }
+  }
+  return view;
+}
+
+/// The lookahead resolver: the alignment verification auto-scroll depends on.
+bool runLookaheadChecks() {
+  using Tag = ForwardLookaheadResolution::Tag;
+  const auto literalSet = [](std::initializer_list<ForwardMatchCandidate> candidates,
+                             bool truncated, int searchMaxDelta) {
+    ForwardCandidateSet set;
+    set.candidates = candidates;
+    set.truncated = truncated;
+    set.searchMaxDelta = searchMaxDelta;
+    return set;
+  };
+
+  // A consistent cumulative candidate is required: matching adjacent seams
+  // whose sum disagrees with every cumulative basin stay unresolved (the
+  // best-effort path is preserved for an explicit user choice).
+  {
+    const ForwardLookaheadResolution resolution = resolveForwardCandidateSets(
+        literalSet({{54, 0.0}}, false, 100), literalSet({{18, 0.0}}, false, 100),
+        literalSet({{80, 0.0}}, false, 100), true);
+    if (resolution.tag != Tag::Unresolved || !resolution.path ||
+        !(*resolution.path == ForwardMatchPath{54, 18, 0.0}))
+      return false;
+  }
+  // A seam above the matcher-grade error ceiling poisons every path.
+  {
+    const double bad = kMaxMatchError + 0.01;
+    const ForwardLookaheadResolution resolution = resolveForwardCandidateSets(
+        literalSet({{54, 0.0}, {126, 0.0}}, false, 240),
+        literalSet({{18, bad}, {90, bad}}, false, 240),
+        literalSet({{72, 0.0}, {144, 0.0}, {216, 0.0}}, false, 240), true);
+    if (resolution.tag != Tag::Unresolved || !resolution.path)
+      return false;
+  }
+  // A truncated landscape cannot be Resolved, but a retained matcher-grade
+  // path is still accepted for known-forward auto capture (cadence prior).
+  {
+    const ForwardLookaheadResolution resolution = resolveForwardCandidateSets(
+        literalSet({{54, 0.0}, {126, 0.0}}, true, 240),
+        literalSet({{18, 0.0}, {90, 0.0}}, false, 240),
+        literalSet({{72, 0.0}, {144, 0.0}, {216, 0.0}}, false, 240), true);
+    if (resolution.tag != Tag::LowErrorPeriodic ||
+        !(*resolution.path == ForwardMatchPath{54, 18, 0.0}))
+      return false;
+  }
+  // Non-canonical cadence with matcher-grade errors is still accepted.
+  {
+    const ForwardLookaheadResolution resolution = resolveForwardCandidateSets(
+        literalSet({{420, 4.0}, {700, 4.2}}, true, 1200),
+        literalSet({{360, 5.0}, {640, 5.3}}, false, 1200),
+        literalSet({{780, 6.0}, {1060, 6.5}}, false, 1200), true);
+    if (resolution.tag != Tag::LowErrorPeriodic ||
+        !(*resolution.path == ForwardMatchPath{420, 360, 15.0}))
+      return false;
+  }
+
+  // A stationary probe never verifies a truncated candidate search.
+  {
+    const GrayView frame = uniqueDocumentGray(0);
+    const ForwardMatchCandidate candidate{60, 0.5};
+    ForwardCandidateSet first;
+    first.candidates = {candidate};
+    first.truncated = true;
+    first.searchMaxDelta = 240;
+    const ForwardLookahead pending(frame, frame, Axis::Vertical, first,
+                                   {{MotionKind::Ambiguous, 60}, 0.5, 1.0});
+    const ForwardLookaheadResolution resolution = pending.resolve(frame);
+    if (resolution.tag != Tag::StationaryProbe || !resolution.firstMatch ||
+        resolution.firstMatch->tag != StationaryProbeFirstMatch::Tag::Ambiguous ||
+        resolution.firstMatch->candidate != std::optional(candidate))
+      return false;
+  }
+
+  // Exactly periodic content: the strict resolver stays hint-free while the
+  // known-forward automatic resolver uses the 3:1 cadence.
+  {
+    const GrayView f0 = exactlyPeriodicGray(0);
+    const GrayView f1 = exactlyPeriodicGray(54);
+    const GrayView f2 = exactlyPeriodicGray(54 + 18);
+    const ForwardMatch match =
+        classifyForwardWithLookahead(f0, f1, Axis::Vertical);
+    if (match.tag != ForwardMatch::Tag::Ambiguous || !match.ambiguous)
+      return false;
+    const ForwardLookahead &pending = *match.ambiguous;
+    if (pending.candidates().size() < 2)
+      return false;
+    if (pending.resolve(f2).tag != Tag::Unresolved || !pending.resolve(f2).path)
+      return false;
+    const ForwardLookaheadResolution automatic = pending.resolveAuto(f2);
+    if (automatic.tag != Tag::LowErrorPeriodic ||
+        automatic.path->firstDelta != 54 || automatic.path->secondDelta != 18)
+      return false;
+    // A trusted physical bound isolates only the small repeated basin.
+    const std::optional<ForwardMatchCandidate> bounded =
+        pending.uniqueCandidateAtMost(60);
+    if (!bounded || bounded->delta != 54)
+      return false;
+    if (pending.uniqueCandidateAtMost(200))
+      return false; // 54 and 126 both qualify: not unique
+    // A probe that did not move reports a stationary probe, not a new band.
+    if (pending.resolve(f1).tag != Tag::StationaryProbe)
+      return false;
+  }
+
+  // Periodic terminal content with later unique evidence resolves strictly.
+  {
+    const GrayView f0 = periodicTerminalWithUniqueGray(0);
+    const GrayView f1 = periodicTerminalWithUniqueGray(18);
+    const GrayView f2 = periodicTerminalWithUniqueGray(18 + 182);
+    const ForwardMatch match =
+        classifyForwardWithLookahead(f0, f1, Axis::Vertical);
+    if (match.tag != ForwardMatch::Tag::Ambiguous || !match.ambiguous)
+      return false;
+    const ForwardLookahead &pending = *match.ambiguous;
+    if (std::none_of(pending.candidates().begin(), pending.candidates().end(),
+                     [](const ForwardMatchCandidate &c) { return c.delta == 18; }))
+      return false;
+    const ForwardLookaheadResolution resolution = pending.resolve(f2);
+    if (resolution.tag != Tag::Resolved || resolution.path->firstDelta != 18 ||
+        resolution.path->secondDelta != 182)
+      return false;
+  }
+  return true;
+}
+} // namespace
+
+
+namespace {
+/// The automatic capture machinery: calibration, handshake, the probe
+/// decision table, and full feed() sequences per state-machine row.
+bool runAutoCaptureChecks() {
+  using Ack = AutoCapture::Ack;
+  using Event = AutoCapture::Event;
+  using Kind = AutoProbeDecision::Kind;
+  using PauseReason = AutoProbeDecision::PauseReason;
+
+  // --- AutoStepCalibration --------------------------------------------------
+  {
+    AutoStepCalibration calibration;
+    if (calibration.endpointUpperBound())
+      return false; // < 3 samples
+    calibration.recordVerifiedNormalStep(230);
+    calibration.recordVerifiedNormalStep(0); // ignored
+    calibration.recordVerifiedNormalStep(231);
+    if (calibration.endpointUpperBound())
+      return false;
+    calibration.recordVerifiedNormalStep(232);
+    // median 231, jitter max(ceil(231*5%)=12, 4) = 12; bound = 232+12.
+    if (calibration.endpointUpperBound() != std::optional(244))
+      return false;
+    calibration.recordVerifiedNormalStep(231);
+    calibration.recordVerifiedNormalStep(232);
+    calibration.recordVerifiedNormalStep(231); // window slides to 5 samples
+    if (calibration.endpointUpperBound() != std::optional(244))
+      return false;
+  }
+  {
+    AutoStepCalibration unstable;
+    unstable.recordVerifiedNormalStep(180);
+    unstable.recordVerifiedNormalStep(231);
+    unstable.recordVerifiedNormalStep(300);
+    if (unstable.endpointUpperBound())
+      return false; // spread beyond jitter: no bound, keep the pause
+  }
+
+  // --- CaptureHandshake -----------------------------------------------------
+  {
+    CaptureHandshake handshake;
+    std::atomic<bool> stop{false};
+    if (handshake.readyCycle() != 0 || handshake.publishReady() != 1)
+      return false;
+    handshake.acknowledgeWithNotches(1, 0); // clamps to 1 notch
+    if (handshake.waitForCapture(1, stop) != std::optional(1))
+      return false;
+    // One-shot consumption: the same cycle cannot deliver twice.
+    handshake.acknowledge(1);
+    // duplicate ack of an already-acknowledged cycle is ignored
+    const std::uint64_t second = handshake.publishReady();
+    handshake.acknowledgeWithNotches(second + 5, 99); // clamps to published, 3
+    if (handshake.waitForCapture(second, stop) != std::optional(3))
+      return false;
+    stop = true;
+    if (handshake.waitForCapture(second + 1, stop))
+      return false; // stopped
+  }
+
+  // --- autoProbeDecision table ---------------------------------------------
+  {
+    const ForwardMatchPath path{54, 18, 0.0};
+    ForwardLookaheadResolution resolved;
+    resolved.tag = ForwardLookaheadResolution::Tag::Resolved;
+    resolved.path = path;
+    AutoProbeDecision decision = autoProbeDecision(resolved, 0, std::nullopt);
+    if (decision.kind != Kind::Commit || decision.periodic || !(decision.path == path))
+      return false;
+    resolved.tag = ForwardLookaheadResolution::Tag::LowErrorPeriodic;
+    decision = autoProbeDecision(resolved, 0, std::nullopt);
+    if (decision.kind != Kind::Commit || !decision.periodic)
+      return false;
+    ForwardLookaheadResolution unresolved;
+    unresolved.tag = ForwardLookaheadResolution::Tag::Unresolved;
+    unresolved.path = path;
+    decision = autoProbeDecision(unresolved, 1, std::nullopt);
+    if (decision.kind != Kind::Pause ||
+        decision.pauseReason != PauseReason::StillAmbiguous ||
+        decision.bestEffort != std::optional(path))
+      return false;
+    ForwardLookaheadResolution stationary;
+    stationary.tag = ForwardLookaheadResolution::Tag::StationaryProbe;
+    StationaryProbeFirstMatch unique;
+    unique.tag = StationaryProbeFirstMatch::Tag::Unique;
+    unique.candidate = ForwardMatchCandidate{60, 0.5};
+    stationary.firstMatch = unique;
+    if (autoProbeDecision(stationary, 0, std::nullopt).kind != Kind::ProbeAgain)
+      return false; // first stationary probe retries
+    decision = autoProbeDecision(stationary, 1, std::nullopt);
+    if (decision.kind != Kind::End ||
+        decision.endCandidate != std::optional(ForwardMatchCandidate{60, 0.5}))
+      return false;
+    StationaryProbeFirstMatch ambiguous;
+    ambiguous.tag = StationaryProbeFirstMatch::Tag::Ambiguous;
+    ambiguous.candidate = ForwardMatchCandidate{18, 0.0};
+    stationary.firstMatch = ambiguous;
+    const ForwardMatchCandidate calibrated{22, 0.1};
+    decision = autoProbeDecision(stationary, 1, calibrated);
+    if (decision.kind != Kind::End || decision.endCandidate != std::optional(calibrated))
+      return false; // the calibrated physical bound wins
+    decision = autoProbeDecision(stationary, 1, std::nullopt);
+    if (decision.kind != Kind::End ||
+        decision.endCandidate != std::optional(ForwardMatchCandidate{18, 0.0}))
+      return false; // matcher-ranked best effort finishes without a pause
+    ambiguous.candidate = std::nullopt;
+    stationary.firstMatch = ambiguous;
+    decision = autoProbeDecision(stationary, 1, std::nullopt);
+    if (decision.kind != Kind::Pause || decision.pauseReason != PauseReason::Stationary)
+      return false;
+  }
+
+  // Widen a GrayView fixture into an RGB image whose vertical downsample
+  // reproduces it exactly (each gray pixel repeated kDownsampleCross times;
+  // gray luma is the identity).
+  const auto grayToImage = [](const GrayView &view) {
+    QImage image(view.width * kDownsampleCross, view.height,
+                 QImage::Format_RGBA8888);
+    for (int y = 0; y < view.height; ++y) {
+      QRgb *row = reinterpret_cast<QRgb *>(image.scanLine(y));
+      for (int x = 0; x < image.width(); ++x) {
+        const std::uint8_t v =
+            view.pixels[static_cast<std::size_t>(y) * view.width +
+                        x / kDownsampleCross];
+        row[x] = qRgba(v, v, v, 255);
+      }
+    }
+    return image;
+  };
+
+  // --- AutoCapture sequences -----------------------------------------------
+  // (a) Seed, three verified forward steps, then two stationary cycles.
+  {
+    const QImage doc = makeTexture(64, 500);
+    const auto window = [&](int top) { return doc.copy(0, top, 64, 200); };
+    AutoCapture session(Axis::Vertical);
+    AutoCapture::Outcome out = session.feed(window(0));
+    if (out.event != Event::Seeded || out.ack != Ack::Normal)
+      return false;
+    int height = 200;
+    for (const int top : {60, 120, 180}) {
+      out = session.feed(window(top));
+      if (out.event != Event::Appended || out.ack != Ack::Normal)
+        return false;
+      height += 60;
+    }
+    out = session.feed(window(180));
+    if (out.event != Event::StillOnce || out.ack != Ack::Normal)
+      return false;
+    out = session.feed(window(180));
+    if (out.event != Event::ReachedEnd || !session.reachedEnd())
+      return false;
+    QString error;
+    const QImage stitched = session.finish(error);
+    if (stitched.isNull() || stitched.height() != height)
+      return false;
+  }
+  // (b) Solid first frames never seed; the ninth halts.
+  {
+    AutoCapture session(Axis::Vertical);
+    QImage blank(64, 200, QImage::Format_RGBA8888);
+    blank.fill(Qt::darkGray);
+    for (int i = 0; i < 7; ++i) {
+      const AutoCapture::Outcome out = session.feed(blank);
+      if (out.event != Event::Blank || out.ack != Ack::Hold)
+        return false;
+    }
+    const AutoCapture::Outcome out = session.feed(blank);
+    if (out.event != Event::Halted ||
+        out.haltReason != AutoCapture::HaltReason::BlankFrames)
+      return false;
+  }
+  // (c) Periodic content: probe with one notch, resolve, commit both frames.
+  {
+    AutoCapture session(Axis::Vertical);
+    if (session.feed(grayToImage(exactlyPeriodicGray(0))).event != Event::Seeded)
+      return false;
+    AutoCapture::Outcome out = session.feed(grayToImage(exactlyPeriodicGray(54)));
+    if (out.event != Event::ProbeStarted || out.ack != Ack::Probe ||
+        session.keptFrames() != 1)
+      return false; // F1 held, not committed
+    out = session.feed(grayToImage(exactlyPeriodicGray(72)));
+    if (out.event != Event::Committed || out.ack != Ack::Normal ||
+        out.firstDelta != 54 || out.secondDelta != 18 ||
+        session.keptFrames() != 3)
+      return false;
+    QString error;
+    const QImage stitched = session.finish(error);
+    if (stitched.isNull() || stitched.height() != 360 + 54 + 18)
+      return false;
+  }
+  // (d) Probe, then two stationary probes: the end is confirmed at the seam
+  // and only F1 is committed.
+  {
+    AutoCapture session(Axis::Vertical);
+    if (session.feed(grayToImage(exactlyPeriodicGray(0))).event != Event::Seeded)
+      return false;
+    if (session.feed(grayToImage(exactlyPeriodicGray(54))).event !=
+        Event::ProbeStarted)
+      return false;
+    AutoCapture::Outcome out = session.feed(grayToImage(exactlyPeriodicGray(54)));
+    if (out.event != Event::ProbeAgain || out.ack != Ack::Probe)
+      return false;
+    out = session.feed(grayToImage(exactlyPeriodicGray(54)));
+    if (out.event != Event::ReachedEndAtSeam || out.ack != Ack::Hold ||
+        session.keptFrames() != 2 || !session.reachedEnd())
+      return false;
+    QString error;
+    const QImage stitched = session.finish(error);
+    if (stitched.isNull() || stitched.height() != 360 + out.firstDelta)
+      return false;
+  }
+  // (e) An unresolvable probe pauses holding the frames; abandoning keeps only
+  // verified content.
+  {
+    AutoCapture session(Axis::Vertical);
+    if (session.feed(grayToImage(exactlyPeriodicGray(0))).event != Event::Seeded)
+      return false;
+    if (session.feed(grayToImage(exactlyPeriodicGray(54))).event !=
+        Event::ProbeStarted)
+      return false;
+    const AutoCapture::Outcome out =
+        session.feed(grayToImage(uniqueDocumentGray(0)));
+    if (out.event != Event::Paused || out.ack != Ack::Hold)
+      return false;
+    session.abandonPause();
+    QString error;
+    const QImage stitched = session.finish(error);
+    if (stitched.isNull() || stitched.height() != 360 ||
+        session.unverifiedSeams() != 0)
+      return false;
+  }
+  return true;
+}
+} // namespace
+
+/// A session that concluded because the screen went still can be picked up
+/// again: the bands it has are kept and the next scroll appends to them.
+bool checkAutoResume() {
+  const QSize size(120, 90);
+  auto frameAt = [size](int offset) {
+    QImage frame(size, QImage::Format_RGBA8888);
+    for (int y = 0; y < size.height(); ++y) {
+      QRgb *row = reinterpret_cast<QRgb *>(frame.scanLine(y));
+      for (int x = 0; x < size.width(); ++x) {
+        const int document = y + offset;
+        row[x] = qRgb((document * 7) & 0xff, (document * 13) & 0xff,
+                      ((document ^ x) * 5) & 0xff);
+      }
+    }
+    return frame;
+  };
+  stitch::AutoCapture session(stitch::Axis::Vertical);
+  for (const int offset : {0, 20, 40}) {
+    const stitch::AutoCapture::Outcome out = session.feed(frameAt(offset));
+    static_cast<void>(out);
+  }
+  const int keptBefore = session.keptFrames();
+  // The screen goes still, as it does when the pointer leaves the frame.
+  for (int still = 0; still < 8; ++still)
+    static_cast<void>(session.feed(frameAt(40)));
+  if (!session.reachedEnd())
+    return true; // never concluded; nothing to resume, and nothing to prove
+  session.resumeFromEnd();
+  if (session.reachedEnd())
+    return false;
+  static_cast<void>(session.feed(frameAt(60)));
+  return session.keptFrames() >= keptBefore;
+}
+
+bool runStitchChecks() {
+  // Downsample: cross axis /4, motion axis exact; luma correct.
+  const QImage texture = makeTexture(256, 180);
+  const GrayView vertical = downsampleToGray(texture, Axis::Vertical);
+  if (vertical.width != 64 || vertical.height != 180 || vertical.sourceWidth != 256)
+    return false;
+  const GrayView horizontal = downsampleToGray(texture, Axis::Horizontal);
+  if (horizontal.width != 256 || horizontal.height != 45)
+    return false;
+  // cropAxis spans the requested range on either axis.
+  const GrayView band = vertical.cropAxis(Axis::Vertical, 20, 80);
+  if (band.height != 60 || band.width != 64)
+    return false;
+
+  // scoreShift is bit-identical to the naive reference across axes, shifts and
+  // sampling steps.
+  const GrayView vp = downsampleToGray(makeTexture(53, 71), Axis::Vertical);
+  const GrayView hp = downsampleToGray(makeTexture(53, 71), Axis::Horizontal);
+  for (const auto &pair : {std::pair{Axis::Vertical, &vp}, std::pair{Axis::Horizontal, &hp}}) {
+    const Axis axis = pair.first;
+    const GrayView &view = *pair.second;
+    const int axisLen = view.axisLen(axis);
+    for (int maxShift : {3, 7, axisLen / 3}) {
+      for (long shift = -maxShift; shift <= maxShift; ++shift)
+        for (int aStep : {0, 1, 2, 5, 13})
+          for (int cStep : {0, 1, 3, 8}) {
+            const double fast = scoreShift(view, view, axis, shift, maxShift, aStep, cStep);
+            const double slow = scoreShiftReference(view, view, axis, shift, maxShift, aStep, cStep);
+            if (fast != slow && !(std::isinf(fast) && std::isinf(slow)))
+              return false;
+          }
+    }
+  }
+
+  // A stationary pair caps each scoring edge at axisLen/4 and classifies as
+  // Stationary.
+  {
+    QImage still = makeTexture(64, 180);
+    const GrayView g = downsampleToGray(still, Axis::Vertical);
+    const StationaryEdges edges = stationaryScoringEdges(g, g, Axis::Vertical);
+    if (edges.lead != 45 || edges.trail != 45)
+      return false;
+    if (classifyMotion(g, g, Axis::Vertical).motion.kind != MotionKind::Stationary)
+      return false;
+  }
+
+  // A known vertical shift classifies as Forward(delta) and stitches to the
+  // expected height with the deltas applied.
+  {
+    QImage tall = makeTexture(64, 400);
+    QImage a = tall.copy(0, 0, 64, 200);
+    QImage b = tall.copy(0, 40, 64, 200);   // shifted down 40 px
+    QImage c = tall.copy(0, 90, 64, 200);   // a further 50 px
+    const MotionEstimate est =
+        classifyMotion(downsampleToGray(a, Axis::Vertical),
+                       downsampleToGray(b, Axis::Vertical), Axis::Vertical);
+    if (est.motion.kind != MotionKind::Forward || est.motion.delta != 40)
+      return false;
+    QString error;
+    const QImage stitched = stitchWithDeltas({a, b, c}, {40, 50}, Axis::Vertical, error);
+    if (stitched.isNull() || stitched.width() != 64 || stitched.height() != 290)
+      return false;
+  }
+
+  // Reverse (scrolled-up) frames rebuild the document in order: windows that
+  // each show content 40 px higher than the last stitch back to the span they
+  // cover, top-to-bottom.
+  {
+    const QImage doc = makeTexture(64, 400);
+    const QImage f0 = doc.copy(0, 200, 64, 160); // window low in the document
+    const QImage f1 = doc.copy(0, 160, 64, 160); // scrolled up 40
+    const QImage f2 = doc.copy(0, 120, 64, 160); // up another 40
+    const MotionEstimate est =
+        classifyMotion(downsampleToGray(f0, Axis::Vertical),
+                       downsampleToGray(f1, Axis::Vertical), Axis::Vertical);
+    if (est.motion.kind != MotionKind::Reverse || est.motion.delta != 40)
+      return false;
+    QString error;
+    bool ok = false;
+    StitchAccumulator acc(f0, Axis::Vertical, ok, error);
+    if (!ok || !acc.pushReverse(f1, 40, error) || !acc.pushReverse(f2, 40, error))
+      return false;
+    // Forward and reverse cannot mix.
+    if (acc.pushForward(f2, 40, error))
+      return false;
+    const QImage rebuilt = acc.finish(error);
+    // Spans doc rows [120, 360): 160 + 40 + 40 = 240 tall.
+    const QImage expected = doc.copy(0, 120, 64, 240)
+                                .convertToFormat(QImage::Format_RGBA8888);
+    if (rebuilt.isNull() || rebuilt.size() != expected.size())
+      return false;
+    if (rebuilt.convertToFormat(QImage::Format_RGBA8888) != expected)
+      return false;
+  }
+  // ---- ManualCapture: the live-loop semantics ------------------------------
+  {
+    using Event = ManualCapture::Event;
+    // A 64x400 document viewed through a 64x200 window (coalesce threshold
+    // for axisLen 200 = clamp(25,16,128) = 25).
+    const QImage doc = makeTexture(64, 400);
+    const auto window = [&](int top) { return doc.copy(0, top, 64, 200); };
+
+    // (a) Ordinary forward scrolling in steps above the coalesce threshold
+    // stitches the span; a solid first frame is refused; stationary grabs
+    // are ignored.
+    {
+      ManualCapture session(Axis::Vertical);
+      QImage blank(64, 200, QImage::Format_RGBA8888);
+      blank.fill(Qt::black);
+      if (session.feed(blank).event != Event::Blank || session.started())
+        return false;
+      if (session.feed(window(0)).event != Event::Seeded)
+        return false;
+      if (session.feed(window(0)).event != Event::Still)
+        return false;
+      if (session.feed(window(60)).event != Event::Kept)
+        return false;
+      if (session.feed(window(60)).event != Event::Still)
+        return false;
+      if (session.feed(window(150)).event != Event::Kept)
+        return false;
+      QString error;
+      const QImage out = session.finish(error);
+      const QImage expected = doc.copy(0, 0, 64, 350).convertToFormat(QImage::Format_RGBA8888);
+      if (out.isNull() || out.convertToFormat(QImage::Format_RGBA8888) != expected)
+        return false;
+    }
+    // (b) Small movements are held as one pending frame, replaced as they
+    // grow, dropped when reversed, and committed at finish.
+    {
+      ManualCapture session(Axis::Vertical);
+      if (session.feed(window(0)).event != Event::Seeded)
+        return false;
+      ManualCapture::Outcome out = session.feed(window(10));
+      if (out.event != Event::Pending || out.pendingDelta != 10)
+        return false;
+      out = session.feed(window(20));
+      if (out.event != Event::Pending || out.pendingDelta != 20 || out.keptFrames != 1)
+        return false;
+      // Back to the start: the pending movement is dropped.
+      if (session.feed(window(0)).event != Event::PendingDropped)
+        return false;
+      // Grow past the threshold: committed as one band.
+      if (session.feed(window(12)).event != Event::Pending)
+        return false;
+      out = session.feed(window(40));
+      if (out.event != Event::Kept || out.keptFrames != 2)
+        return false;
+      // A trailing small movement is committed by finish().
+      if (session.feed(window(52)).event != Event::Pending)
+        return false;
+      QString error;
+      const QImage outImage = session.finish(error);
+      const QImage expected = doc.copy(0, 0, 64, 252).convertToFormat(QImage::Format_RGBA8888);
+      if (outImage.isNull() || outImage.convertToFormat(QImage::Format_RGBA8888) != expected)
+        return false;
+    }
+    // (c) Content that changes in place before anything is committed (an
+    // autoplaying video) re-seeds the first frame instead of jamming the
+    // capture; scrolling then proceeds from the new appearance.
+    {
+      ManualCapture session(Axis::Vertical);
+      if (session.feed(window(0)).event != Event::Seeded)
+        return false;
+      QImage changed = window(0);
+      {
+        QPainter painter(&changed); // a "video" area repainted in place
+        painter.fillRect(QRect(0, 60, 64, 100), QColor(200, 30, 30));
+      }
+      // First sight of the change: unmatched vs the reference, and it moved
+      // vs the previous grab, so not yet at rest → keep the reference.
+      if (session.feed(changed).event != Event::Unmatchable)
+        return false;
+      // Same changed frame again: at rest and nothing committed → re-seed.
+      if (session.feed(changed).event != Event::ReSeeded)
+        return false;
+      // Now scrolling from the changed appearance works.
+      QImage changedScrolled = window(60);
+      {
+        QPainter painter(&changedScrolled);
+        painter.fillRect(QRect(0, 0, 64, 100), QColor(200, 30, 30));
+      }
+      if (session.feed(changedScrolled).event != Event::Kept)
+        return false;
+    }
+    // (d) A jump beyond the safe overlap cannot be aligned; the reference is
+    // kept, and scrolling back into overlap resumes the capture without a gap.
+    {
+      ManualCapture session(Axis::Vertical);
+      if (session.feed(window(0)).event != Event::Seeded)
+        return false;
+      if (session.feed(window(60)).event != Event::Kept)
+        return false;
+      // 200-px window: safe max shift is 200 - max(200/3, 32) = 133, so this
+      // frame cannot be aligned to the reference (on this synthetic texture
+      // it may surface an aliasing peak the wrong way instead; either way it
+      // must be refused without changing state).
+      const auto refused = [](Event event) {
+        return event == Event::Unmatchable || event == Event::WrongDirection;
+      };
+      ManualCapture::Outcome jump = session.feed(window(60 + 180));
+      if (!refused(jump.event) || jump.keptFrames != 2)
+        return false;
+      // Once a band exists, a repeat never re-seeds (that could hide a gap).
+      jump = session.feed(window(60 + 180));
+      if (!refused(jump.event) || jump.keptFrames != 2)
+        return false;
+      // Scroll back into overlap: resumes against the kept reference.
+      ManualCapture::Outcome out = session.feed(window(60 + 100));
+      if (out.event != Event::Kept || out.estimate.motion.delta != 100)
+        return false;
+      QString error;
+      const QImage outImage = session.finish(error);
+      const QImage expected = doc.copy(0, 0, 64, 360).convertToFormat(QImage::Format_RGBA8888);
+      if (outImage.isNull() || outImage.convertToFormat(QImage::Format_RGBA8888) != expected)
+        return false;
+    }
+    // (e) Direction locks once a band exists; before that it may switch.
+    {
+      ManualCapture session(Axis::Vertical);
+      if (session.feed(window(200)).event != Event::Seeded)
+        return false;
+      if (session.feed(window(190)).event != Event::Pending) // small reverse
+        return false;
+      if (session.feed(window(260)).event != Event::Kept) // switched forward, ok
+        return false;
+      if (session.feed(window(200)).event != Event::WrongDirection)
+        return false;
+      if (session.feed(window(320)).event != Event::Kept)
+        return false;
+    }
+  }
+  // The capture budget: 512 MB of RGBA, so a 2446-wide capture may grow to
+  // ~54k rows and is refused past that. The predicate is checked directly
+  // because tripping it for real would need half a gigabyte of frames.
+  if (exceedsStitchBudget(2446, 50000) ||
+      !exceedsStitchBudget(2446, 60000)) {
+    std::fprintf(stderr, "stitch budget did not bound a tall capture\n");
+    return false;
+  }
+  if (exceedsStitchBudget(0, 1) || exceedsStitchBudget(1, 0) ||
+      exceedsStitchBudget(2446, 1)) {
+    std::fprintf(stderr, "stitch budget rejected an ordinary capture\n");
+    return false;
+  }
+  // The advisory edge sits well inside the hard budget, so a capture warns
+  // long before it is refused: capture must not stop at the advisory.
+  if (!(static_cast<long long>(2446) * kWidelyOpenableEdge <
+        kMaxStitchedPixels)) {
+    std::fprintf(stderr, "advisory edge is not inside the capture budget\n");
+    return false;
+  }
+
+  if (!runLookaheadChecks())
+    return false;
+  if (!runAutoCaptureChecks())
+    return false;
+
+  if (!checkAutoResume())
+    return false;
+  return true;
+}

--- a/tests/stitch-smoke.hpp
+++ b/tests/stitch-smoke.hpp
@@ -1,0 +1,6 @@
+/** @fileoverview Declares the scroll-capture stitcher smoke checks. */
+#pragma once
+
+/** Runs the pure stitcher unit checks (downsample, classifier, accumulator).
+ *  Returns true on success. */
+bool runStitchChecks();

--- a/tests/surface-capture-smoke.cpp
+++ b/tests/surface-capture-smoke.cpp
@@ -8,12 +8,15 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 
 namespace {
 enum class CleanupCall {
   Frame,
   Session,
   Source,
+  Output,
+  OutputSourceManager,
   CaptureManager,
   Buffer,
   Pool,
@@ -22,7 +25,7 @@ enum class CleanupCall {
   Display,
 };
 
-std::array<CleanupCall, 9> cleanupCalls;
+std::array<CleanupCall, 12> cleanupCalls;
 std::size_t cleanupCallCount = 0;
 bool recordingCleanup = false;
 
@@ -53,6 +56,21 @@ void recordSourceDestroy(ext_image_capture_source_v1 *proxy) {
     recordCleanup<CleanupCall::Source>(proxy);
   else
     ::ext_image_capture_source_v1_destroy(proxy);
+}
+/** Records or forwards output release. */
+void recordOutputRelease(wl_output *proxy) {
+  if (recordingCleanup)
+    recordCleanup<CleanupCall::Output>(proxy);
+  else
+    ::wl_output_release(proxy);
+}
+/** Records or forwards output-source-manager destruction. */
+void recordOutputSourceManagerDestroy(
+    ext_output_image_capture_source_manager_v1 *proxy) {
+  if (recordingCleanup)
+    recordCleanup<CleanupCall::OutputSourceManager>(proxy);
+  else
+    ::ext_output_image_capture_source_manager_v1_destroy(proxy);
 }
 /** Records or forwards capture-manager destruction. */
 void recordCaptureManagerDestroy(ext_image_copy_capture_manager_v1 *proxy) {
@@ -100,6 +118,9 @@ void recordDisplayDisconnect(wl_display *proxy) {
 #define ext_image_copy_capture_frame_v1_destroy recordFrameDestroy
 #define ext_image_copy_capture_session_v1_destroy recordSessionDestroy
 #define ext_image_capture_source_v1_destroy recordSourceDestroy
+#define wl_output_release recordOutputRelease
+#define ext_output_image_capture_source_manager_v1_destroy                     \
+  recordOutputSourceManagerDestroy
 #define ext_image_copy_capture_manager_v1_destroy recordCaptureManagerDestroy
 #define wl_buffer_destroy recordBufferDestroy
 #define wl_shm_pool_destroy recordPoolDestroy
@@ -110,6 +131,8 @@ void recordDisplayDisconnect(wl_display *proxy) {
 #undef ext_image_copy_capture_frame_v1_destroy
 #undef ext_image_copy_capture_session_v1_destroy
 #undef ext_image_capture_source_v1_destroy
+#undef wl_output_release
+#undef ext_output_image_capture_source_manager_v1_destroy
 #undef ext_image_copy_capture_manager_v1_destroy
 #undef wl_buffer_destroy
 #undef wl_shm_pool_destroy
@@ -126,6 +149,14 @@ bool runWaylandCleanupChecks() {
     state.display = reinterpret_cast<wl_display *>(1);
     state.registry = reinterpret_cast<wl_registry *>(2);
     state.shm = reinterpret_cast<wl_shm *>(3);
+    state.outputSourceManager =
+        reinterpret_cast<ext_output_image_capture_source_manager_v1 *>(5);
+    for (const auto handle : {4, 12}) {
+      auto output = std::make_unique<OutputInfo>();
+      output->output =
+          reinterpret_cast<wl_output *>(static_cast<std::uintptr_t>(handle));
+      state.outputs.push_back(std::move(output));
+    }
     state.captureManager =
         reinterpret_cast<ext_image_copy_capture_manager_v1 *>(6);
     state.source = reinterpret_cast<ext_image_capture_source_v1 *>(7);
@@ -135,12 +166,13 @@ bool runWaylandCleanupChecks() {
     state.pool = reinterpret_cast<wl_shm_pool *>(11);
   }
   recordingCleanup = false;
-  constexpr std::array expected{
-      CleanupCall::Frame,         CleanupCall::Session,
-      CleanupCall::Source,        CleanupCall::CaptureManager,
-      CleanupCall::Buffer,        CleanupCall::Pool,
-      CleanupCall::Shm,           CleanupCall::Registry,
-      CleanupCall::Display,
-  };
+    constexpr std::array expected{
+        CleanupCall::Frame,          CleanupCall::Session,
+        CleanupCall::Source,         CleanupCall::Output,
+        CleanupCall::Output,         CleanupCall::OutputSourceManager,
+        CleanupCall::CaptureManager, CleanupCall::Buffer,
+        CleanupCall::Pool,           CleanupCall::Shm,
+        CleanupCall::Registry,       CleanupCall::Display,
+    };
   return cleanupCallCount == expected.size() && cleanupCalls == expected;
 }


### PR DESCRIPTION
Rebased on current main after the batch that merged; three commits now, since the viewport it used to stack on is in.

`omasnap --scroll` captures a scrolling region and stitches the frames into one tall (or wide) image, which opens in the editor like any other capture.

Drag a region, pick manual or automatic, scroll (or let it scroll), and it assembles. The frame resizes by its corners and edges and moves by its border. The page underneath stays live throughout, so you can scroll it into position first and by hand during a manual capture. The region is remembered for the session (one line in the runtime dir, gone at reboot) and `R` brings it back; an automatic capture that stops short picks up again with Continue. This overlay and the capture overlay wear the same chrome, and `S` / `A` swap between them.

## The three commits

None does anything alone, and the seams between them are where the interesting failures live.

**`feat(capture)`** adds `OutputCapture`, a reusable session on the machinery your in-process monitor capture already set up: scroll capture needs many frames a second and can't pay a handshake for each, so it keeps the copy-capture session open and grabs repeatedly into the same shm buffer. The one-shot `captureOutputSurface()` goes through the same helpers now, so there's one code path rather than two. Two deliberate bits of paranoia. Buffer geometry and format are recorded at buffer creation rather than read live, because the compositor can re-announce constraints in the same dispatch batch as a frame's ready event, and the live values then describe a different mmap. And `grab()` takes a timeout with `sessionStopped()` reporting a compositor-ended session, because the protocol only delivers on damage, so a static screen is otherwise indistinguishable from a hang. Measured live on Hyprland (DP-1, 2560x1600): 4 to 843 ms a frame, the slow ones being the damage wait on a static screen.

**`feat(stitch)`** is the pure half, over `QImage` with no compositor dependency, so all of it runs offscreen in the smoke suite. A downsampled fixed-window MAE correlation with stationary-edge cropping (so viewport-fixed chrome doesn't floor every candidate) classifies each pair as Stationary, Forward, Reverse, Ambiguous or Unmatchable, and a path only resolves when `F0->F1`, `F1->F2` and `F0->F2` agree cumulatively within 2 px and beat every competitor. That last rule is what stops a periodic background inventing a plausible shift. The accumulator handles retained tail bands, sticky headers and footers, and drop shadows. Captures are bounded by memory (512 MB of RGBA) rather than extent, because Linux overcommits: an unbounded capture isn't refused at allocation time, it's OOM-killed part-way through assembly after a long scroll. Hitting the budget is a state, not a failure.

**`feat(scroll)`** is the overlay: region selection, the manual/automatic choice, the live page underneath, Continue, and the shared chrome.

## Bits I'd like your read on

The overlay chrome moved into `src/overlay-chrome.{hpp,cpp}` and both overlays draw through it, which touches the existing capture overlay. That's the part most likely to disagree with where you'd want the code to live.

Keeping the page interactive means holding the input region to the frame's chrome only and taking the keyboard grab only while the overlay needs it, because on Hyprland an exclusive keyboard grab also pins pointer focus, even over an input-region hole. That's why the grab is released before an automatic capture starts.

`exceedsWidelyOpenableEdge()` is advisory, not a limit: past 32767 px many renderers stop (signed 16-bit pixel coordinates), but nothing breaks at that size here, so capture continues and the editor mentions it once on opening.

## Testing

Exit 104 (`scoreShift` bit-identical to a naive reference, stationary-pair edge capping, a known shift stitching to the expected height), 108 (lookahead fixtures through the candidate-set decisions), 112 (`AutoCapture` through every row of the state machine), plus 116 and 111 from the PR under this one. `stitch-replay` stitches a dumped frame directory with no compositor, which is how I debug a bad stitch.

I also keep a corpus of real frame sequences (~360 MB, five scenarios including sticky headers and a horizontal one) and gate every change on the stitch being pixel-identical to a recorded result. Too big to carry here, but I can put it somewhere you can run it.

`test/all-features` on my fork is all nineteen branches merged on current `main`, green on the suite and that gate: https://github.com/jondkinney/omasnap/tree/test/all-features
