### PR TITLE
Add cut-out tool and configurable preset colors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ qt_add_executable(omasnap
   src/capture.hpp
   src/cut.cpp
   src/cut.hpp
+  src/palette-config.cpp
+  src/palette-config.hpp
   src/eyedropper.cpp
   src/eyedropper.hpp
   src/surface-capture.cpp
@@ -99,6 +101,10 @@ qt_add_executable(omasnap-smoke
   src/cut.hpp
   tests/cut-smoke.cpp
   tests/cut-smoke.hpp
+  src/palette-config.cpp
+  src/palette-config.hpp
+  tests/palette-config-smoke.cpp
+  tests/palette-config-smoke.hpp
   tests/surface-capture-smoke.cpp
   tests/surface-capture-smoke.hpp
   ${PROTOCOL_SOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ qt_add_executable(omasnap
   src/pin-layout.hpp
   src/capture.cpp
   src/capture.hpp
+  src/cut.cpp
+  src/cut.hpp
   src/eyedropper.cpp
   src/eyedropper.hpp
   src/surface-capture.cpp
@@ -93,6 +95,10 @@ qt_add_executable(omasnap-smoke
   src/cli-path.hpp
   src/capture.cpp
   src/capture.hpp
+  src/cut.cpp
+  src/cut.hpp
+  tests/cut-smoke.cpp
+  tests/cut-smoke.hpp
   tests/surface-capture-smoke.cpp
   tests/surface-capture-smoke.hpp
   ${PROTOCOL_SOURCES}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LINT_SOURCES := \
 	src/cli-path.cpp src/icons.cpp src/pin.cpp src/pin-file.cpp \
 	src/pin-layout.cpp src/eyedropper.cpp src/instance-lock.cpp \
 	tests/editor-smoke.cpp tests/transform-smoke.cpp \
-	tests/clipboard-smoke.cpp \
+	tests/clipboard-smoke.cpp tests/cut-smoke.cpp \
 	tests/surface-capture-smoke.cpp tests/pin-layout-smoke.cpp \
 	tests/pin-lifecycle-smoke.cpp tests/instance-lock-smoke.cpp
 LINT_CHECKS ?= -*,clang-analyzer-*,bugprone-*,performance-*,misc-*

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ LINT_SOURCES := \
 	src/pin-layout.cpp src/eyedropper.cpp src/instance-lock.cpp \
 	tests/editor-smoke.cpp tests/transform-smoke.cpp \
 	tests/clipboard-smoke.cpp tests/cut-smoke.cpp \
+	tests/palette-config-smoke.cpp \
 	tests/surface-capture-smoke.cpp tests/pin-layout-smoke.cpp \
 	tests/pin-lifecycle-smoke.cpp tests/instance-lock-smoke.cpp
 LINT_CHECKS ?= -*,clang-analyzer-*,bugprone-*,performance-*,misc-*

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   OCR-region capture,
   mesh-gradient backdrops, and rendered drop shadows.
+- Cut tool: drag across a band of the image to remove it and collapse the gap, with a
+  live preview and dashed seam marker while dragging; annotations shift to follow.
 - Pin a finished capture as a bottom-right always-on-top layer surface, launched
   from the same `omasnap` executable and visible on every workspace.
 - Crash-resistant working snapshots under `/run/user/<UID>/omasnap/` (falling back to
@@ -259,6 +261,7 @@ Install the corresponding Tesseract language data before adding a language to
 | `C` | Numbered marker |
 | `R` | Rectangle |
 | `D` | Redact; press again to toggle randomized pixelation or solid redaction |
+| `X` | Cut out a band; drag across the image to remove and collapse a horizontal or vertical strip |
 | `T` | Neucha text |
 | `O` | Drag an OCR region and copy recognized text |
 | `B` | Cycle backdrop |

--- a/src/cut.cpp
+++ b/src/cut.cpp
@@ -54,10 +54,20 @@ QImage composeCuts(const QImage &pristine, const QVector<CutOp> &cuts) {
 QSize composedLogicalSize(QSize pristineLogical, const QVector<CutOp> &cuts) {
   for (const CutOp &cut : cuts) {
     const int band = cut.logicalEnd - cut.logicalStart;
-    if (cut.orientation == Qt::Horizontal)
-      pristineLogical.setHeight(std::max(1, pristineLogical.height() - band));
-    else
-      pristineLogical.setWidth(std::max(1, pristineLogical.width() - band));
+    if (cut.orientation == Qt::Horizontal) {
+      const int extent = pristineLogical.height();
+      // Mirror removeBand()'s no-op guard so this can never disagree with
+      // what composeCuts() actually produces: an empty or full-extent band
+      // leaves the image unchanged.
+      if (band <= 0 || band >= extent)
+        continue;
+      pristineLogical.setHeight(std::max(1, extent - band));
+    } else {
+      const int extent = pristineLogical.width();
+      if (band <= 0 || band >= extent)
+        continue;
+      pristineLogical.setWidth(std::max(1, extent - band));
+    }
   }
   return pristineLogical;
 }

--- a/src/cut.cpp
+++ b/src/cut.cpp
@@ -1,0 +1,70 @@
+/** @fileoverview Band cut-out engine: removes a horizontal or vertical band
+ *  from an image and collapses the gap (Snagit-style "cut out", ported from
+ *  omapic). */
+#include "cut.hpp"
+
+#include <QPainter>
+#include <algorithm>
+#include <cstring>
+
+QImage removeBand(const QImage &source, Qt::Orientation orientation,
+                  int start, int end) {
+  if (source.isNull())
+    return source;
+  if (orientation == Qt::Horizontal) {
+    const int height = source.height();
+    start = std::clamp(start, 0, height);
+    end = std::clamp(end, start, height);
+    const int band = end - start;
+    if (band <= 0 || band >= height)
+      return source;
+    QImage out(source.width(), height - band, source.format());
+    out.setDevicePixelRatio(source.devicePixelRatio());
+    for (int y = 0; y < start; ++y)
+      std::memcpy(out.scanLine(y), source.constScanLine(y),
+                  source.bytesPerLine());
+    for (int y = end; y < height; ++y)
+      std::memcpy(out.scanLine(y - band), source.constScanLine(y),
+                  source.bytesPerLine());
+    return out;
+  }
+  const int width = source.width();
+  start = std::clamp(start, 0, width);
+  end = std::clamp(end, start, width);
+  const int band = end - start;
+  if (band <= 0 || band >= width)
+    return source;
+  QImage out(width - band, source.height(), source.format());
+  out.setDevicePixelRatio(source.devicePixelRatio());
+  QPainter painter(&out);
+  painter.drawImage(QPoint(0, 0), source, QRect(0, 0, start, source.height()));
+  painter.drawImage(QPoint(start, 0), source,
+                    QRect(end, 0, width - end, source.height()));
+  return out;
+}
+
+QImage composeCuts(const QImage &pristine, const QVector<CutOp> &cuts) {
+  QImage image = pristine;
+  for (const CutOp &cut : cuts)
+    image = removeBand(image, cut.orientation, cut.sourceStart, cut.sourceEnd);
+  return image;
+}
+
+QSize composedLogicalSize(QSize pristineLogical, const QVector<CutOp> &cuts) {
+  for (const CutOp &cut : cuts) {
+    const int band = cut.logicalEnd - cut.logicalStart;
+    if (cut.orientation == Qt::Horizontal)
+      pristineLogical.setHeight(std::max(1, pristineLogical.height() - band));
+    else
+      pristineLogical.setWidth(std::max(1, pristineLogical.width() - band));
+  }
+  return pristineLogical;
+}
+
+qreal shiftForCut(qreal value, qreal start, qreal end) {
+  if (value <= start)
+    return value;
+  if (value >= end)
+    return value - (end - start);
+  return start;
+}

--- a/src/cut.cpp
+++ b/src/cut.cpp
@@ -37,6 +37,7 @@ QImage removeBand(const QImage &source, Qt::Orientation orientation,
   QImage out(width - band, source.height(), source.format());
   out.setDevicePixelRatio(source.devicePixelRatio());
   QPainter painter(&out);
+  painter.setCompositionMode(QPainter::CompositionMode_Source);
   painter.drawImage(QPoint(0, 0), source, QRect(0, 0, start, source.height()));
   painter.drawImage(QPoint(start, 0), source,
                     QRect(end, 0, width - end, source.height()));

--- a/src/cut.hpp
+++ b/src/cut.hpp
@@ -1,0 +1,41 @@
+/** @fileoverview Band cut-out engine: removes a horizontal or vertical band
+ *  from an image and collapses the gap (Snagit-style "cut out"). */
+#pragma once
+
+#include <QImage>
+#include <QSize>
+#include <QVector>
+#include <Qt>
+
+/** One applied cut. Coordinates are in the space of the image as it existed
+ *  when the cut was applied; replay applies ops in order. `source*` are
+ *  native pixels, `logical*` are preview-logical pixels. `start` is
+ *  inclusive, `end` exclusive. Qt::Horizontal removes rows (image gets
+ *  shorter); Qt::Vertical removes columns (image gets narrower). */
+struct CutOp {
+  Qt::Orientation orientation = Qt::Horizontal;
+  int sourceStart = 0;
+  int sourceEnd = 0;
+  int logicalStart = 0;
+  int logicalEnd = 0;
+  bool operator==(const CutOp &) const = default;
+};
+
+/** Returns `source` with the band removed. Bounds are clamped to the image;
+ *  an empty band or a band covering the full extent returns `source`
+ *  unchanged (an image must never collapse to nothing). */
+[[nodiscard]] QImage removeBand(const QImage &source,
+                                Qt::Orientation orientation, int start,
+                                int end);
+
+/** Replays `cuts` in order over the pristine image. */
+[[nodiscard]] QImage composeCuts(const QImage &pristine,
+                                 const QVector<CutOp> &cuts);
+
+/** Logical preview size after replaying `cuts` over `pristineLogical`. */
+[[nodiscard]] QSize composedLogicalSize(QSize pristineLogical,
+                                        const QVector<CutOp> &cuts);
+
+/** Shifts one coordinate for a removed band [start, end): values past the
+ *  band shift back by the band size, values inside clamp to the seam. */
+[[nodiscard]] qreal shiftForCut(qreal value, qreal start, qreal end);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -3,6 +3,7 @@
 #include "editor.hpp"
 #include "icons.hpp"
 #include "eyedropper.hpp"
+#include "palette-config.hpp"
 
 #include <QtConcurrent/QtConcurrentRun>
 
@@ -35,8 +36,6 @@
 #include <numbers>
 
 namespace {
-constexpr std::array<const char *, 6> kColorNames{
-    "#ff375f", "#ff9f0a", "#ffd60a", "#30d158", "#0a84ff", "#bf5af2"};
 constexpr std::array<qreal, 3> kTextSizes{2.0, 5.0, 9.0};
 constexpr std::array<const char *, 3> kTextSizeNames{"S", "M", "L"};
 constexpr qreal kToolbarWidth = 760;
@@ -245,6 +244,8 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
                              QuickOutputMode quickOutput, QWidget *parent)
     : QWidget(parent), capture_(std::move(capture)),
       quickOutputMode_(quickOutput) {
+  paletteConfig_ = loadPaletteConfig(defaultPaletteConfigPath());
+  customColor_ = paletteConfig_.custom;
   setWindowTitle(QStringLiteral("Omasnap"));
   setWindowFlags(Qt::Window | Qt::FramelessWindowHint |
                  Qt::WindowStaysOnTopHint);
@@ -436,8 +437,7 @@ bool CaptureEditor::eventFilter(QObject *watched, QEvent *event) {
 QColor CaptureEditor::annotationColor() const {
   if (usingCustomColor_)
     return customColor_;
-  return QColor(QString::fromLatin1(
-      kColorNames.at(static_cast<std::size_t>(colorIndex_))));
+  return paletteConfig_.palette.at(static_cast<std::size_t>(colorIndex_));
 }
 QRectF CaptureEditor::annotationBounds(const Annotation &annotation) const {
   if (annotation.kind == Annotation::Kind::Marker) {
@@ -888,8 +888,7 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
            QStringLiteral("color-%1").arg(index),
            {},
            QStringLiteral("Color · %1").arg(index + 1),
-           QColor(QString::fromLatin1(
-               kColorNames.at(static_cast<std::size_t>(index))))});
+           paletteConfig_.palette.at(static_cast<std::size_t>(index))});
     }
     buttons.push_back({{palette.left() + 4 + 6 * 28, palette.top() + 4, 24, 28},
                        QStringLiteral("custom-color"), {},

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -244,6 +244,8 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
                              QuickOutputMode quickOutput, QWidget *parent)
     : QWidget(parent), capture_(std::move(capture)),
       quickOutputMode_(quickOutput) {
+  pristineSource_ = capture_.source;
+  pristineLogicalSize_ = capture_.previewSize;
   paletteConfig_ = loadPaletteConfig(defaultPaletteConfigPath());
   customColor_ = paletteConfig_.custom;
   setWindowTitle(QStringLiteral("Omasnap"));
@@ -317,6 +319,8 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
               return;
             }
             capture_ = job.capture;
+            pristineSource_ = capture_.source;
+            pristineLogicalSize_ = capture_.previewSize;
             redactionBaseStale_ = true;
             switch (pendingMode_) {
             case CaptureMode::Fullscreen:
@@ -355,6 +359,8 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     }
     capture_.source = job.image;
     capture_.previewSize = job.scaledSize;
+    pristineSource_ = capture_.source;
+    pristineLogicalSize_ = capture_.previewSize;
     selection_ = QRectF(QPointF(), job.scaledSize);
     redactionBaseStale_ = true;
     windowMode_ = false;
@@ -906,8 +912,9 @@ void CaptureEditor::setStatus(QString status) {
 }
 
 CaptureEditor::EditState CaptureEditor::editState() const {
-  return {annotations_, backgroundStyle_, selection_, selectedAnnotation_,
-          selectedAnnotations_, nextMarker_};
+  return {annotations_,        backgroundStyle_,     selection_,
+          selectedAnnotation_, selectedAnnotations_, nextMarker_,
+          cuts_};
 }
 
 void CaptureEditor::applyEditState(const EditState &state) {
@@ -926,6 +933,10 @@ void CaptureEditor::applyEditState(const EditState &state) {
       !selectedAnnotations_.contains(selectedAnnotation_))
     selectedAnnotations_.push_back(selectedAnnotation_);
   nextMarker_ = state.nextMarker;
+  if (state.cuts != cuts_) {
+    cuts_ = state.cuts;
+    refreshComposedCapture();
+  }
   editingAnnotation_ = -1;
   interaction_ = Interaction::None;
   freehandPoints_.clear();
@@ -2294,6 +2305,17 @@ void CaptureEditor::updatePointerCursor() {
     setCursor(Qt::IBeamCursor);
   else
     setCursor(Qt::CrossCursor);
+}
+
+void CaptureEditor::refreshComposedCapture(const CutOp *liveCut) {
+  QVector<CutOp> cuts = cuts_;
+  if (liveCut)
+    cuts.push_back(*liveCut);
+  capture_.source = composeCuts(pristineSource_, cuts);
+  capture_.previewSize = composedLogicalSize(pristineLogicalSize_, cuts);
+  backdropKey_ = 0;           // force backdrop pixmap rebuild
+  redactionBaseStale_ = true; // force redaction layer rebuild
+  update();
 }
 
 void CaptureEditor::refreshBackdropCache() {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -306,7 +306,12 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
   connect(&snapshotWatcher_, &QFutureWatcher<bool>::finished, this, [this] {
     snapshotBusy_ = false;
     snapshotWriteOk_ = snapshotWatcher_.result();
-    if (snapshotDirty_)
+    // Don't chain a re-render while a cut drag is live: capture_ is
+    // transiently composed with liveCut_ mid-drag, and copying it here would
+    // persist a phantom cut into the crash-recovery snapshot. snapshotDirty_
+    // stays set, so the cut's own scheduleSnapshot() call on release (or
+    // cancellation) picks the committed state back up.
+    if (snapshotDirty_ && !cutDragActive_)
       startSnapshotRender();
   });
 
@@ -323,6 +328,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
             capture_ = job.capture;
             pristineSource_ = capture_.source;
             pristineLogicalSize_ = capture_.previewSize;
+            cuts_.clear();
             redactionBaseStale_ = true;
             switch (pendingMode_) {
             case CaptureMode::Fullscreen:
@@ -363,6 +369,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     capture_.previewSize = job.scaledSize;
     pristineSource_ = capture_.source;
     pristineLogicalSize_ = capture_.previewSize;
+    cuts_.clear();
     selection_ = QRectF(QPointF(), job.scaledSize);
     redactionBaseStale_ = true;
     windowMode_ = false;
@@ -1511,6 +1518,19 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     return;
   }
 
+  if (cutDragActive_) {
+    // Any key here (Esc's own cancel already returned above) leaves the
+    // live cut with no clean way to finish: Enter/Ctrl+C/Ctrl+S/P would
+    // export/pin capture_ still composed with liveCut_, and a tool-switch
+    // key changes tool_ so mouseReleaseEvent's Cut branch never runs,
+    // stranding cutDragActive_. Cancel first, same cleanup as
+    // handleEscape(), then let the key's own handling run below.
+    cutDragActive_ = false;
+    dragging_ = false;
+    refreshComposedCapture();
+    setStatus(QStringLiteral("Cut cancelled"));
+  }
+
   const bool redoShortcut = event->matches(QKeySequence::Redo) ||
                             (event->key() == Qt::Key_Y &&
                              event->modifiers().testFlag(Qt::ControlModifier));
@@ -2209,12 +2229,28 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       update();
       return;
     }
-    recordEdit(); // push pre-cut state (with the OLD selection/annotations)
-    cuts_.push_back(liveCut_);
     const qreal lo = cutBandLo_;
     const qreal hi = cutBandHi_;
     const bool horizontal = liveCut_.orientation == Qt::Horizontal;
     const qreal band = hi - lo;
+    const qreal extent =
+        horizontal ? selection_.height() : selection_.width();
+    if (band <= 0.0 || band >= extent) {
+      // Full-extent (or empty) band: toAnnotationPoint clamps lo/hi to
+      // [0, extent], so an edge-to-edge drag on a full selection lands
+      // exactly here. removeBand() no-ops on this band, so applying it
+      // would still shrink composedLogicalSize/selection_ while the actual
+      // pixels don't shrink -- desyncing preview size from the source
+      // aspect. Bail out instead.
+      cutDragActive_ = false;
+      refreshComposedCapture();
+      setStatus(QStringLiteral("Cut too large — nothing left"));
+      updatePointerCursor();
+      update();
+      return;
+    }
+    recordEdit(); // push pre-cut state (with the OLD selection/annotations)
+    cuts_.push_back(liveCut_);
     for (Annotation &annotation : annotations_) {
       // Shift every stored coordinate on the cut axis: horizontal cut shifts
       // y values, vertical cut shifts x values.

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -97,6 +97,8 @@ QString toolAction(CaptureEditor::Tool tool) {
     return QStringLiteral("tool-rectangle");
   case CaptureEditor::Tool::Redact:
     return QStringLiteral("tool-redact");
+  case CaptureEditor::Tool::Cut:
+    return QStringLiteral("tool-cut");
   case CaptureEditor::Tool::Text:
     return QStringLiteral("tool-text");
   case CaptureEditor::Tool::Ocr:
@@ -866,6 +868,8 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(36, QStringLiteral("tool-redact"), {},
       QStringLiteral("Redact · D · %1 · D again toggles")
           .arg(redactionStyleName(redactionStyle_)));
+  add(36, QStringLiteral("tool-cut"), {},
+      QStringLiteral("Cut out a band · X · drag across"));
   add(36, QStringLiteral("tool-text"), {},
       QStringLiteral("Neucha text · T · %1 · Wheel")
           .arg(QString::fromLatin1(
@@ -956,6 +960,10 @@ void CaptureEditor::cancelActiveDragForHistory() {
   dragStartStateValid_ = false;
   dragChanged_ = false;
   freehandPoints_.clear();
+  if (cutDragActive_) {
+    cutDragActive_ = false;
+    refreshComposedCapture();
+  }
 }
 
 void CaptureEditor::pushUndoState(const EditState &state) {
@@ -1121,6 +1129,15 @@ void CaptureEditor::enterEdit(QString status) {
 }
 
 void CaptureEditor::handleEscape() {
+  if (cutDragActive_) {
+    cutDragActive_ = false;
+    dragging_ = false;
+    refreshComposedCapture();
+    setStatus(QStringLiteral("Cut cancelled"));
+    updatePointerCursor();
+    update();
+    return;
+  }
   const qint64 closeWindowMs =
       static_cast<qint64>(QApplication::doubleClickInterval()) * 2;
   if (escapeTimer_.isValid() && escapeTimer_.elapsed() <= closeWindowMs) {
@@ -1378,6 +1395,10 @@ void CaptureEditor::handleToolbar(const QString &action) {
     selectedAnnotation_ = -1;
     setStatus(QStringLiteral("Redact: %1 · drag sensitive content · D toggles")
                   .arg(redactionStyleName(redactionStyle_)));
+  } else if (action == QStringLiteral("tool-cut")) {
+    tool_ = Tool::Cut;
+    selectedAnnotation_ = -1;
+    setStatus(QStringLiteral("Cut: drag across a band to remove it"));
   } else if (action == QStringLiteral("tool-text"))
     tool_ = Tool::Text;
   else if (action == QStringLiteral("tool-eyedropper")) {
@@ -1572,6 +1593,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
           QStringLiteral("Redact: %1 · drag sensitive content · D toggles")
               .arg(redactionStyleName(redactionStyle_)));
     }
+  } else if (event->key() == Qt::Key_X) {
+    tool_ = Tool::Cut;
+    setStatus(QStringLiteral("Cut: drag across a band to remove it"));
   } else if (event->key() == Qt::Key_T) {
     tool_ = Tool::Text;
   } else if (event->key() == Qt::Key_I) {
@@ -1778,6 +1802,53 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
       }
       }
       dragChanged_ = true;
+    }
+    if (tool_ == Tool::Cut && dragging_) {
+      const QPointF point = toAnnotationPoint(cursor_);
+      const QPointF delta = point - cutDragStart_;
+      if (!cutDragActive_ &&
+          std::max(std::abs(delta.x()), std::abs(delta.y())) > 3.0) {
+        cutDragActive_ = true;
+        // Dominant vertical delta cuts a horizontal band (rows); dominant
+        // horizontal delta cuts a vertical band (columns).
+        liveCut_.orientation = std::abs(delta.y()) >= std::abs(delta.x())
+                                    ? Qt::Horizontal
+                                    : Qt::Vertical;
+        // Cache the source/preview ratio and selection origin as of *now*
+        // (before this move's refreshComposedCapture call below shrinks
+        // capture_). Re-deriving them from capture_ on later moves would
+        // drift because refreshComposedCapture(&liveCut_) recomposes a
+        // shrunk preview every frame.
+        cutDragOriginOffset_ = liveCut_.orientation == Qt::Horizontal
+                                    ? selection_.top()
+                                    : selection_.left();
+        cutDragRatio_ =
+            liveCut_.orientation == Qt::Horizontal
+                ? capture_.source.height() /
+                      static_cast<qreal>(capture_.previewSize.height())
+                : capture_.source.width() /
+                      static_cast<qreal>(capture_.previewSize.width());
+      }
+      if (cutDragActive_) {
+        const bool horizontal = liveCut_.orientation == Qt::Horizontal;
+        const qreal a = horizontal ? cutDragStart_.y() : cutDragStart_.x();
+        const qreal b = horizontal ? point.y() : point.x();
+        const qreal lo = std::min(a, b);
+        const qreal hi = std::max(a, b);
+        cutBandLo_ = lo;
+        cutBandHi_ = hi;
+        // Annotation space is selection-relative logical px; map to
+        // absolute logical, then to native source px via the cached ratio.
+        liveCut_.sourceStart = static_cast<int>(
+            std::round((cutDragOriginOffset_ + lo) * cutDragRatio_));
+        liveCut_.sourceEnd = static_cast<int>(
+            std::round((cutDragOriginOffset_ + hi) * cutDragRatio_));
+        liveCut_.logicalStart =
+            static_cast<int>(std::round(cutDragOriginOffset_ + lo));
+        liveCut_.logicalEnd =
+            static_cast<int>(std::round(cutDragOriginOffset_ + hi));
+        refreshComposedCapture(&liveCut_);
+      }
     }
     if ((tool_ == Tool::Freehand || tool_ == Tool::Highlighter) && dragging_) {
       const QPointF point = toAnnotationPoint(cursor_);
@@ -2042,6 +2113,13 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     updatePointerCursor();
   } else if (tool_ == Tool::Text) {
     beginText(point);
+  } else if (tool_ == Tool::Cut) {
+    // Activation waits for a dominant drag axis (see mouseMoveEvent); a
+    // plain click never crosses that threshold and mouseReleaseEvent treats
+    // it as a no-op.
+    cutDragStart_ = point;
+    cutDragActive_ = false;
+    dragging_ = true;
   } else {
     dragStart_ = point;
     dragging_ = true;
@@ -2119,6 +2197,46 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
           "Crop updated · Select moves layers · wheel zooms selected layer"));
     if (changed)
       scheduleSnapshot();
+    updatePointerCursor();
+    update();
+    return;
+  }
+
+  if (tool_ == Tool::Cut) {
+    dragging_ = false;
+    if (!cutDragActive_) {
+      // Plain click: never crossed the activation threshold, no-op.
+      update();
+      return;
+    }
+    recordEdit(); // push pre-cut state (with the OLD selection/annotations)
+    cuts_.push_back(liveCut_);
+    const qreal lo = cutBandLo_;
+    const qreal hi = cutBandHi_;
+    const bool horizontal = liveCut_.orientation == Qt::Horizontal;
+    const qreal band = hi - lo;
+    for (Annotation &annotation : annotations_) {
+      // Shift every stored coordinate on the cut axis: horizontal cut shifts
+      // y values, vertical cut shifts x values.
+      auto shift = [&](QPointF &point) {
+        if (horizontal)
+          point.setY(shiftForCut(point.y(), lo, hi));
+        else
+          point.setX(shiftForCut(point.x(), lo, hi));
+      };
+      shift(annotation.start);
+      shift(annotation.end);
+      for (QPointF &point : annotation.points)
+        shift(point);
+    }
+    if (horizontal)
+      selection_.setHeight(std::max<qreal>(1.0, selection_.height() - band));
+    else
+      selection_.setWidth(std::max<qreal>(1.0, selection_.width() - band));
+    cutDragActive_ = false;
+    refreshComposedCapture();
+    scheduleSnapshot();
+    setStatus(QStringLiteral("Cut applied · Ctrl+Z to undo"));
     updatePointerCursor();
     update();
     return;
@@ -2303,6 +2421,8 @@ void CaptureEditor::updatePointerCursor() {
     setCursor(Qt::PointingHandCursor);
   else if (tool_ == Tool::Text)
     setCursor(Qt::IBeamCursor);
+  else if (tool_ == Tool::Cut)
+    setCursor(Qt::CrossCursor);
   else
     setCursor(Qt::CrossCursor);
 }
@@ -2506,7 +2626,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         AnnotationLayer::Default)
       defaultAnnotations.push_back(annotations_.at(index));
   }
-  if (dragging_ && tool_ != Tool::Select && tool_ != Tool::Redact) {
+  if (dragging_ && tool_ != Tool::Select && tool_ != Tool::Redact &&
+      tool_ != Tool::Cut) {
     Annotation preview;
     if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
       preview.kind = tool_ == Tool::Highlighter ? Annotation::Kind::Highlighter
@@ -2562,6 +2683,21 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         QPen(QColor(QStringLiteral("#0a84ff")), 2.0 / scale));
     painter.setBrush(QColor(10, 132, 255, 38));
     painter.drawRect(marqueeRect_.normalized());
+  }
+  if (cutDragActive_) {
+    // Snagit-style joint marker: shows where the two edges will seam once
+    // the band collapses. `cutBandLo_` is already in this block's
+    // annotation-space coordinate system (selection-relative logical px).
+    const qreal scale = std::max<qreal>(editScale(), 0.01);
+    painter.setPen(
+        QPen(QColor(QStringLiteral("#0a84ff")), 1.0 / scale, Qt::DashLine));
+    painter.setBrush(Qt::NoBrush);
+    if (liveCut_.orientation == Qt::Horizontal)
+      painter.drawLine(QPointF(0, cutBandLo_),
+                       QPointF(selection_.width(), cutBandLo_));
+    else
+      painter.drawLine(QPointF(cutBandLo_, 0),
+                       QPointF(cutBandLo_, selection_.height()));
   }
 
   if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2894,6 +2894,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
        {QStringLiteral("F / H"), QStringLiteral("Freehand / Highlighter")},
        {QStringLiteral("C"), QStringLiteral("Marker")},
        {QStringLiteral("R / D"), QStringLiteral("Rectangle / Redact")},
+       {QStringLiteral("X"), QStringLiteral("Cut out a band")},
        {QStringLiteral("T"), QStringLiteral("Text")},
        {QStringLiteral("Double click"), QStringLiteral("Edit text layer")},
        {QStringLiteral("1–6"), QStringLiteral("Color")},

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -218,7 +218,7 @@ private:
   int hoveredWindow_ = -1;
   int colorIndex_ = 0;
   PaletteConfig paletteConfig_ = defaultPaletteConfig();
-  QColor customColor_ = QColor(QStringLiteral("#ff375f"));
+  QColor customColor_;
   qreal customHue_ = 0.98;
   int nextMarker_ = 1;
   qreal annotationSize_ = 4.0;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "capture.hpp"
+#include "palette-config.hpp"
 
 #include <QElapsedTimer>
 #include <QFutureWatcher>
@@ -195,6 +196,7 @@ private:
   bool usingCustomColor_ = false;
   int hoveredWindow_ = -1;
   int colorIndex_ = 0;
+  PaletteConfig paletteConfig_ = defaultPaletteConfig();
   QColor customColor_ = QColor(QStringLiteral("#ff375f"));
   qreal customHue_ = 0.98;
   int nextMarker_ = 1;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -80,6 +80,7 @@ public:
     Marker,
     Rectangle,
     Redact,
+    Cut,
     Text,
     Ocr,
     Eyedropper
@@ -196,6 +197,18 @@ private:
   bool marqueeAdditive_ = false;
   Interaction interaction_ = Interaction::None;
   QVector<QPointF> freehandPoints_;
+  // Cut tool live-drag state. cutDragStart_/cutBandLo_/cutBandHi_ and
+  // liveCut_.orientation are in annotation space (selection-relative logical
+  // px); cutDragRatio_/cutDragOriginOffset_ are cached once the drag axis
+  // locks so later moves (which recompose a shrinking capture_ each frame)
+  // don't re-derive them from a live preview that has already collapsed.
+  bool cutDragActive_ = false;
+  QPointF cutDragStart_;
+  CutOp liveCut_;
+  qreal cutBandLo_ = 0.0;
+  qreal cutBandHi_ = 0.0;
+  qreal cutDragRatio_ = 1.0;
+  qreal cutDragOriginOffset_ = 0.0;
   bool windowMode_ = false;
   BackgroundStyle backgroundStyle_ = BackgroundStyle::None;
   bool busy_ = false;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "capture.hpp"
+#include "cut.hpp"
 #include "palette-config.hpp"
 
 #include <QElapsedTimer>
@@ -122,6 +123,7 @@ private:
     int selectedAnnotation = -1;
     QVector<int> selectedAnnotations;
     int nextMarker = 1;
+    QVector<CutOp> cuts;
   };
 
   [[nodiscard]] QRectF annotationBounds(const Annotation &annotation) const;
@@ -167,6 +169,7 @@ private:
   void paintEdit(QPainter &painter);
   void paintSelect(QPainter &painter);
   void refreshBackdropCache();
+  void refreshComposedCapture(const CutOp *liveCut = nullptr);
   void runOcr(const QRectF &localSelection = {});
   void setStatus(QString status);
   void scaleSelectedAnnotation(qreal factor);
@@ -174,6 +177,11 @@ private:
   void updatePointerCursor();
 
   CaptureData capture_;
+  // Untouched capture, kept alongside cuts_ so cuts can be recomposed from
+  // scratch (undo/redo, in-progress cut preview) without accumulating error.
+  QImage pristineSource_;
+  QSize pristineLogicalSize_;
+  QVector<CutOp> cuts_;
   Phase phase_ = Phase::Select;
   Tool tool_ = Tool::Select;
   QRectF selection_;

--- a/src/icons.cpp
+++ b/src/icons.cpp
@@ -80,6 +80,16 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
           painter.drawRect(QRectF(x, y, 3, 3));
       }
     }
+  } else if (action == QStringLiteral("tool-cut")) {
+    painter.drawLine(QPointF(5, 5), QPointF(19, 19));
+    painter.drawLine(QPointF(19, 5), QPointF(5, 19));
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(color);
+    painter.drawEllipse(QPointF(12, 12), 1.5, 1.5);
+    painter.setPen(QPen(color, 2.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter.setBrush(Qt::NoBrush);
+    painter.drawEllipse(QPointF(5, 5), 2.4, 2.4);
+    painter.drawEllipse(QPointF(5, 19), 2.4, 2.4);
   } else if (action == QStringLiteral("tool-text")) {
     painter.drawLine(QPointF(5, 5), QPointF(19, 5));
     painter.drawLine(QPointF(12, 5), QPointF(12, 19));

--- a/src/icons.cpp
+++ b/src/icons.cpp
@@ -81,15 +81,11 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
       }
     }
   } else if (action == QStringLiteral("tool-cut")) {
-    painter.drawLine(QPointF(5, 5), QPointF(19, 19));
-    painter.drawLine(QPointF(19, 5), QPointF(5, 19));
-    painter.setPen(Qt::NoPen);
-    painter.setBrush(color);
-    painter.drawEllipse(QPointF(12, 12), 1.5, 1.5);
-    painter.setPen(QPen(color, 2.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-    painter.setBrush(Qt::NoBrush);
-    painter.drawEllipse(QPointF(5, 5), 2.4, 2.4);
-    painter.drawEllipse(QPointF(5, 19), 2.4, 2.4);
+    // Two image halves with the removed band collapsing between them.
+    painter.drawRect(QRectF(5, 4, 14, 5.5));
+    painter.drawRect(QRectF(5, 14.5, 14, 5.5));
+    painter.setPen(QPen(color, 1.4, Qt::DashLine, Qt::FlatCap));
+    painter.drawLine(QPointF(5, 12), QPointF(19, 12));
   } else if (action == QStringLiteral("tool-text")) {
     painter.drawLine(QPointF(5, 5), QPointF(19, 5));
     painter.drawLine(QPointF(12, 5), QPointF(12, 19));

--- a/src/palette-config.cpp
+++ b/src/palette-config.cpp
@@ -1,0 +1,37 @@
+/** @fileoverview Loads editor preset colors from the user's INI config. */
+#include "palette-config.hpp"
+
+#include <QSettings>
+#include <QStandardPaths>
+#include <QStringList>
+
+PaletteConfig defaultPaletteConfig() {
+  return {{QColor(QStringLiteral("#ff375f")), QColor(QStringLiteral("#ff9f0a")),
+           QColor(QStringLiteral("#ffd60a")), QColor(QStringLiteral("#30d158")),
+           QColor(QStringLiteral("#0a84ff")), QColor(QStringLiteral("#bf5af2"))},
+          QColor(QStringLiteral("#ff375f"))};
+}
+
+PaletteConfig loadPaletteConfig(const QString &filePath) {
+  PaletteConfig config = defaultPaletteConfig();
+  QSettings settings(filePath, QSettings::IniFormat);
+  const QStringList palette =
+      settings.value(QStringLiteral("colors/palette")).toStringList();
+  for (int index = 0;
+       index < palette.size() && index < static_cast<int>(config.palette.size());
+       ++index) {
+    const QColor color(palette.at(index).trimmed());
+    if (color.isValid())
+      config.palette.at(static_cast<std::size_t>(index)) = color;
+  }
+  const QColor custom(
+      settings.value(QStringLiteral("colors/custom")).toString().trimmed());
+  if (custom.isValid())
+    config.custom = custom;
+  return config;
+}
+
+QString defaultPaletteConfigPath() {
+  return QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
+         QStringLiteral("/omasnap/omasnap.conf");
+}

--- a/src/palette-config.hpp
+++ b/src/palette-config.hpp
@@ -1,0 +1,23 @@
+/** @fileoverview Loads editor preset colors from the user's INI config. */
+#pragma once
+
+#include <QColor>
+#include <QString>
+#include <array>
+
+/** Editor color presets, loaded from the user's INI config or defaults. */
+struct PaletteConfig {
+  std::array<QColor, 6> palette;
+  QColor custom;
+};
+
+/** Built-in defaults (the colors previously hardcoded in editor.cpp). */
+[[nodiscard]] PaletteConfig defaultPaletteConfig();
+
+/** Reads [colors] palette (comma-separated hex list, up to 6 entries,
+ *  invalid entries keep the default for that slot) and [colors] custom from
+ *  an INI file. A missing file or key leaves defaults untouched. */
+[[nodiscard]] PaletteConfig loadPaletteConfig(const QString &filePath);
+
+/** ~/.config/omasnap/omasnap.conf (XDG config location). */
+[[nodiscard]] QString defaultPaletteConfigPath();

--- a/tests/cut-smoke.cpp
+++ b/tests/cut-smoke.cpp
@@ -1,0 +1,83 @@
+/** @fileoverview Tests the cut engine: band removal, replay, coordinate
+ *  shifting. */
+#include "cut-smoke.hpp"
+
+#include "cut.hpp"
+
+#include <QImage>
+#include <QVector>
+
+namespace {
+/** Creates a small image whose red channel stores easy-to-check values. */
+QImage indexedImage(const QVector<QVector<int>> &rows) {
+  QImage image(rows.constFirst().size(), rows.size(), QImage::Format_RGB32);
+  for (int y = 0; y < rows.size(); ++y) {
+    for (int x = 0; x < rows.at(y).size(); ++x)
+      image.setPixelColor(x, y, QColor(rows.at(y).at(x), 0, 0));
+  }
+  return image;
+}
+
+int redAt(const QImage &image, int x, int y) {
+  return image.pixelColor(x, y).red();
+}
+} // namespace
+
+bool runCutSmoke(QString &error) {
+  // 4x4 image, rows valued 10,20,30,40.
+  const QImage source = indexedImage(
+      {{10, 10, 10, 10}, {20, 20, 20, 20}, {30, 30, 30, 30}, {40, 40, 40, 40}});
+
+  // Horizontal band removes rows [1,3): rows 20 and 30 vanish, 40 moves up.
+  const QImage rows = removeBand(source, Qt::Horizontal, 1, 3);
+  if (rows.size() != QSize(4, 2) || redAt(rows, 0, 0) != 10 ||
+      redAt(rows, 0, 1) != 40) {
+    error = QStringLiteral("horizontal removeBand produced wrong image");
+    return false;
+  }
+
+  // Vertical band removes columns [0,2) from a column-indexed image.
+  const QImage cols = removeBand(
+      indexedImage({{1, 2, 3, 4}, {1, 2, 3, 4}}), Qt::Vertical, 0, 2);
+  if (cols.size() != QSize(2, 2) || redAt(cols, 0, 0) != 3 ||
+      redAt(cols, 1, 0) != 4) {
+    error = QStringLiteral("vertical removeBand produced wrong image");
+    return false;
+  }
+
+  // Out-of-range bounds clamp; empty and full-extent bands are no-ops.
+  if (removeBand(source, Qt::Horizontal, -5, 1).height() != 3 ||
+      removeBand(source, Qt::Horizontal, 2, 2) != source ||
+      removeBand(source, Qt::Horizontal, 0, 99) != source) {
+    error = QStringLiteral("removeBand bounds handling wrong");
+    return false;
+  }
+
+  // Replay: two sequential cuts, each in the coordinates of its moment.
+  // Cut A removes row 1 (value 20); cut B then removes row 1 of the
+  // remaining 10,30,40 image (value 30) -> 10,40.
+  const QVector<CutOp> cuts{{Qt::Horizontal, 1, 2, 1, 2},
+                            {Qt::Horizontal, 1, 2, 1, 2}};
+  const QImage replayed = composeCuts(source, cuts);
+  if (replayed.size() != QSize(4, 2) || redAt(replayed, 0, 0) != 10 ||
+      redAt(replayed, 0, 1) != 40) {
+    error = QStringLiteral("composeCuts replay wrong");
+    return false;
+  }
+
+  if (composedLogicalSize(QSize(100, 80), cuts) != QSize(100, 78)) {
+    error = QStringLiteral("composedLogicalSize wrong");
+    return false;
+  }
+
+  // Coordinate shifting: before band unchanged, inside clamps to seam,
+  // after shifts back by the band size.
+  if (shiftForCut(3.0, 5.0, 10.0) != 3.0 ||
+      shiftForCut(7.0, 5.0, 10.0) != 5.0 ||
+      shiftForCut(12.0, 5.0, 10.0) != 7.0) {
+    error = QStringLiteral("shiftForCut wrong");
+    return false;
+  }
+
+  return true;
+}

--- a/tests/cut-smoke.cpp
+++ b/tests/cut-smoke.cpp
@@ -79,5 +79,18 @@ bool runCutSmoke(QString &error) {
     return false;
   }
 
+  // Vertical band removal must preserve alpha: create ARGB32 image with
+  // semi-transparent pixel, remove a vertical band, verify alpha is unchanged.
+  QImage alphaSource(4, 2, QImage::Format_ARGB32);
+  alphaSource.fill(QColor(0, 0, 0, 255)); // Opaque black
+  alphaSource.setPixelColor(2, 0, QColor(255, 0, 0, 128)); // Semi-transparent red
+  const QImage alphaCut = removeBand(alphaSource, Qt::Vertical, 0, 2);
+  if (alphaCut.size() != QSize(2, 2) ||
+      alphaCut.pixelColor(0, 0) != QColor(255, 0, 0, 128) ||
+      alphaCut.pixelColor(0, 1) != QColor(0, 0, 0, 255)) {
+    error = QStringLiteral("vertical removeBand alpha preservation failed");
+    return false;
+  }
+
   return true;
 }

--- a/tests/cut-smoke.cpp
+++ b/tests/cut-smoke.cpp
@@ -70,6 +70,16 @@ bool runCutSmoke(QString &error) {
     return false;
   }
 
+  // A full-extent band is a no-op in removeBand(); composedLogicalSize must
+  // agree and leave the size unchanged rather than shrinking it (which would
+  // desync the preview size from the actual, unchanged pixels).
+  const QVector<CutOp> fullExtentCut{{Qt::Horizontal, 0, 80, 0, 80}};
+  if (composedLogicalSize(QSize(100, 80), fullExtentCut) != QSize(100, 80)) {
+    error = QStringLiteral(
+        "composedLogicalSize shrank on a full-extent band");
+    return false;
+  }
+
   // Coordinate shifting: before band unchanged, inside clamps to seam,
   // after shifts back by the band size.
   if (shiftForCut(3.0, 5.0, 10.0) != 3.0 ||

--- a/tests/cut-smoke.hpp
+++ b/tests/cut-smoke.hpp
@@ -1,0 +1,6 @@
+/** @fileoverview Declares the cut-engine smoke test. */
+#pragma once
+
+#include <QString>
+
+[[nodiscard]] bool runCutSmoke(QString &error);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -3,6 +3,7 @@
 #include "capture.hpp"
 #include "cli-path.hpp"
 #include "clipboard-smoke.hpp"
+#include "cut-smoke.hpp"
 #include "editor.hpp"
 #include "instance-lock-smoke.hpp"
 #include "pin-layout-smoke.hpp"
@@ -2408,6 +2409,13 @@ int main(int argc, char **argv) {
     qWarning().noquote() << transformError;
     return 67;
   }
+
+  QString cutError;
+  if (!runCutSmoke(cutError)) {
+    qWarning().noquote() << "cut smoke failed:" << cutError;
+    return EXIT_FAILURE;
+  }
+
   QString instanceError;
   if (!runInstanceLockSmoke(instanceError)) {
     qWarning().noquote() << instanceError;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1204,6 +1204,137 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
   editor.close();
   return true;
 }
+
+/**
+ * Exercises the cut tool end to end: tool selection/cursor, a plain click
+ * being a no-op, a vertical drag removing a horizontal band (height
+ * shrinks), a horizontal drag removing a vertical band (width shrinks), and
+ * undo/redo restoring/reapplying both cuts. The synthetic capture is 1:1
+ * (source size == previewSize), so annotation-space, logical, and native
+ * source px all coincide and the editor's display scale is exactly 1.0 for
+ * every selection size used here (see editImageRect()'s available-rect math:
+ * a 600-wide, <=400-tall selection always fits under scale 1.0 in an 800x600
+ * widget), which keeps the expected band sizes exact integers.
+ */
+bool runCutToolSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(700, 500), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(700, 500));
+  application.processEvents();
+
+  const QImage originalOutput = editor.renderCurrentOutput();
+  if (originalOutput.isNull()) {
+    error = QStringLiteral("Cut smoke: initial selection produced no output");
+    return false;
+  }
+  const int originalWidth = originalOutput.width();
+  const int originalHeight = originalOutput.height();
+
+  QTest::keyClick(&editor, Qt::Key_X);
+  application.processEvents();
+  if (editor.cursor().shape() != Qt::CrossCursor) {
+    error = QStringLiteral("Cut tool did not set cross cursor");
+    return false;
+  }
+
+  // A plain click never crosses the drag-activation threshold, so it must
+  // be a no-op.
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 200));
+  application.processEvents();
+  if (editor.renderCurrentOutput() != originalOutput) {
+    error = QStringLiteral("Plain click with the cut tool changed the output");
+    return false;
+  }
+
+  // Dominant-vertical delta locks a horizontal band (rows removed): the
+  // image collapses vertically, so height shrinks by the band size.
+  constexpr int band1 = 60;
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(150, 200));
+  QTest::mouseMove(&editor, QPoint(150, 200 + band1), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(150, 200 + band1));
+  application.processEvents();
+
+  const QImage afterCut1 = editor.renderCurrentOutput();
+  if (afterCut1.width() != originalWidth ||
+      afterCut1.height() != originalHeight - band1) {
+    error = QStringLiteral(
+                "Vertical drag did not shrink height by the band size: "
+                "expected %1x%2, got %3x%4")
+                .arg(originalWidth)
+                .arg(originalHeight - band1)
+                .arg(afterCut1.width())
+                .arg(afterCut1.height());
+    return false;
+  }
+
+  // Dominant-horizontal delta locks a vertical band (columns removed):
+  // width shrinks by the band size, height stays as cut1 left it.
+  constexpr int band2 = 80;
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 200));
+  QTest::mouseMove(&editor, QPoint(300 + band2, 200), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(300 + band2, 200));
+  application.processEvents();
+
+  const QImage afterCut2 = editor.renderCurrentOutput();
+  if (afterCut2.width() != originalWidth - band2 ||
+      afterCut2.height() != originalHeight - band1) {
+    error = QStringLiteral(
+                "Horizontal drag did not shrink width by the band size: "
+                "expected %1x%2, got %3x%4")
+                .arg(originalWidth - band2)
+                .arg(originalHeight - band1)
+                .arg(afterCut2.width())
+                .arg(afterCut2.height());
+    return false;
+  }
+
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  const QImage afterUndo = editor.renderCurrentOutput();
+  if (afterUndo.width() != originalWidth || afterUndo.height() != originalHeight) {
+    error = QStringLiteral(
+                "Two undoEdit calls did not restore the original size: got %1x%2")
+                .arg(afterUndo.width())
+                .arg(afterUndo.height());
+    return false;
+  }
+
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  const QImage afterRedo = editor.renderCurrentOutput();
+  if (afterRedo.width() != afterCut2.width() ||
+      afterRedo.height() != afterCut2.height()) {
+    error = QStringLiteral(
+                "Two redoEdit calls did not reapply both cuts: got %1x%2")
+                .arg(afterRedo.width())
+                .arg(afterRedo.height());
+    return false;
+  }
+
+  editor.close();
+  return true;
+}
+
 bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
   QTemporaryDir commands;
   if (!commands.isValid()) {
@@ -1500,6 +1631,10 @@ int main(int argc, char **argv) {
   if (!runSpotlightWheelSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 94;
+  }
+  if (!runCutToolSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 95;
   }
   const QString outputRoot =
       argc > 1 ? QString::fromLocal8Bit(argv[1])

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -6,6 +6,7 @@
 #include "cut-smoke.hpp"
 #include "editor.hpp"
 #include "instance-lock-smoke.hpp"
+#include "palette-config-smoke.hpp"
 #include "pin-layout-smoke.hpp"
 #include "pin-lifecycle-smoke.hpp"
 #include "transform-smoke.hpp"
@@ -2413,6 +2414,12 @@ int main(int argc, char **argv) {
   QString cutError;
   if (!runCutSmoke(cutError)) {
     qWarning().noquote() << "cut smoke failed:" << cutError;
+    return EXIT_FAILURE;
+  }
+
+  QString paletteError;
+  if (!runPaletteConfigSmoke(paletteError)) {
+    qWarning().noquote() << "palette config smoke failed:" << paletteError;
     return EXIT_FAILURE;
   }
 

--- a/tests/palette-config-smoke.cpp
+++ b/tests/palette-config-smoke.cpp
@@ -1,0 +1,67 @@
+/** @fileoverview Tests INI palette loading: full, partial, invalid, missing. */
+#include "palette-config-smoke.hpp"
+
+#include "palette-config.hpp"
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+
+namespace {
+bool writeFile(const QString &path, const QByteArray &contents) {
+  QFile file(path);
+  return file.open(QIODevice::WriteOnly) &&
+         file.write(contents) == contents.size();
+}
+} // namespace
+
+bool runPaletteConfigSmoke(QString &error) {
+  QTemporaryDir dir;
+  if (!dir.isValid()) {
+    error = QStringLiteral("could not create temporary directory");
+    return false;
+  }
+  const PaletteConfig defaults = defaultPaletteConfig();
+
+  // Missing file -> defaults.
+  const PaletteConfig missing =
+      loadPaletteConfig(dir.filePath(QStringLiteral("absent.conf")));
+  if (missing.palette != defaults.palette || missing.custom != defaults.custom) {
+    error = QStringLiteral("missing file did not fall back to defaults");
+    return false;
+  }
+
+  // Full config overrides all six slots and the custom seed.
+  const QString full = dir.filePath(QStringLiteral("full.conf"));
+  if (!writeFile(full, "[colors]\n"
+                       "palette=#FF5D62,#3150AA,#98BB6C,#FFA066,#D27E99,#DCD7BA\n"
+                       "custom=#FF5D62\n")) {
+    error = QStringLiteral("could not write full config");
+    return false;
+  }
+  const PaletteConfig loaded = loadPaletteConfig(full);
+  if (loaded.palette.at(0) != QColor(QStringLiteral("#FF5D62")) ||
+      loaded.palette.at(5) != QColor(QStringLiteral("#DCD7BA")) ||
+      loaded.custom != QColor(QStringLiteral("#FF5D62"))) {
+    error = QStringLiteral("full config not applied");
+    return false;
+  }
+
+  // Partial palette overrides only the first N; an invalid entry keeps the
+  // default for its slot.
+  const QString partial = dir.filePath(QStringLiteral("partial.conf"));
+  if (!writeFile(partial, "[colors]\npalette=#112233,nonsense\n")) {
+    error = QStringLiteral("could not write partial config");
+    return false;
+  }
+  const PaletteConfig sparse = loadPaletteConfig(partial);
+  if (sparse.palette.at(0) != QColor(QStringLiteral("#112233")) ||
+      sparse.palette.at(1) != defaults.palette.at(1) ||
+      sparse.palette.at(2) != defaults.palette.at(2) ||
+      sparse.custom != defaults.custom) {
+    error = QStringLiteral("partial config handling wrong");
+    return false;
+  }
+
+  return true;
+}

--- a/tests/palette-config-smoke.hpp
+++ b/tests/palette-config-smoke.hpp
@@ -1,0 +1,6 @@
+/** @fileoverview Declares the palette-config smoke test. */
+#pragma once
+
+#include <QString>
+
+[[nodiscard]] bool runPaletteConfigSmoke(QString &error);


### PR DESCRIPTION
I added a feature that I originally missed in Snagit and built [Omapic](https://github.com/sspaeti/Omapic) for it  to get out in between the images quickly (see the README for how the feature works with a video or image). After seeing Omasnap, I ported that feature to it and added a custom color palette as well, since I like to use my custom colors.

Not sure if any of the features is desired for Omasnap, but I just share the PR to pick and choose what would make sense. It's created with Claude Code (Fable).

## Details
Here are the details - and two additions:

**Cut out (`X`)** — remove a horizontal or vertical band from the capture and collapse the gap. Drag direction picks the orientation, the preview collapses live while dragging with a dashed seam indicator, and cuts integrate with undo/redo, save/copy/pin, and OCR. Ported from [Omapic](https://github.com/sspaeti/Omapic), which brought Snagit's ["cut out"](https://www.techsmith.com/learn/tutorials/snagit/cut-out/) to Linux — now native in the annotation editor.

https://github.com/user-attachments/assets/483fc995-fcb0-49ea-8531-00be8ccda729

<img width="2404" height="1540" alt="image" src="https://github.com/user-attachments/assets/7e13d09e-d9fd-4cdf-892d-24caf02f02de" />



**Configurable preset colors** — optional `~/.config/omasnap/omasnap.conf` (INI, read via QSettings):

```ini
[colors]
palette=#FF5D62,#3150AA,#98BB6C,#FFA066,#D27E99,#DCD7BA
custom=#FF5D62
```
this looks like this: 
<img width="1480" height="876" alt="image" src="https://github.com/user-attachments/assets/d0b9320c-8e41-4f03-aebf-694c9a19bc13" />

`palette` overrides the six toolbar presets (fewer entries override only the first N; invalid entries keep their default), `custom` seeds the custom color. Without a config file, behavior is unchanged.

Both come with smoke tests (cut engine incl. alpha preservation and full-extent guards; config loading incl. partial/invalid entries). The hotkey legend, README keys table, and features list are updated.