### PR TITLE
feat(editor): show the pixel size of the frame you are drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 ## Features
 
 - Freeform region, window, and full-monitor capture modes.
+- A pointer-side readout that turns any drag into a ruler: the pointer position
+  while the crosshair is idle, then the frame size in native export pixels while a
+  region, a hovered window, or a crop handle is being sized.
 - Clean window-surface capture through Wayland image-copy protocols. A failed native
   capture stays in the window picker; Omasnap never substitutes a crop of the desktop.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
@@ -239,7 +242,7 @@ Install the corresponding Tesseract language data before adding a language to
 
 | Input | Action |
 |---|---|
-| Drag | Select a region |
+| Drag | Select a region, with its native pixel size shown at the pointer |
 | `Space` | Toggle region/window selection |
 | `SUPER + Arrow` | Move among windows in window mode |
 | `Enter` | Capture the highlighted window |
@@ -322,8 +325,8 @@ QT_QPA_PLATFORM=offscreen \
 
 The smoke executable exercises region/window/fullscreen startup modes, capture selection,
 temporary snapshot updates, annotation tools, undo/redo, vector movement and scaling,
-text editing, OCR, native-DPI output, endpoint-only line selection, and external crop
-handles.
+text editing, OCR, native-DPI output, endpoint-only line selection, external crop
+handles, and the native-pixel measurement readout on a scaled monitor.
 
 `.github/workflows/build-linux.yml` performs the same release build and interaction smoke
 in an Arch Linux container, stages the CMake installation, and uploads a versioned Linux

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -165,6 +165,56 @@ void drawInstantTooltip(QPainter &painter, const QRect &bounds,
   painter.drawText(pill, Qt::AlignCenter, text);
 }
 
+/**
+ * Formats a native pixel size for the measurement readout. The number is the
+ * pixel count the export actually carries, which on a scaled monitor is not
+ * the logical size the pointer moves through.
+ */
+QString formatPixelSize(const QSizeF &size) {
+  return QStringLiteral("%1 × %2")
+      .arg(qRound(size.width()))
+      .arg(qRound(size.height()));
+}
+
+QString formatPixelPoint(const QPointF &point) {
+  return QStringLiteral("%1, %2").arg(qRound(point.x())).arg(qRound(point.y()));
+}
+
+/**
+ * Draws the measurement readout below-right of the pointer, flipping to the
+ * opposite side instead of clipping at an overlay edge. Digits use the fixed
+ * font so a live drag does not jitter the pill width per frame.
+ */
+void drawMeasureBadge(QPainter &painter, const QRect &bounds,
+                      const QPointF &cursor, const QString &text) {
+  if (text.isEmpty())
+    return;
+  QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+  font.setPixelSize(12);
+  font.setBold(true);
+  painter.setFont(font);
+  const qreal width = painter.fontMetrics().horizontalAdvance(text) + 16;
+  constexpr qreal height = 22;
+  constexpr qreal gap = 15;
+  constexpr qreal margin = 6;
+  qreal x = cursor.x() + gap;
+  if (x + width > bounds.width() - margin)
+    x = cursor.x() - gap - width;
+  qreal y = cursor.y() + gap;
+  if (y + height > bounds.height() - margin)
+    y = cursor.y() - gap - height;
+  const QRectF pill(
+      std::clamp(x, margin, std::max(margin, bounds.width() - width - margin)),
+      std::clamp(y, margin,
+                 std::max(margin, bounds.height() - height - margin)),
+      width, height);
+  painter.setPen(QPen(QColor(255, 255, 255, 42), 1));
+  painter.setBrush(QColor(12, 12, 15, 235));
+  painter.drawRoundedRect(pill, 6, 6);
+  painter.setPen(Qt::white);
+  painter.drawText(pill, Qt::AlignCenter, text);
+}
+
 void drawHotkeyLegend(QPainter &painter, const QRect &bounds,
                       const QPointF &cursor,
                       const QVector<QPair<QString, QString>> &entries) {
@@ -765,6 +815,32 @@ QRectF CaptureEditor::sourceRect(const QRectF &logicalRect) const {
       capture_.source.height() / static_cast<qreal>(capture_.previewSize.height());
   return {logicalRect.x() * scaleX, logicalRect.y() * scaleY,
           logicalRect.width() * scaleX, logicalRect.height() * scaleY};
+}
+
+QPointF CaptureEditor::sourcePoint(const QPointF &logicalPoint) const {
+  return sourceRect(QRectF(logicalPoint, QSizeF())).topLeft();
+}
+
+QString CaptureEditor::measurementText() const {
+  if (capture_.source.isNull())
+    return {};
+  if (phase_ == Phase::Select) {
+    if (windowMode_) {
+      if (hoveredWindow_ < 0 || hoveredWindow_ >= capture_.windows.size())
+        return {};
+      return formatPixelSize(
+          sourceRect(capture_.windows.at(hoveredWindow_).rect).size());
+    }
+    // A fresh drag reads 0 × 0 rather than falling back to the pointer
+    // position: the number must track the frame the moment it starts.
+    if (dragging_ || !selection_.isEmpty())
+      return formatPixelSize(sourceRect(selection_).size());
+    return formatPixelPoint(sourcePoint(cursor_));
+  }
+  if (tool_ == Tool::Select && dragging_ &&
+      interaction_ >= Interaction::CropTopLeft)
+    return formatPixelSize(sourceRect(selection_).size());
+  return {};
 }
 
 int CaptureEditor::windowAt(const QPointF &position) const {
@@ -2391,6 +2467,7 @@ void CaptureEditor::paintSelect(QPainter &painter) {
                     {QStringLiteral("Ctrl+A"), QStringLiteral("Fullscreen")},
                     {QStringLiteral("Esc ×2"), QStringLiteral("Close")}});
   drawStatusPill(painter, rect(), status_);
+  drawMeasureBadge(painter, rect(), cursor_, measurementText());
 }
 
 void CaptureEditor::paintEdit(QPainter &painter) {
@@ -2741,6 +2818,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       }
     }
   }
+  drawMeasureBadge(painter, rect(), cursor_, measurementText());
 }
 
 void CaptureEditor::paintEvent(QPaintEvent *event) {

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -46,6 +46,13 @@ public:
   bool waitForSnapshot();
   /** Renders the current selection and layer data for headless verification. */
   [[nodiscard]] QImage renderCurrentOutput() const;
+  /**
+   * Native-pixel readout drawn next to the pointer: the size of whatever frame
+   * is being drawn, or the pointer position while no frame exists yet. Empty
+   * when nothing is being measured. Public so the smoke suite can read the
+   * number without scraping it back out of the rendered overlay.
+   */
+  [[nodiscard]] QString measurementText() const;
   /** Current monitor data (background capture may be in flight). */
   const CaptureData &captureData() const { return capture_; }
 
@@ -139,6 +146,7 @@ private:
   [[nodiscard]] qreal editScale() const;
   [[nodiscard]] QPointF toAnnotationPoint(const QPointF &position) const;
   [[nodiscard]] QRectF sourceRect(const QRectF &logicalRect) const;
+  [[nodiscard]] QPointF sourcePoint(const QPointF &logicalPoint) const;
   [[nodiscard]] int windowAt(const QPointF &position) const;
   [[nodiscard]] int windowInDirection(int current, int key) const;
   [[nodiscard]] QVector<ToolbarButton> toolbarButtons() const;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -81,6 +81,79 @@ bool runBackdropCacheRenderingCheck(QString &error) {
   return true;
 }
 
+/**
+ * The pointer readout reports native export pixels, not the logical units the
+ * pointer travels through. On a 2x monitor a 450x310 drag exports 900x620, and
+ * quoting the logical number would make the overlay useless as a ruler.
+ */
+bool runMeasurementReadoutCheck(QString &error) {
+  CaptureData capture;
+  capture.monitor.geometry = QRect(0, 0, 800, 600);
+  capture.monitor.pixelSize = QSize(1600, 1200);
+  capture.monitor.scale = 2.0;
+  capture.source = QImage(1600, 1200, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#6480a0")));
+  capture.previewSize = QSize(800, 600);
+  capture.windows = {
+      {{80, 80, 300, 220}, QStringLiteral("1"), QStringLiteral("first")}};
+
+  CaptureEditor editor(capture);
+  // The readout is overlay-only, so this check never needs the working
+  // snapshot. Writing one would race the shared runtime path with the checks
+  // that follow.
+  editor.setSuppressSnapshots(true);
+  editor.resize(800, 600);
+  editor.show();
+  QApplication::processEvents();
+
+  const auto expect = [&editor, &error](const QString &wanted,
+                                        const QString &what) {
+    const QString actual = editor.measurementText();
+    if (actual == wanted)
+      return true;
+    error = QStringLiteral("%1 readout was \"%2\", expected \"%3\"")
+                .arg(what, actual, wanted);
+    return false;
+  };
+
+  QTest::mouseMove(&editor, QPoint(150, 120), 20);
+  QApplication::processEvents();
+  if (!expect(QStringLiteral("300, 240"), QStringLiteral("Idle pointer")))
+    return false;
+
+  QTest::keyClick(&editor, Qt::Key_Space);
+  QTest::mouseMove(&editor, QPoint(200, 150), 20);
+  QApplication::processEvents();
+  if (!expect(QStringLiteral("600 × 440"), QStringLiteral("Hovered window")))
+    return false;
+  QTest::keyClick(&editor, Qt::Key_Space);
+  QApplication::processEvents();
+
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(150, 120));
+  QApplication::processEvents();
+  if (!expect(QStringLiteral("0 × 0"), QStringLiteral("Fresh drag")))
+    return false;
+  QTest::mouseMove(&editor, QPoint(600, 430), 20);
+  QApplication::processEvents();
+  if (!expect(QStringLiteral("900 × 620"), QStringLiteral("Live drag")))
+    return false;
+
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(600, 430));
+  QApplication::processEvents();
+  // QTest carries one pointer position across every check in this binary and
+  // drops a move that repeats it, so this check parks the pointer somewhere no
+  // later check moves to first.
+  QTest::mouseMove(&editor, QPoint(512, 337), 20);
+  QApplication::processEvents();
+  // Annotating is not measuring: the badge must not shadow the canvas once the
+  // frame is settled.
+  if (!expect(QString(), QStringLiteral("Settled edit phase")))
+    return false;
+  editor.close();
+  return true;
+}
+
 /** Checks that positional local image targets are recognized. */
 bool runPositionalImageTargetCheck(QString &error) {
   QTemporaryDir directory;
@@ -1462,6 +1535,10 @@ int main(int argc, char **argv) {
   if (!runCreationConstraintCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 90;
+  }
+  if (!runMeasurementReadoutCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 95;
   }
   if (!runQuickOutputChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
I've used macOS for years, and one thing I always relied on is the crosshair in the screenshot tool: drag it over anything and it tells you the size in pixels. I use that constantly while developing.

That was the one thing I missed in omasnap, so I added it. The readout sits next to the pointer: the position while the crosshair is idle, and the frame size while you drag a region, hover a window, or pull a crop handle.

The number is native export pixels, so on a scaled monitor it matches the PNG that comes out.

https://github.com/user-attachments/assets/1ef587b8-7ed3-43b2-b965-7d0abf428b5b