### PR TITLE
feat: persist an op log and capture the monitor in-process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,10 @@ markers, text, OCR). Finished captures go to clipboard,
 |---|---|
 | `src/main.cpp` | CLI parsing, single-instance lock, mode dispatch (capture / edit file / pin) |
 | `src/instance-lock.cpp/.hpp` | Single-instance handover: cancel a running overlay, or stop it and take over for `--file` |
-| `src/capture.cpp/.hpp` | Capture selection overlay, rendering, output, and private runtime snapshots |
-| `src/editor.cpp/.hpp` | Annotation editor: tools, vector layers, undo/redo, rendering, export |
+| `src/capture.cpp/.hpp` | Capture, rendering, output, and source+JSON operation-log persistence |
+| `src/editor.cpp/.hpp` | Annotation editor: tools, vector layers, operation-log undo/redo, export |
 | `src/pin.cpp/.hpp` | Pinned-capture layer-shell surfaces (bottom-right, all workspaces) |
-| `src/surface-capture.cpp` | Clean window capture via `ext-image-copy-capture` Wayland protocol |
+| `src/surface-capture.cpp` | In-process output/window capture via `ext-image-copy-capture` |
 | `src/icons.cpp/.hpp` | Vector icon renderer for toolbar and pin controls |
 | `src/cli-path.cpp/.hpp` | Command-line image target resolution |
 | `src/eyedropper.cpp/.hpp` | Display-to-source color sampling |
@@ -59,7 +59,7 @@ Always run `make check` after behavioral changes. CI
 push and PR.
 
 Dependencies (Arch): `base-devel cmake ninja pkgconf qt6-base layer-shell-qt
-wayland wayland-protocols grim wl-clipboard tesseract tesseract-data-eng`.
+wayland wayland-protocols wl-clipboard tesseract tesseract-data-eng`.
 
 ## Release process
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - A pointer-side readout that turns any drag into a ruler: the pointer position
   while the crosshair is idle, then the frame size in native export pixels while a
   region, a hovered window, or a crop handle is being sized.
-- Clean window-surface capture through Wayland image-copy protocols. A failed native
-  capture stays in the window picker; Omasnap never substitutes a crop of the desktop.
+- Window capture is a crop of the focused-monitor frame. Overlapping windows stay
+  visible; there is no second clean-window recapture.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
 - Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
   hollow or filled rectangles (optionally rounded) and ellipses, numbered markers,
@@ -27,10 +27,10 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   live preview and dashed seam marker while dragging; annotations shift to follow.
 - Pin a finished capture as a bottom-right always-on-top layer surface, launched
   from the same `omasnap` executable and visible on every workspace.
-- Crash-resistant working snapshots under `/run/user/<UID>/omasnap/` (falling back to
-  a private `/tmp/omasnap-<UID>/`), written immediately after selection and overwritten
-  after every completed edit. Saving moves that file into `~/Pictures/Screenshots`;
-  clipboard output streams the same PNG.
+- Crash-resistant working documents under `/run/user/<UID>/omasnap/` (falling back to
+  a private `/tmp/omasnap-<UID>/`): the original source image plus a sidecar JSON
+  operation log. Undo still works after a crash or `--file` reopen. Saving and
+  copying write a normal flattened PNG to the clipboard or `~/Pictures/Screenshots`.
 - Verified PNG clipboard output through `wl-copy`/`wl-paste`, plus timestamped files
   under `~/Pictures/Screenshots` by default.
 - Open an image already on the clipboard directly in the annotation editor.
@@ -39,9 +39,10 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 ## Platform scope
 
 The supported target is **Wayland + Hyprland**, with Omarchy as the primary integration.
-The renderer, layer surface, clipboard, and clean-window capture use Wayland protocols;
-monitor/window discovery currently calls `hyprctl`. `grim` captures the monitor before
-the layer maps. Selection displays that captured frame, while the annotation editor uses
+The renderer, layer surface, clipboard, and monitor capture use Wayland protocols;
+monitor/window discovery currently calls `hyprctl`. The focused output is captured
+in-process through `ext-image-copy-capture` before the layer maps. Selection displays
+that captured frame, while the annotation editor uses
 a translucent layer scrim over the live desktop and draws only the selected capture.
 Another Wayland compositor could support the application after supplying equivalent
 monitor and window discovery; generic Wayland support is not claimed by 1.0.
@@ -49,7 +50,6 @@ monitor and window discovery; generic Wayland support is not claimed by 1.0.
 Runtime commands used by the application:
 
 - `hyprctl`
-- `grim`
 - `wl-copy` and `wl-paste`
 - `tesseract`
 - `omarchy-notification-send` when available; saved captures include a thumbnail and
@@ -113,7 +113,7 @@ Install the complete build/runtime dependency set:
 ```bash
 sudo pacman -S --needed \
   base-devel cmake ninja pkgconf qt6-base layer-shell-qt \
-  wayland wayland-protocols hyprland grim wl-clipboard \
+  wayland wayland-protocols hyprland wl-clipboard \
   tesseract tesseract-data-eng tesseract-data-tha
 ```
 
@@ -332,9 +332,10 @@ QT_QPA_PLATFORM=offscreen \
 ```
 
 The smoke executable exercises region/window/fullscreen startup modes, capture selection,
-temporary snapshot updates, annotation tools, undo/redo, vector movement and scaling,
-text editing, OCR, native-DPI output, endpoint-only line selection, external crop
-handles, and the native-pixel measurement readout on a scaled monitor.
+working-document persistence (source plus op-log JSON), annotation tools, undo/redo
+replay, vector movement and scaling, text editing, OCR, native-DPI output,
+endpoint-only line selection, external crop handles, and the native-pixel
+measurement readout on a scaled monitor.
 
 `.github/workflows/build-linux.yml` performs the same release build and interaction smoke
 in an Arch Linux container, stages the CMake installation, and uploads a versioned Linux

--- a/install-omarchy
+++ b/install-omarchy
@@ -12,7 +12,7 @@ fi
 
 omarchy-pkg-add \
   base-devel cmake ninja pkgconf qt6-base layer-shell-qt \
-  wayland wayland-protocols grim wl-clipboard \
+  wayland wayland-protocols wl-clipboard \
   tesseract tesseract-data-eng tesseract-data-tha
 
 cmake -S "$repo_dir" -B "$build_dir" -G Ninja \

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1321,6 +1321,17 @@ QJsonObject operationToJson(const Operation &operation) {
     object.insert(QStringLiteral("ids"), ids);
     break;
   }
+  case Operation::Type::Cut:
+    object.insert(QStringLiteral("type"), QStringLiteral("cut"));
+    object.insert(QStringLiteral("orientation"),
+                  operation.cut.orientation == Qt::Horizontal
+                      ? QStringLiteral("horizontal")
+                      : QStringLiteral("vertical"));
+    object.insert(QStringLiteral("sourceStart"), operation.cut.sourceStart);
+    object.insert(QStringLiteral("sourceEnd"), operation.cut.sourceEnd);
+    object.insert(QStringLiteral("logicalStart"), operation.cut.logicalStart);
+    object.insert(QStringLiteral("logicalEnd"), operation.cut.logicalEnd);
+    break;
   }
   return object;
 }
@@ -1366,6 +1377,22 @@ bool operationFromJson(const QJsonObject &object, Operation &operation,
     operation.type = Operation::Type::Delete;
     for (const QJsonValue value : object.value(QStringLiteral("ids")).toArray())
       operation.ids.push_back(value.toString().toULongLong());
+    return true;
+  }
+  if (type == QStringLiteral("cut")) {
+    operation.type = Operation::Type::Cut;
+    const QString orientation =
+        object.value(QStringLiteral("orientation")).toString();
+    operation.cut.orientation = orientation == QStringLiteral("vertical")
+                                    ? Qt::Vertical
+                                    : Qt::Horizontal;
+    operation.cut.sourceStart =
+        object.value(QStringLiteral("sourceStart")).toInt();
+    operation.cut.sourceEnd = object.value(QStringLiteral("sourceEnd")).toInt();
+    operation.cut.logicalStart =
+        object.value(QStringLiteral("logicalStart")).toInt();
+    operation.cut.logicalEnd =
+        object.value(QStringLiteral("logicalEnd")).toInt();
     return true;
   }
   error = QStringLiteral("Operation log has an unknown operation type");

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1143,6 +1143,8 @@ QString annotationToolName(Annotation::Kind kind) {
     return QStringLiteral("marker");
   case Annotation::Kind::Rectangle:
     return QStringLiteral("rectangle");
+  case Annotation::Kind::Ellipse:
+    return QStringLiteral("ellipse");
   case Annotation::Kind::Text:
     return QStringLiteral("text");
   case Annotation::Kind::Redaction:
@@ -1166,6 +1168,8 @@ bool annotationKindFromName(const QString &name, Annotation::Kind &kind) {
     kind = Annotation::Kind::Marker;
   else if (name == QStringLiteral("rectangle"))
     kind = Annotation::Kind::Rectangle;
+  else if (name == QStringLiteral("ellipse"))
+    kind = Annotation::Kind::Ellipse;
   else if (name == QStringLiteral("text"))
     kind = Annotation::Kind::Text;
   else if (name == QStringLiteral("redaction"))
@@ -1236,6 +1240,12 @@ QJsonObject annotationToJson(const Annotation &annotation) {
     object.insert(QStringLiteral("seed"),
                   QString::number(annotation.redactionSeed));
   }
+  if (annotation.filled)
+    object.insert(QStringLiteral("filled"), true);
+  if (annotation.cornerRadius > 0.0)
+    object.insert(QStringLiteral("cornerRadius"), annotation.cornerRadius);
+  if (annotation.textBackground != TextBackground::Pill)
+    object.insert(QStringLiteral("textBackground"), QStringLiteral("plain"));
   if (annotation.kind == Annotation::Kind::Spotlight) {
     object.insert(QStringLiteral("magnification"), annotation.magnification);
     object.insert(QStringLiteral("spotlightShape"),
@@ -1274,6 +1284,14 @@ bool annotationFromJson(const QJsonObject &object, Annotation &annotation,
                                   : RedactionStyle::Pixelate;
   annotation.redactionSeed =
       object.value(QStringLiteral("seed")).toString().toUInt();
+  annotation.filled = object.value(QStringLiteral("filled")).toBool(false);
+  annotation.cornerRadius =
+      object.value(QStringLiteral("cornerRadius")).toDouble(0.0);
+  annotation.textBackground =
+      object.value(QStringLiteral("textBackground")).toString() ==
+              QStringLiteral("plain")
+          ? TextBackground::Plain
+          : TextBackground::Pill;
   annotation.magnification =
       object.value(QStringLiteral("magnification")).toDouble(2.0);
   const QString spotlightShape =

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1487,6 +1487,11 @@ QString recognizeText(const QImage &image, QString &error) {
   return text;
 }
 
+QString shellQuote(QString value) {
+  value.replace('\'', QStringLiteral("'\"'\"'"));
+  return QStringLiteral("'%1'").arg(value);
+}
+
 void sendCaptureNotification(const QString &message, const QString &imagePath) {
   QStringList arguments{QStringLiteral("-g"), QStringLiteral(""),
                         QStringLiteral("--app-name"), QStringLiteral("omasnap"),

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -5,15 +5,16 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
-#include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonValue>
 #include <QLinearGradient>
 #include <QPainter>
+#include <QPointF>
 #include <QPainterPath>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -127,51 +128,6 @@ ProcessResult runProcess(const QString &program, const QStringList &arguments,
           finished ? process.exitCode() : -1, finished};
 }
 
-/**
- * Runs a process whose stdout carries a large payload, draining the pipe as it
- * arrives into one buffer sized up front. Letting QProcess buffer the whole
- * payload first costs an extra copy of the full frame.
- */
-ProcessResult runStreamingProcess(const QString &program,
-                                  const QStringList &arguments,
-                                  qsizetype expectedBytes, int timeoutMs) {
-  QProcess process;
-  process.setProcessChannelMode(QProcess::SeparateChannels);
-  process.start(program, arguments, QIODevice::ReadOnly);
-  if (!process.waitForStarted(2000))
-    return {{}, process.errorString().toUtf8(), -1, false};
-
-  QByteArray output;
-  output.reserve(std::max<qsizetype>(expectedBytes, 0));
-  const auto drain = [&process, &output] {
-    const qint64 available = process.bytesAvailable();
-    if (available <= 0)
-      return;
-    const qsizetype offset = output.size();
-    output.resize(offset + available);
-    const qint64 read = process.read(output.data() + offset, available);
-    output.resize(offset + std::max<qint64>(read, 0));
-  };
-
-  QElapsedTimer clock;
-  clock.start();
-  const auto remainingMs = [&clock, timeoutMs] {
-    return std::max<qint64>(0, timeoutMs - clock.elapsed());
-  };
-  while (remainingMs() > 0 &&
-         process.waitForReadyRead(static_cast<int>(remainingMs())))
-    drain();
-
-  const bool finished =
-      process.state() == QProcess::NotRunning ||
-      process.waitForFinished(static_cast<int>(remainingMs()));
-  if (!finished)
-    process.kill();
-  drain();
-  return {std::move(output), process.readAllStandardError(),
-          finished ? process.exitCode() : -1, finished};
-}
-
 bool copyToWaylandClipboard(const QString &mimeType, const QByteArray &payload,
                             QString &error) {
   QByteArray lastError;
@@ -203,11 +159,6 @@ bool copyToWaylandClipboard(const QString &mimeType, const QByteArray &payload,
 QString runtimePath(const QString &name) {
   const QString runtime = secureRuntimeDirectory();
   return runtime.isEmpty() ? QString() : QDir(runtime).filePath(name);
-}
-
-QString shellQuote(QString value) {
-  value.replace('\'', QStringLiteral("'\"'\"'"));
-  return QStringLiteral("'%1'").arg(value);
 }
 
 QString screenshotTargetPath(QString &error) {
@@ -777,7 +728,7 @@ bool captureMonitorPixels(const MonitorInfo &monitor, CaptureData &capture,
   }
 
   // Window discovery is independent of the screen grab, so let the hyprctl
-  // round trip overlap grim instead of running after it.
+  // round trip overlap the in-process output capture.
   QProcess clients;
   if (includeWindows) {
     clients.setProcessChannelMode(QProcess::SeparateChannels);
@@ -786,38 +737,17 @@ bool captureMonitorPixels(const MonitorInfo &monitor, CaptureData &capture,
     clients.closeWriteChannel();
   }
 
-  const QString grimGeometry = QStringLiteral("%1,%2 %3x%4")
-                                   .arg(geometry.x())
-                                   .arg(geometry.y())
-                                   .arg(geometry.width())
-                                   .arg(geometry.height());
-  // A PPM frame is three bytes per pixel plus a short header.
-  const qsizetype expectedBytes =
-      static_cast<qsizetype>(capture.monitor.pixelSize.width()) *
-          capture.monitor.pixelSize.height() * 3 +
-      64;
-  const ProcessResult grim = runStreamingProcess(
-      QStringLiteral("grim"),
-      {QStringLiteral("-t"), QStringLiteral("ppm"), QStringLiteral("-s"),
-       QString::number(capture.monitor.scale, 'g', 8), QStringLiteral("-g"),
-       grimGeometry, QStringLiteral("-")},
-      expectedBytes, 10000);
-
-  if (!grim.finished || grim.exitCode != 0) {
-    QString detail = QString::fromUtf8(grim.error).trimmed();
-    if (detail.isEmpty()) {
-      detail = grim.finished ? QStringLiteral("grim exited with code %1")
-                                   .arg(grim.exitCode)
-                             : QStringLiteral("grim did not finish in time");
+  const QString testCapture = qEnvironmentVariable("OMASNAP_TEST_CAPTURE");
+  if (!testCapture.isEmpty()) {
+    if (!capture.source.load(testCapture)) {
+      error = QStringLiteral("Screen capture failed: could not load test "
+                             "capture %1")
+                  .arg(testCapture);
+      return false;
     }
-    error = QStringLiteral("Screen capture failed: %1").arg(detail);
-    return false;
-  }
-  if (!capture.source.loadFromData(grim.output, "PPM")) {
-    error = QStringLiteral(
-                "Screen capture failed: could not decode %1 bytes of PPM data "
-                "from grim")
-                .arg(grim.output.size());
+  } else if (!captureOutputSurface(monitor, capture.source, error)) {
+    if (!error.startsWith(QStringLiteral("Screen capture failed:")))
+      error = QStringLiteral("Screen capture failed: %1").arg(error);
     return false;
   }
 
@@ -1092,6 +1022,18 @@ QString temporarySnapshotPath() {
                          .arg(nonce, 8, 16, QChar('0')));
 }
 
+QString temporaryExportPath() {
+  return runtimePath(QStringLiteral("export-%1-%2.png")
+                         .arg(QCoreApplication::applicationPid())
+                         .arg(QRandomGenerator::global()->generate64(), 16, 16,
+                              QChar('0')));
+}
+
+QString operationLogPath(const QString &imagePath) {
+  const QFileInfo info(imagePath);
+  return info.dir().filePath(info.completeBaseName() + QStringLiteral(".json"));
+}
+
 QString pinnedSnapshotPath(int index) {
   // A fresh nonce prevents collisions when the editor PID is recycled.
   return runtimePath(QStringLiteral("pin-%1-%2-%3.png")
@@ -1160,6 +1102,346 @@ bool saveTemporarySnapshot(const QImage &image, QString path, QString &error,
                 .arg(file.errorString());
     return false;
   }
+  return true;
+}
+
+namespace {
+QJsonArray pointArray(const QPointF &point) {
+  return QJsonArray{point.x(), point.y()};
+}
+
+QJsonArray rectArray(const QRectF &rect) {
+  return QJsonArray{rect.x(), rect.y(), rect.width(), rect.height()};
+}
+
+QPointF pointFromArray(const QJsonValue &value) {
+  const QJsonArray array = value.toArray();
+  if (array.size() < 2)
+    return {};
+  return {array.at(0).toDouble(), array.at(1).toDouble()};
+}
+
+QRectF rectFromArray(const QJsonValue &value) {
+  const QJsonArray array = value.toArray();
+  if (array.size() < 4)
+    return {};
+  return {array.at(0).toDouble(), array.at(1).toDouble(), array.at(2).toDouble(),
+          array.at(3).toDouble()};
+}
+
+QString annotationToolName(Annotation::Kind kind) {
+  switch (kind) {
+  case Annotation::Kind::Arrow:
+    return QStringLiteral("arrow");
+  case Annotation::Kind::Line:
+    return QStringLiteral("line");
+  case Annotation::Kind::Freehand:
+    return QStringLiteral("freehand");
+  case Annotation::Kind::Highlighter:
+    return QStringLiteral("highlighter");
+  case Annotation::Kind::Marker:
+    return QStringLiteral("marker");
+  case Annotation::Kind::Rectangle:
+    return QStringLiteral("rectangle");
+  case Annotation::Kind::Text:
+    return QStringLiteral("text");
+  case Annotation::Kind::Redaction:
+    return QStringLiteral("redaction");
+  case Annotation::Kind::Spotlight:
+    return QStringLiteral("spotlight");
+  }
+  return QStringLiteral("arrow");
+}
+
+bool annotationKindFromName(const QString &name, Annotation::Kind &kind) {
+  if (name == QStringLiteral("arrow"))
+    kind = Annotation::Kind::Arrow;
+  else if (name == QStringLiteral("line"))
+    kind = Annotation::Kind::Line;
+  else if (name == QStringLiteral("freehand"))
+    kind = Annotation::Kind::Freehand;
+  else if (name == QStringLiteral("highlighter"))
+    kind = Annotation::Kind::Highlighter;
+  else if (name == QStringLiteral("marker"))
+    kind = Annotation::Kind::Marker;
+  else if (name == QStringLiteral("rectangle"))
+    kind = Annotation::Kind::Rectangle;
+  else if (name == QStringLiteral("text"))
+    kind = Annotation::Kind::Text;
+  else if (name == QStringLiteral("redaction"))
+    kind = Annotation::Kind::Redaction;
+  else if (name == QStringLiteral("spotlight"))
+    kind = Annotation::Kind::Spotlight;
+  else
+    return false;
+  return true;
+}
+
+QString backgroundStyleName(BackgroundStyle style) {
+  switch (style) {
+  case BackgroundStyle::None:
+    return QStringLiteral("none");
+  case BackgroundStyle::Aurora:
+    return QStringLiteral("aurora");
+  case BackgroundStyle::Sunset:
+    return QStringLiteral("sunset");
+  case BackgroundStyle::Lagoon:
+    return QStringLiteral("lagoon");
+  case BackgroundStyle::Violet:
+    return QStringLiteral("violet");
+  }
+  return QStringLiteral("none");
+}
+
+bool backgroundStyleFromName(const QString &name, BackgroundStyle &style) {
+  if (name == QStringLiteral("none"))
+    style = BackgroundStyle::None;
+  else if (name == QStringLiteral("aurora"))
+    style = BackgroundStyle::Aurora;
+  else if (name == QStringLiteral("sunset"))
+    style = BackgroundStyle::Sunset;
+  else if (name == QStringLiteral("lagoon"))
+    style = BackgroundStyle::Lagoon;
+  else if (name == QStringLiteral("violet"))
+    style = BackgroundStyle::Violet;
+  else
+    return false;
+  return true;
+}
+
+QJsonObject annotationToJson(const Annotation &annotation) {
+  QJsonObject object;
+  object.insert(QStringLiteral("id"), QString::number(annotation.id));
+  object.insert(QStringLiteral("tool"), annotationToolName(annotation.kind));
+  object.insert(QStringLiteral("start"), pointArray(annotation.start));
+  object.insert(QStringLiteral("end"), pointArray(annotation.end));
+  object.insert(QStringLiteral("color"),
+                annotation.color.name(QColor::HexArgb));
+  object.insert(QStringLiteral("size"), annotation.size);
+  if (!annotation.text.isEmpty())
+    object.insert(QStringLiteral("text"), annotation.text);
+  if (annotation.number > 0)
+    object.insert(QStringLiteral("number"), annotation.number);
+  if (!annotation.points.isEmpty()) {
+    QJsonArray points;
+    for (const QPointF &point : annotation.points)
+      points.push_back(pointArray(point));
+    object.insert(QStringLiteral("points"), points);
+  }
+  if (annotation.kind == Annotation::Kind::Redaction) {
+    object.insert(QStringLiteral("redactionStyle"),
+                  annotation.redactionStyle == RedactionStyle::Solid
+                      ? QStringLiteral("solid")
+                      : QStringLiteral("pixelate"));
+    object.insert(QStringLiteral("seed"),
+                  QString::number(annotation.redactionSeed));
+  }
+  if (annotation.kind == Annotation::Kind::Spotlight) {
+    object.insert(QStringLiteral("magnification"), annotation.magnification);
+    object.insert(QStringLiteral("spotlightShape"),
+                  annotation.spotlightShape == SpotlightShape::Rectangle
+                      ? QStringLiteral("rectangle")
+                      : annotation.spotlightShape ==
+                                SpotlightShape::RoundedRectangle
+                            ? QStringLiteral("rounded")
+                            : QStringLiteral("ellipse"));
+  }
+  return object;
+}
+
+bool annotationFromJson(const QJsonObject &object, Annotation &annotation,
+                        QString &error) {
+  if (!annotationKindFromName(object.value(QStringLiteral("tool")).toString(),
+                              annotation.kind)) {
+    error = QStringLiteral("Operation log has an unknown annotation tool");
+    return false;
+  }
+  annotation.id =
+      object.value(QStringLiteral("id")).toString().toULongLong();
+  annotation.start = pointFromArray(object.value(QStringLiteral("start")));
+  annotation.end = pointFromArray(object.value(QStringLiteral("end")));
+  annotation.color = QColor(object.value(QStringLiteral("color")).toString());
+  annotation.size = object.value(QStringLiteral("size")).toDouble(4.0);
+  annotation.text = object.value(QStringLiteral("text")).toString();
+  annotation.number = object.value(QStringLiteral("number")).toInt();
+  annotation.points.clear();
+  for (const QJsonValue point : object.value(QStringLiteral("points")).toArray())
+    annotation.points.push_back(pointFromArray(point));
+  const QString redactionStyle =
+      object.value(QStringLiteral("redactionStyle")).toString();
+  annotation.redactionStyle = redactionStyle == QStringLiteral("solid")
+                                  ? RedactionStyle::Solid
+                                  : RedactionStyle::Pixelate;
+  annotation.redactionSeed =
+      object.value(QStringLiteral("seed")).toString().toUInt();
+  annotation.magnification =
+      object.value(QStringLiteral("magnification")).toDouble(2.0);
+  const QString spotlightShape =
+      object.value(QStringLiteral("spotlightShape")).toString();
+  annotation.spotlightShape =
+      spotlightShape == QStringLiteral("rectangle")
+          ? SpotlightShape::Rectangle
+          : spotlightShape == QStringLiteral("rounded")
+                ? SpotlightShape::RoundedRectangle
+                : SpotlightShape::Ellipse;
+  return true;
+}
+
+QJsonObject operationToJson(const Operation &operation) {
+  QJsonObject object;
+  switch (operation.type) {
+  case Operation::Type::Crop:
+    object.insert(QStringLiteral("type"), QStringLiteral("crop"));
+    object.insert(QStringLiteral("rect"), rectArray(operation.crop));
+    break;
+  case Operation::Type::Background:
+    object.insert(QStringLiteral("type"), QStringLiteral("background"));
+    object.insert(QStringLiteral("style"),
+                  backgroundStyleName(operation.background));
+    break;
+  case Operation::Type::Annotate:
+    object.insert(QStringLiteral("type"), QStringLiteral("annotate"));
+    if (!operation.annotations.isEmpty())
+      object.insert(QStringLiteral("annotation"),
+                    annotationToJson(operation.annotations.constFirst()));
+    break;
+  case Operation::Type::Patch: {
+    object.insert(QStringLiteral("type"), QStringLiteral("patch"));
+    QJsonArray annotations;
+    for (const Annotation &annotation : operation.annotations)
+      annotations.push_back(annotationToJson(annotation));
+    object.insert(QStringLiteral("annotations"), annotations);
+    break;
+  }
+  case Operation::Type::Delete: {
+    object.insert(QStringLiteral("type"), QStringLiteral("delete"));
+    QJsonArray ids;
+    for (const quint64 id : operation.ids)
+      ids.push_back(QString::number(id));
+    object.insert(QStringLiteral("ids"), ids);
+    break;
+  }
+  }
+  return object;
+}
+
+bool operationFromJson(const QJsonObject &object, Operation &operation,
+                       QString &error) {
+  const QString type = object.value(QStringLiteral("type")).toString();
+  if (type == QStringLiteral("crop")) {
+    operation.type = Operation::Type::Crop;
+    operation.crop = rectFromArray(object.value(QStringLiteral("rect")));
+    return true;
+  }
+  if (type == QStringLiteral("background")) {
+    operation.type = Operation::Type::Background;
+    if (!backgroundStyleFromName(object.value(QStringLiteral("style")).toString(),
+                                 operation.background)) {
+      error = QStringLiteral("Operation log has an unknown background style");
+      return false;
+    }
+    return true;
+  }
+  if (type == QStringLiteral("annotate")) {
+    operation.type = Operation::Type::Annotate;
+    Annotation annotation;
+    if (!annotationFromJson(object.value(QStringLiteral("annotation")).toObject(),
+                            annotation, error))
+      return false;
+    operation.annotations = {annotation};
+    return true;
+  }
+  if (type == QStringLiteral("patch")) {
+    operation.type = Operation::Type::Patch;
+    for (const QJsonValue value :
+         object.value(QStringLiteral("annotations")).toArray()) {
+      Annotation annotation;
+      if (!annotationFromJson(value.toObject(), annotation, error))
+        return false;
+      operation.annotations.push_back(annotation);
+    }
+    return true;
+  }
+  if (type == QStringLiteral("delete")) {
+    operation.type = Operation::Type::Delete;
+    for (const QJsonValue value : object.value(QStringLiteral("ids")).toArray())
+      operation.ids.push_back(value.toString().toULongLong());
+    return true;
+  }
+  error = QStringLiteral("Operation log has an unknown operation type");
+  return false;
+}
+
+} // namespace
+
+bool saveOperationLog(const QString &path, const OperationLog &log,
+                      QString &error) {
+  if (path.isEmpty()) {
+    error = QStringLiteral("Operation log path is empty");
+    return false;
+  }
+  QJsonArray ops;
+  for (const Operation &operation : log.ops)
+    ops.push_back(operationToJson(operation));
+  QJsonObject root;
+  root.insert(QStringLiteral("version"), 1);
+  root.insert(QStringLiteral("index"), log.index);
+  root.insert(QStringLiteral("nextId"), QString::number(log.nextId));
+  root.insert(QStringLiteral("nextMarker"), log.nextMarker);
+  root.insert(QStringLiteral("ops"), ops);
+
+  QSaveFile file(path);
+  file.setDirectWriteFallback(false);
+  if (!file.open(QIODevice::WriteOnly) ||
+      !file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner)) {
+    error = QStringLiteral("Could not open operation log: %1")
+                .arg(file.errorString());
+    return false;
+  }
+  file.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+  file.putChar('\n');
+  if (!file.commit()) {
+    error = QStringLiteral("Could not write operation log: %1")
+                .arg(file.errorString());
+    return false;
+  }
+  return true;
+}
+
+bool loadOperationLog(const QString &path, OperationLog &log, QString &error) {
+  QFile file(path);
+  if (!file.open(QIODevice::ReadOnly)) {
+    error = QStringLiteral("Could not read operation log: %1").arg(path);
+    return false;
+  }
+  QJsonParseError parseError;
+  const QJsonDocument document = QJsonDocument::fromJson(file.readAll(), &parseError);
+  if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+    error = QStringLiteral("Could not parse operation log: %1")
+                .arg(parseError.errorString());
+    return false;
+  }
+  const QJsonObject root = document.object();
+  if (root.value(QStringLiteral("version")).toInt() != 1) {
+    error = QStringLiteral("Unsupported operation log version");
+    return false;
+  }
+  OperationLog loaded;
+  loaded.index = root.value(QStringLiteral("index")).toInt();
+  loaded.nextId = root.value(QStringLiteral("nextId")).toString().toULongLong();
+  loaded.nextMarker = root.value(QStringLiteral("nextMarker")).toInt(1);
+  if (loaded.nextId == 0)
+    loaded.nextId = 1;
+  if (loaded.nextMarker < 1)
+    loaded.nextMarker = 1;
+  for (const QJsonValue value : root.value(QStringLiteral("ops")).toArray()) {
+    Operation operation;
+    if (!operationFromJson(value.toObject(), operation, error))
+      return false;
+    loaded.ops.push_back(std::move(operation));
+  }
+  loaded.index = std::clamp(loaded.index, 0, static_cast<int>(loaded.ops.size()));
+  log = std::move(loaded);
   return true;
 }
 

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -1,6 +1,8 @@
 /** @fileoverview Declares screenshot capture, rendering, and output types. */
 #pragma once
 
+#include "cut.hpp"
+
 #include <cstdint>
 
 #include <QPainterPath>
@@ -80,13 +82,14 @@ struct Annotation {
 };
 
 struct Operation {
-  enum class Type { Crop, Background, Annotate, Patch, Delete };
+  enum class Type { Crop, Background, Annotate, Patch, Delete, Cut };
 
   Type type = Type::Annotate;
   QRectF crop;
   BackgroundStyle background = BackgroundStyle::None;
   QVector<Annotation> annotations;
   QVector<quint64> ids;
+  CutOp cut;
 
   bool operator==(const Operation &) const = default;
 };

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -201,5 +201,7 @@ void prunePinnedSnapshots();
 [[nodiscard]] bool saveTemporarySnapshot(const QImage &image, QString path,
                                          QString &error, int quality = -1);
 [[nodiscard]] QString recognizeText(const QImage &image, QString &error);
+/** Quotes a string for a shell argument passed to omarchy-notification-send. */
+[[nodiscard]] QString shellQuote(QString value);
 void sendCaptureNotification(const QString &message,
                              const QString &imagePath = {});

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -6,7 +6,9 @@
 #include <QPainterPath>
 #include <QColor>
 #include <QImage>
+#include <QPointF>
 #include <QRect>
+#include <QRectF>
 #include <QString>
 #include <QVector>
 
@@ -72,8 +74,30 @@ struct Annotation {
   SpotlightShape spotlightShape = SpotlightShape::Ellipse;
   quint32 redactionSeed = 0;
   TextBackground textBackground = TextBackground::Pill;
+  quint64 id = 0;
 
   bool operator==(const Annotation &) const = default;
+};
+
+struct Operation {
+  enum class Type { Crop, Background, Annotate, Patch, Delete };
+
+  Type type = Type::Annotate;
+  QRectF crop;
+  BackgroundStyle background = BackgroundStyle::None;
+  QVector<Annotation> annotations;
+  QVector<quint64> ids;
+
+  bool operator==(const Operation &) const = default;
+};
+
+struct OperationLog {
+  QVector<Operation> ops;
+  int index = 0;
+  quint64 nextId = 1;
+  int nextMarker = 1;
+
+  bool operator==(const OperationLog &) const = default;
 };
 
 enum class AnnotationLayer { Redaction, Default };
@@ -108,6 +132,15 @@ enum class AnnotationLayer { Redaction, Default };
 [[nodiscard]] QRectF annotationTextBounds(const Annotation &annotation);
 [[nodiscard]] bool captureWindowSurface(const WindowTarget &window,
                                         QImage &image, QString &error);
+/** Captures the named output through ext-image-copy-capture. */
+[[nodiscard]] bool captureOutputSurface(const MonitorInfo &monitor,
+                                        QImage &image, QString &error);
+[[nodiscard]] QString operationLogPath(const QString &imagePath);
+[[nodiscard]] bool saveOperationLog(const QString &path, const OperationLog &log,
+                                    QString &error);
+[[nodiscard]] bool loadOperationLog(const QString &path, OperationLog &log,
+                                    QString &error);
+[[nodiscard]] QString temporaryExportPath();
 /** Returns an upright image for captured Wayland buffer contents. */
 [[nodiscard]] QImage normalizeWaylandCapture(const QImage &image,
                                              std::uint32_t transform);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1631,7 +1631,12 @@ void CaptureEditor::commitOp(Operation op) {
   ops_.push_back(std::move(op));
   constexpr qsizetype maximumOps = 100;
   while (ops_.size() > maximumOps) {
-    ops_.removeFirst();
+    // Replay starts at the full monitor; the first Crop is the selected
+    // region/window. Dropping it leaves annotations in cropped space.
+    if (ops_.constFirst().type == Operation::Type::Crop)
+      ops_.removeAt(1);
+    else
+      ops_.removeFirst();
     if (opIndex_ > 0)
       --opIndex_;
   }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -365,16 +365,33 @@ void drawMeasureBadge(QPainter &painter, const QRect &bounds,
 
 void drawHotkeyLegend(QPainter &painter, const QRect &bounds,
                       const QPointF &cursor,
-                      const QVector<QPair<QString, QString>> &entries) {
+                      const QVector<QPair<QString, QString>> &entries,
+                      const QVector<QPointF> &keepVisible = {}) {
   if (entries.isEmpty())
     return;
   constexpr int columns = 2;
   const int rows = (entries.size() + columns - 1) / columns;
   const qreal width = 414;
   const qreal height = rows * 19 + 24;
-  QRectF panel(bounds.width() - width - 14, 14, width, height);
-  if (panel.adjusted(-28, -28, 28, 28).contains(cursor))
-    panel.moveLeft(14);
+  const QRectF right(bounds.width() - width - 14, 14, width, height);
+  const QRectF left(14, 14, width, height);
+  auto hiddenCount = [&](const QRectF &candidate) {
+    int count = 0;
+    for (const QPointF &point : keepVisible) {
+      if (candidate.contains(point))
+        ++count;
+    }
+    return count;
+  };
+  // Flip away from the pointer, but not onto a selected handle. Adding Cut
+  // grew the card far enough that a line-select click near mid-canvas moved
+  // it over the start handle.
+  const bool cursorWantsLeft =
+      right.adjusted(-28, -28, 28, 28).contains(cursor);
+  QRectF panel = cursorWantsLeft ? left : right;
+  const QRectF other = cursorWantsLeft ? right : left;
+  if (hiddenCount(panel) > hiddenCount(other))
+    panel = other;
 
   painter.setPen(QPen(QColor(255, 255, 255, 34), 1));
   painter.setBrush(QColor(13, 15, 20, 224));
@@ -3837,6 +3854,14 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     }
   }
   drawStatusPill(painter, rect(), status_);
+  QVector<QPointF> keepVisible;
+  if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+      hasEndpointHandles(annotations_.at(selectedAnnotation_).kind)) {
+    const Annotation &selected = annotations_.at(selectedAnnotation_);
+    const qreal scale = editScale();
+    keepVisible = {image.topLeft() + selected.start * scale,
+                   image.topLeft() + selected.end * scale};
+  }
   drawHotkeyLegend(
       painter, rect(), cursor_,
       {{QStringLiteral("V"), QStringLiteral("Select / move layer")},
@@ -3857,7 +3882,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
        {QStringLiteral("Enter"), QStringLiteral("Copy + save")},
        {QStringLiteral("Ctrl+C"), QStringLiteral("Copy only")},
        {QStringLiteral("Ctrl+S"), QStringLiteral("Save only")},
-       {QStringLiteral("Esc"), QStringLiteral("Arrow / twice close")}});
+       {QStringLiteral("Esc"), QStringLiteral("Arrow / twice close")}},
+      keepVisible);
   if (hoveredButton) {
     drawInstantTooltip(painter, rect(), hoveredButton->rect,
                        hoveredButton->tooltip);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1690,6 +1690,13 @@ void CaptureEditor::commitCrop(const QRectF &crop) {
   commitOp(std::move(op));
 }
 
+void CaptureEditor::commitCut(CutOp cut) {
+  Operation op;
+  op.type = Operation::Type::Cut;
+  op.cut = std::move(cut);
+  commitOp(std::move(op));
+}
+
 void CaptureEditor::commitBackground(BackgroundStyle style) {
   Operation op;
   op.type = Operation::Type::Background;
@@ -1709,9 +1716,13 @@ void CaptureEditor::replayLog() {
           ? annotations_.at(selectedAnnotation_).id
           : 0;
 
-  QRectF selection(QPointF(), capture_.previewSize);
+  const QSize startSize =
+      pristineLogicalSize_.isEmpty() ? capture_.previewSize
+                                     : pristineLogicalSize_;
+  QRectF selection{QPointF(), QSizeF(startSize)};
   BackgroundStyle background = BackgroundStyle::None;
   QVector<Annotation> annotations;
+  QVector<CutOp> cuts;
   int nextMarker = 1;
   for (int index = 0; index < opIndex_ && index < ops_.size(); ++index) {
     const Operation &op = ops_.at(index);
@@ -1749,11 +1760,41 @@ void CaptureEditor::replayLog() {
                                        }),
                         annotations.end());
       break;
+    case Operation::Type::Cut: {
+      const bool horizontal = op.cut.orientation == Qt::Horizontal;
+      const qreal lo = op.cut.logicalStart;
+      const qreal hi = op.cut.logicalEnd;
+      const qreal band = hi - lo;
+      for (Annotation &annotation : annotations) {
+        auto shift = [&](QPointF &point) {
+          if (horizontal)
+            point.setY(shiftForCut(point.y(), lo, hi));
+          else
+            point.setX(shiftForCut(point.x(), lo, hi));
+        };
+        shift(annotation.start);
+        shift(annotation.end);
+        for (QPointF &point : annotation.points)
+          shift(point);
+      }
+      if (band > 0.0) {
+        if (horizontal)
+          selection.setHeight(std::max<qreal>(1.0, selection.height() - band));
+        else
+          selection.setWidth(std::max<qreal>(1.0, selection.width() - band));
+      }
+      cuts.push_back(op.cut);
+      break;
+    }
     }
   }
 
   annotations_ = std::move(annotations);
   backgroundStyle_ = background;
+  if (cuts != cuts_) {
+    cuts_ = std::move(cuts);
+    refreshComposedCapture();
+  }
   if (!selection.isEmpty())
     selection_ = selection;
   nextMarker_ = nextMarker;
@@ -3108,29 +3149,8 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       update();
       return;
     }
-    recordEdit(); // push pre-cut state (with the OLD selection/annotations)
-    cuts_.push_back(liveCut_);
-    for (Annotation &annotation : annotations_) {
-      // Shift every stored coordinate on the cut axis: horizontal cut shifts
-      // y values, vertical cut shifts x values.
-      auto shift = [&](QPointF &point) {
-        if (horizontal)
-          point.setY(shiftForCut(point.y(), lo, hi));
-        else
-          point.setX(shiftForCut(point.x(), lo, hi));
-      };
-      shift(annotation.start);
-      shift(annotation.end);
-      for (QPointF &point : annotation.points)
-        shift(point);
-    }
-    if (horizontal)
-      selection_.setHeight(std::max<qreal>(1.0, selection_.height() - band));
-    else
-      selection_.setWidth(std::max<qreal>(1.0, selection_.width() - band));
     cutDragActive_ = false;
-    refreshComposedCapture();
-    scheduleSnapshot();
+    commitCut(liveCut_);
     setStatus(QStringLiteral("Cut applied · Ctrl+Z to undo"));
     updatePointerCursor();
     update();

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1142,14 +1142,13 @@ void CaptureEditor::toggleShapeFill() {
 void CaptureEditor::toggleTextBackground() {
   if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
       annotations_.at(selectedAnnotation_).kind == Annotation::Kind::Text) {
-    recordEdit();
     Annotation &text = annotations_[selectedAnnotation_];
     text.textBackground = text.textBackground == TextBackground::Pill
                               ? TextBackground::Plain
                               : TextBackground::Pill;
     setStatus(QStringLiteral("Selected text: %1 · T again toggles")
                   .arg(textBackgroundName(text.textBackground).toLower()));
-    scheduleSnapshot();
+    commitPatch({selectedAnnotation_});
     return;
   }
   textBackground_ = textBackground_ == TextBackground::Pill
@@ -1751,11 +1750,8 @@ void CaptureEditor::replayLog() {
       background = op.background;
       break;
     case Operation::Type::Annotate:
-      for (const Annotation &annotation : op.annotations) {
+      for (const Annotation &annotation : op.annotations)
         annotations.push_back(annotation);
-        if (annotation.kind == Annotation::Kind::Marker)
-          nextMarker = std::max(nextMarker, annotation.number + 1);
-      }
       break;
     case Operation::Type::Patch:
       for (const Annotation &annotation : op.annotations) {
@@ -1763,11 +1759,8 @@ void CaptureEditor::replayLog() {
             annotations, [&](const Annotation &current) {
               return current.id != 0 && current.id == annotation.id;
             });
-        if (match != annotations.end()) {
+        if (match != annotations.end())
           *match = annotation;
-          if (annotation.kind == Annotation::Kind::Marker)
-            nextMarker = std::max(nextMarker, annotation.number + 1);
-        }
       }
       break;
     case Operation::Type::Delete:
@@ -1814,6 +1807,11 @@ void CaptureEditor::replayLog() {
   }
   if (!selection.isEmpty())
     selection_ = selection;
+  nextMarker = 1;
+  for (const Annotation &annotation : annotations_) {
+    if (annotation.kind == Annotation::Kind::Marker)
+      nextMarker = std::max(nextMarker, annotation.number + 1);
+  }
   nextMarker_ = nextMarker;
   selectedAnnotations_.clear();
   selectedAnnotation_ = -1;
@@ -2470,7 +2468,6 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     if (!dragging_ && selectedAnnotation_ >= 0 &&
         selectedAnnotation_ < annotations_.size() &&
         annotations_.at(selectedAnnotation_).kind == dragShapeKind(shape)) {
-      recordEdit();
       Annotation &selected = annotations_[selectedAnnotation_];
       selected.filled = !selected.filled;
       setStatus(
@@ -2479,7 +2476,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
                              : QStringLiteral("ellipse"))
               .arg(fillName(selected.filled).toLower())
               .arg(rectangle ? QStringLiteral("R") : QStringLiteral("E")));
-      scheduleSnapshot();
+      commitPatch({selectedAnnotation_});
     } else if (tool_ == shape) {
       toggleShapeFill();
     } else {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -448,13 +448,20 @@ QPointF centeredCreationStart(CaptureEditor::Tool tool, const QPointF &center,
 }
 
 CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
-                             QuickOutputMode quickOutput, QWidget *parent)
+                             QuickOutputMode quickOutput, OperationLog log,
+                             QWidget *parent)
     : QWidget(parent), capture_(std::move(capture)),
       quickOutputMode_(quickOutput) {
   pristineSource_ = capture_.source;
   pristineLogicalSize_ = capture_.previewSize;
   paletteConfig_ = loadPaletteConfig(defaultPaletteConfigPath());
   customColor_ = paletteConfig_.custom;
+  if (!log.ops.isEmpty()) {
+    ops_ = std::move(log.ops);
+    opIndex_ = std::clamp(log.index, 0, static_cast<int>(ops_.size()));
+    nextAnnotationId_ = std::max<quint64>(log.nextId, 1);
+    nextMarker_ = std::max(log.nextMarker, 1);
+  }
   setWindowTitle(QStringLiteral("Omasnap"));
   setWindowFlags(Qt::Window | Qt::FramelessWindowHint |
                  Qt::WindowStaysOnTopHint);
@@ -530,6 +537,8 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
   connect(&snapshotWatcher_, &QFutureWatcher<bool>::finished, this, [this] {
     snapshotBusy_ = false;
     snapshotWriteOk_ = snapshotWatcher_.result();
+    if (snapshotWriteOk_ && QFile::exists(snapshotPath_))
+      sourceWritten_ = true;
     // Don't chain a re-render while a cut drag is live: capture_ is
     // transiently composed with liveCut_ mid-drag, and copying it here would
     // persist a phantom cut into the crash-recovery snapshot. snapshotDirty_
@@ -580,28 +589,6 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
             emit captureReady(true, {});
           });
 
-  connect(&windowWatcher_, &QFutureWatcher<WindowJob>::finished, this, [this] {
-    windowPending_ = false;
-    const WindowJob job = windowWatcher_.result();
-    if (!job.ok) {
-      setStatus(QStringLiteral("Window capture failed · %1 · choose another")
-                    .arg(job.error));
-      update();
-      return;
-    }
-    capture_.source = job.image;
-    capture_.previewSize = job.scaledSize;
-    pristineSource_ = capture_.source;
-    pristineLogicalSize_ = capture_.previewSize;
-    cuts_.clear();
-    selection_ = QRectF(QPointF(), job.scaledSize);
-    redactionBaseStale_ = true;
-    windowMode_ = false;
-    enterEdit(QStringLiteral(
-        "Window selected · Select moves layers · wheel zooms · outer handles "
-        "crop"));
-  });
-
   connect(&pinWatcher_, &QFutureWatcher<QImage>::finished, this, [this] {
     pinPending_ = false;
     const QString path = pendingPinPath_;
@@ -631,7 +618,10 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     pendingMode_ = mode;
     setStatus(QStringLiteral("Capturing screen…"));
   } else if (mode == CaptureMode::Fullscreen || mode == CaptureMode::File) {
-    selection_ = QRectF(QPointF(), capture_.previewSize);
+    if (ops_.isEmpty())
+      selection_ = QRectF(QPointF(), capture_.previewSize);
+    else
+      replayLog();
     enterEdit(
         mode == CaptureMode::File
             ? QStringLiteral("Editing image from file · Copy/Save to output")
@@ -651,11 +641,15 @@ CaptureEditor::~CaptureEditor() {
   // current render (dropping any coalesced follow-up) before cleanup.
   snapshotDirty_ = false;
   waitForSnapshot();
-  if (snapshotPath_.isEmpty() || !QFile::exists(snapshotPath_))
-    return;
   const QString runtime = secureRuntimeDirectory();
-  if (!runtime.isEmpty() && QFileInfo(snapshotPath_).absolutePath() == runtime)
-    QFile::remove(snapshotPath_);
+  const auto removeWorking = [&](const QString &path) {
+    if (path.isEmpty() || !QFile::exists(path))
+      return;
+    if (!runtime.isEmpty() && QFileInfo(path).absolutePath() == runtime)
+      QFile::remove(path);
+  };
+  removeWorking(snapshotPath_);
+  removeWorking(workingLogPath());
 }
 
 bool CaptureEditor::eventFilter(QObject *watched, QEvent *event) {
@@ -1063,14 +1057,13 @@ void CaptureEditor::duplicateSelectedAnnotation() {
 void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
   if (selectedAnnotation_ < 0 || selectedAnnotation_ >= annotations_.size())
     return;
-  recordEdit();
   Annotation &annotation = annotations_[selectedAnnotation_];
   if (annotation.kind == Annotation::Kind::Spotlight) {
     annotation.magnification =
         std::clamp(annotation.magnification * factor, 1.0, 4.0);
     setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
                   .arg(annotation.magnification, 0, 'f', 1));
-    scheduleSnapshot();
+    commitPatch({selectedAnnotation_});
     return;
   }
   const QPointF center = annotationBounds(annotation).center();
@@ -1106,7 +1099,7 @@ void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
   }
   setStatus(QStringLiteral("Selected layer · wheel zoom %1%")
                 .arg(qRound(factor * 100)));
-  scheduleSnapshot();
+  commitPatch({selectedAnnotation_});
 }
 
 QLineF CaptureEditor::creationSpan(const QPointF &rawEnd) const {
@@ -1248,9 +1241,8 @@ void CaptureEditor::applyCustomColor(const QPointF &position) {
   if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
       annotations_.at(selectedAnnotation_).kind !=
           Annotation::Kind::Redaction) {
-    recordEdit();
     annotations_[selectedAnnotation_].color = customColor_;
-    scheduleSnapshot();
+    commitPatch({selectedAnnotation_});
   }
   update();
 }
@@ -1600,7 +1592,7 @@ void CaptureEditor::applyEditState(const EditState &state) {
 
 void CaptureEditor::cancelActiveDragForHistory() {
   if (dragStartStateValid_)
-    applyEditState(dragStartState_);
+    replayLog();
   dragging_ = false;
   creationConstraintActive_ = false;
   creationCenteredActive_ = false;
@@ -1615,27 +1607,176 @@ void CaptureEditor::cancelActiveDragForHistory() {
   }
 }
 
-void CaptureEditor::pushUndoState(const EditState &state) {
-  // Any other edit ends a run of coalesced nudges.
-  endNudgeRun();
-  undoStack_.push_back(state);
-  constexpr qsizetype maximumUndoStates = 100;
-  while (undoStack_.size() > maximumUndoStates)
-    undoStack_.removeFirst();
-  redoStack_.clear();
+QString CaptureEditor::workingLogPath() const {
+  return snapshotPath_.isEmpty() ? QString() : operationLogPath(snapshotPath_);
 }
 
-void CaptureEditor::recordEdit() { pushUndoState(editState()); }
+bool CaptureEditor::restoreOperationLog(const QString &path, QString &error) {
+  OperationLog log;
+  if (!loadOperationLog(path, log, error))
+    return false;
+  ops_ = std::move(log.ops);
+  opIndex_ = std::clamp(log.index, 0, static_cast<int>(ops_.size()));
+  nextAnnotationId_ = std::max<quint64>(log.nextId, 1);
+  nextMarker_ = std::max(log.nextMarker, 1);
+  replayLog();
+  phase_ = Phase::Edit;
+  scheduleSnapshot();
+  return true;
+}
+
+void CaptureEditor::commitOp(Operation op) {
+  if (opIndex_ < ops_.size())
+    ops_.resize(opIndex_);
+  ops_.push_back(std::move(op));
+  constexpr qsizetype maximumOps = 100;
+  while (ops_.size() > maximumOps) {
+    ops_.removeFirst();
+    if (opIndex_ > 0)
+      --opIndex_;
+  }
+  opIndex_ = ops_.size();
+  replayLog();
+  scheduleSnapshot();
+}
+
+void CaptureEditor::commitAnnotate(Annotation annotation) {
+  if (annotation.id == 0)
+    annotation.id = nextAnnotationId_++;
+  Operation op;
+  op.type = Operation::Type::Annotate;
+  op.annotations = {std::move(annotation)};
+  commitOp(std::move(op));
+}
+
+void CaptureEditor::commitPatch(const QVector<int> &indices) {
+  Operation op;
+  op.type = Operation::Type::Patch;
+  for (const int index : indices) {
+    if (index < 0 || index >= annotations_.size())
+      continue;
+    Annotation annotation = annotations_.at(index);
+    if (annotation.id == 0)
+      annotation.id = nextAnnotationId_++;
+    op.annotations.push_back(std::move(annotation));
+  }
+  if (op.annotations.isEmpty())
+    return;
+  commitOp(std::move(op));
+}
+
+void CaptureEditor::commitDelete(const QVector<int> &indices) {
+  Operation op;
+  op.type = Operation::Type::Delete;
+  for (const int index : indices) {
+    if (index >= 0 && index < annotations_.size() &&
+        annotations_.at(index).id != 0)
+      op.ids.push_back(annotations_.at(index).id);
+  }
+  if (op.ids.isEmpty())
+    return;
+  commitOp(std::move(op));
+}
+
+void CaptureEditor::commitCrop(const QRectF &crop) {
+  Operation op;
+  op.type = Operation::Type::Crop;
+  op.crop = crop;
+  commitOp(std::move(op));
+}
+
+void CaptureEditor::commitBackground(BackgroundStyle style) {
+  Operation op;
+  op.type = Operation::Type::Background;
+  op.background = style;
+  commitOp(std::move(op));
+}
+
+void CaptureEditor::replayLog() {
+  QVector<quint64> selectedIds;
+  for (const int index : selectedAnnotations_) {
+    if (index >= 0 && index < annotations_.size() &&
+        annotations_.at(index).id != 0)
+      selectedIds.push_back(annotations_.at(index).id);
+  }
+  const quint64 selectedId =
+      selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size()
+          ? annotations_.at(selectedAnnotation_).id
+          : 0;
+
+  QRectF selection(QPointF(), capture_.previewSize);
+  BackgroundStyle background = BackgroundStyle::None;
+  QVector<Annotation> annotations;
+  int nextMarker = 1;
+  for (int index = 0; index < opIndex_ && index < ops_.size(); ++index) {
+    const Operation &op = ops_.at(index);
+    switch (op.type) {
+    case Operation::Type::Crop:
+      selection = op.crop;
+      break;
+    case Operation::Type::Background:
+      background = op.background;
+      break;
+    case Operation::Type::Annotate:
+      for (const Annotation &annotation : op.annotations) {
+        annotations.push_back(annotation);
+        if (annotation.kind == Annotation::Kind::Marker)
+          nextMarker = std::max(nextMarker, annotation.number + 1);
+      }
+      break;
+    case Operation::Type::Patch:
+      for (const Annotation &annotation : op.annotations) {
+        const auto match = std::ranges::find_if(
+            annotations, [&](const Annotation &current) {
+              return current.id != 0 && current.id == annotation.id;
+            });
+        if (match != annotations.end()) {
+          *match = annotation;
+          if (annotation.kind == Annotation::Kind::Marker)
+            nextMarker = std::max(nextMarker, annotation.number + 1);
+        }
+      }
+      break;
+    case Operation::Type::Delete:
+      annotations.erase(std::remove_if(annotations.begin(), annotations.end(),
+                                       [&](const Annotation &annotation) {
+                                         return op.ids.contains(annotation.id);
+                                       }),
+                        annotations.end());
+      break;
+    }
+  }
+
+  annotations_ = std::move(annotations);
+  backgroundStyle_ = background;
+  if (!selection.isEmpty())
+    selection_ = selection;
+  nextMarker_ = nextMarker;
+  selectedAnnotations_.clear();
+  selectedAnnotation_ = -1;
+  for (int index = 0; index < annotations_.size(); ++index) {
+    if (selectedIds.contains(annotations_.at(index).id))
+      selectedAnnotations_.push_back(index);
+    if (selectedId != 0 && annotations_.at(index).id == selectedId)
+      selectedAnnotation_ = index;
+  }
+  if (selectedAnnotation_ < 0 && !selectedAnnotations_.isEmpty())
+    selectedAnnotation_ = selectedAnnotations_.constLast();
+  editingAnnotation_ = -1;
+  redactionBaseStale_ = true;
+  updatePointerCursor();
+  update();
+}
 
 void CaptureEditor::undoEdit() {
   endNudgeRun();
   cancelActiveDragForHistory();
-  if (undoStack_.isEmpty()) {
+  if (opIndex_ <= 0) {
     setStatus(QStringLiteral("Nothing to undo"));
     return;
   }
-  redoStack_.push_back(editState());
-  applyEditState(undoStack_.takeLast());
+  --opIndex_;
+  replayLog();
   scheduleSnapshot();
   setStatus(QStringLiteral("Undo · Ctrl+Shift+Z or Ctrl+Y to redo"));
 }
@@ -1643,22 +1784,18 @@ void CaptureEditor::undoEdit() {
 void CaptureEditor::redoEdit() {
   endNudgeRun();
   cancelActiveDragForHistory();
-  if (redoStack_.isEmpty()) {
+  if (opIndex_ >= ops_.size()) {
     setStatus(QStringLiteral("Nothing to redo"));
     return;
   }
-  undoStack_.push_back(editState());
-  applyEditState(redoStack_.takeLast());
+  ++opIndex_;
+  replayLog();
   scheduleSnapshot();
   setStatus(QStringLiteral("Redo · Ctrl+Z to undo"));
 }
 
 void CaptureEditor::scheduleSnapshot() {
-  // Persist the composite after every completed edit so a crash leaves the
-  // annotated result on disk. Callers are edit completions (never per-motion),
-  // and snapshotBusy_/snapshotDirty_ collapse a burst into the in-flight write
-  // plus one trailing write, so no extra debounce timer is needed.
-  if (suppressSnapshots_ || selection_.isEmpty())
+  if (suppressSnapshots_ || capture_.source.isNull())
     return;
   if (snapshotPath_.isEmpty())
     snapshotPath_ = temporarySnapshotPath();
@@ -1676,23 +1813,17 @@ QImage CaptureEditor::renderCurrentOutput() const {
 void CaptureEditor::startSnapshotRender() {
   snapshotBusy_ = true;
   snapshotDirty_ = false;
-  const CaptureData captureCopy = capture_;
-  const QVector<Annotation> annotations = annotations_;
-  const QRectF selection = selection_;
-  const BackgroundStyle background = backgroundStyle_;
+  const QImage source = capture_.source;
   const QString path = snapshotPath_;
-  // Mid-edit writes exist for crash recovery only, so they trade PNG size for
-  // encode latency; finish() re-renders the same path at default compression
-  // because that file becomes the screenshot the user keeps.
-  const int quality = snapshotOutputRequested_ ? -1 : 80;
+  const QString logPath = operationLogPath(path);
+  const OperationLog log{ops_, opIndex_, nextAnnotationId_, nextMarker_};
+  const bool writeSource = !sourceWritten_ || !QFile::exists(path);
   snapshotWatcher_.setFuture(QtConcurrent::run(
-      [captureCopy, annotations, selection, background, path, quality] {
+      [source, path, logPath, log, writeSource] {
         QString error;
-        const QImage image = renderCapture(captureCopy, selection, annotations,
-                                           background);
-        if (image.isNull())
+        if (writeSource && !saveTemporarySnapshot(source, path, error, -1))
           return false;
-        return saveTemporarySnapshot(image, path, error, quality);
+        return saveOperationLog(logPath, log, error);
       }));
 }
 
@@ -1747,26 +1878,9 @@ void CaptureEditor::startCapture(CaptureMode mode, bool includeWindows) {
   }));
 }
 
-void CaptureEditor::startWindowCleanCapture(int index) {
-  if (windowPending_ || index < 0 || index >= capture_.windows.size())
-    return;
-  const WindowTarget target = capture_.windows.at(index);
-  setStatus(QStringLiteral("Capturing clean window surface…"));
-  QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-  windowPending_ = true;
-  windowWatcher_.setFuture(QtConcurrent::run([target] {
-    WindowJob job;
-    job.scaledSize = target.rect.size();
-    job.ok = captureWindowSurface(target, job.image, job.error);
-    return job;
-  }));
-}
-
 void CaptureEditor::enterEdit(QString status) {
   phase_ = Phase::Edit;
   tool_ = Tool::Select;
-  undoStack_.clear();
-  redoStack_.clear();
   setStatus(std::move(status));
   updatePointerCursor();
   if (quickOutputMode_ != QuickOutputMode::None) {
@@ -1778,7 +1892,11 @@ void CaptureEditor::enterEdit(QString status) {
     finish(output);
     return;
   }
-  scheduleSnapshot();
+  const QRectF full(QPointF(), capture_.previewSize);
+  if (ops_.isEmpty() && !selection_.isEmpty() && selection_ != full)
+    commitCrop(selection_);
+  else
+    scheduleSnapshot();
 }
 
 void CaptureEditor::handleEscape() {
@@ -1803,7 +1921,7 @@ void CaptureEditor::handleEscape() {
   textCaretTimer_.stop();
   editingAnnotation_ = -1;
   if (dragStartStateValid_) {
-    applyEditState(dragStartState_);
+    replayLog();
     scheduleSnapshot();
   }
   dragStartStateValid_ = false;
@@ -1832,7 +1950,12 @@ void CaptureEditor::handleEscape() {
 void CaptureEditor::chooseWindow(int index) {
   if (index < 0 || index >= capture_.windows.size())
     return;
-  startWindowCleanCapture(index);
+  selection_ = QRectF(capture_.windows.at(index).rect);
+  redactionBaseStale_ = true;
+  windowMode_ = false;
+  enterEdit(QStringLiteral(
+      "Window selected · Select moves layers · wheel zooms · outer handles "
+      "crop"));
 }
 
 void CaptureEditor::beginText(const QPointF &point, int annotationIndex) {
@@ -1889,7 +2012,6 @@ void CaptureEditor::beginText(const QPointF &point, int annotationIndex) {
 void CaptureEditor::acceptText() {
   const QString text = textEditor_->text().trimmed();
   if (!text.isEmpty()) {
-    recordEdit();
     Annotation annotation;
     annotation.kind = Annotation::Kind::Text;
     annotation.start =
@@ -1903,16 +2025,17 @@ void CaptureEditor::acceptText() {
             ? annotations_.at(editingAnnotation_).textBackground
             : textBackground_;
     if (editingAnnotation_ >= 0 && editingAnnotation_ < annotations_.size()) {
-      annotations_[editingAnnotation_] = std::move(annotation);
+      annotation.id = annotations_.at(editingAnnotation_).id;
+      annotations_[editingAnnotation_] = annotation;
       selectedAnnotation_ = editingAnnotation_;
       tool_ = Tool::Select;
       setStatus(QStringLiteral("Text updated · drag to move · handle resizes"));
+      commitPatch({editingAnnotation_});
     } else {
-      annotations_.push_back(std::move(annotation));
       selectedAnnotation_ = -1;
       setStatus(QStringLiteral("Text added · Esc for select mode"));
+      commitAnnotate(std::move(annotation));
     }
-    scheduleSnapshot();
   } else if (editingAnnotation_ >= 0) {
     tool_ = Tool::Select;
   }
@@ -1985,38 +2108,42 @@ void CaptureEditor::finish(OutputMode mode) {
     return;
   busy_ = true;
   setStatus(QStringLiteral("Preparing screenshot…"));
-  snapshotOutputRequested_ = true;
-  scheduleSnapshot();
-  if (!waitForSnapshot()) {
+  const QImage image = renderCurrentOutput();
+  QString error;
+  const QString exportPath = temporaryExportPath();
+  if (image.isNull() || exportPath.isEmpty() ||
+      !saveTemporarySnapshot(image, exportPath, error, -1)) {
     busy_ = false;
-    setStatus(QStringLiteral("Could not prepare screenshot snapshot"));
-    return;
-  }
-  const QFileInfo snapshotFile(snapshotPath_);
-  if (snapshotPath_.isEmpty() || !snapshotFile.exists() ||
-      snapshotFile.size() <= 0) {
-    busy_ = false;
-    setStatus(QStringLiteral("Could not prepare screenshot snapshot"));
+    setStatus(error.isEmpty()
+                  ? QStringLiteral("Could not prepare screenshot snapshot")
+                  : error);
     return;
   }
 
-  QString error;
   QString saved;
   if (mode == OutputMode::Copy || mode == OutputMode::Both) {
-    if (!copyPngFileToClipboard(snapshotPath_, error)) {
+    if (!copyPngFileToClipboard(exportPath, error)) {
+      QFile::remove(exportPath);
       busy_ = false;
       setStatus(error);
       return;
     }
   }
   if (mode == OutputMode::Save || mode == OutputMode::Both) {
-    saved = moveSnapshotToScreenshots(snapshotPath_, error);
+    saved = moveSnapshotToScreenshots(exportPath, error);
     if (saved.isEmpty()) {
+      QFile::remove(exportPath);
       busy_ = false;
       setStatus(error);
       return;
     }
-    snapshotPath_ = saved;
+  } else {
+    QFile::remove(exportPath);
+  }
+  if (!snapshotPath_.isEmpty()) {
+    QFile::remove(workingLogPath());
+    QFile::remove(snapshotPath_);
+    snapshotPath_.clear();
   }
 
   if (mode == OutputMode::Copy)
@@ -2100,9 +2227,8 @@ void CaptureEditor::handleToolbar(const QString &action) {
     if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
         annotations_.at(selectedAnnotation_).kind !=
             Annotation::Kind::Redaction) {
-      recordEdit();
       annotations_[selectedAnnotation_].color = annotationColor();
-      scheduleSnapshot();
+      commitPatch({selectedAnnotation_});
     }
   } else if (action == QStringLiteral("custom-color")) {
     usingCustomColor_ = true;
@@ -2110,12 +2236,11 @@ void CaptureEditor::handleToolbar(const QString &action) {
   } else if (action == QStringLiteral("ocr"))
     runOcr();
   else if (action == QStringLiteral("background")) {
-    recordEdit();
-    backgroundStyle_ = static_cast<BackgroundStyle>(
+    const auto next = static_cast<BackgroundStyle>(
         (static_cast<int>(backgroundStyle_) + 1) % 5);
     setStatus(QStringLiteral("Backdrop: %1 · B cycles")
-                  .arg(backgroundName(backgroundStyle_)));
-    scheduleSnapshot();
+                  .arg(backgroundName(next)));
+    commitBackground(next);
   } else if (action == QStringLiteral("undo")) {
     undoEdit();
   } else if (action == QStringLiteral("redo")) {
@@ -2259,20 +2384,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if ((event->key() == Qt::Key_Delete ||
               event->key() == Qt::Key_Backspace) &&
              !selectedAnnotations_.isEmpty()) {
-    recordEdit();
-    QVector<int> removed = selectedAnnotations_;
-    std::ranges::sort(removed, [](int first, int second) {
-      return first > second;
-    });
-    for (const int index : removed) {
-      if (index >= 0 && index < annotations_.size())
-        annotations_.removeAt(index);
-    }
+    commitDelete(selectedAnnotations_);
     selectedAnnotations_.clear();
     selectedAnnotation_ = -1;
-    if (annotations_.isEmpty())
-      nextMarker_ = 1;
-    scheduleSnapshot();
   } else if (event->key() == Qt::Key_V) {
     tool_ = Tool::Select;
   } else if (event->matches(QKeySequence::SelectAll)) {
@@ -2323,7 +2437,6 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
         annotations_.at(selectedAnnotation_).kind ==
             Annotation::Kind::Redaction) {
-      recordEdit();
       Annotation &redaction = annotations_[selectedAnnotation_];
       redaction.redactionStyle =
           redaction.redactionStyle == RedactionStyle::Solid
@@ -2331,7 +2444,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
               : RedactionStyle::Solid;
       setStatus(QStringLiteral("Selected redaction: %1 · D toggles")
                     .arg(redactionStyleName(redaction.redactionStyle)));
-      scheduleSnapshot();
+      commitPatch({selectedAnnotation_});
     } else {
       if (tool_ == Tool::Redact) {
         redactionStyle_ = redactionStyle_ == RedactionStyle::Solid
@@ -2366,21 +2479,19 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     pinSnapshot();
     return;
   } else if (event->key() == Qt::Key_B) {
-    recordEdit();
-    backgroundStyle_ = static_cast<BackgroundStyle>(
+    const auto next = static_cast<BackgroundStyle>(
         (static_cast<int>(backgroundStyle_) + 1) % 5);
     setStatus(QStringLiteral("Backdrop: %1 · B cycles")
-                  .arg(backgroundName(backgroundStyle_)));
-    scheduleSnapshot();
+                  .arg(backgroundName(next)));
+    commitBackground(next);
   } else if (event->key() >= Qt::Key_1 && event->key() <= Qt::Key_6) {
     colorIndex_ = event->key() - Qt::Key_1;
     usingCustomColor_ = false;
     if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
         annotations_.at(selectedAnnotation_).kind !=
             Annotation::Kind::Redaction) {
-      recordEdit();
       annotations_[selectedAnnotation_].color = annotationColor();
-      scheduleSnapshot();
+      commitPatch({selectedAnnotation_});
     }
   } else {
     QWidget::keyPressEvent(event);
@@ -2759,9 +2870,8 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
             Annotation::Kind::Redaction &&
         annotations_.at(selectedAnnotation_).kind !=
             Annotation::Kind::Spotlight) {
-      recordEdit();
       annotations_[selectedAnnotation_].color = customColor_;
-      scheduleSnapshot();
+      commitPatch({selectedAnnotation_});
     }
     QString clipboardError;
     static_cast<void>(copyTextToClipboard(
@@ -2862,18 +2972,16 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     return;
   }
   if (tool_ == Tool::Marker) {
-    recordEdit();
     Annotation annotation;
     annotation.kind = Annotation::Kind::Marker;
     annotation.start = point;
-    annotation.number = nextMarker_++;
+    annotation.number = nextMarker_;
     annotation.color = annotationColor();
     annotation.size = annotationSize_;
-    annotations_.push_back(std::move(annotation));
     selectedAnnotation_ = -1;
     setStatus(QStringLiteral("Marker %1 added · Esc for select mode")
                   .arg(annotation.number));
-    scheduleSnapshot();
+    commitAnnotate(std::move(annotation));
     updatePointerCursor();
   } else if (tool_ == Tool::Text) {
     beginText(point);
@@ -2949,8 +3057,12 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     }
     const bool cropped = interaction_ >= Interaction::CropTopLeft;
     const bool changed = dragStartStateValid_ && dragChanged_;
-    if (changed)
-      pushUndoState(dragStartState_);
+    if (changed) {
+      if (cropped)
+        commitCrop(selection_);
+      else
+        commitPatch(selectedAnnotations_);
+    }
     dragStartStateValid_ = false;
     dragChanged_ = false;
     dragging_ = false;
@@ -2959,8 +3071,6 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     if (cropped)
       setStatus(QStringLiteral(
           "Crop updated · Select moves layers · wheel zooms selected layer"));
-    if (changed)
-      scheduleSnapshot();
     updatePointerCursor();
     update();
     return;
@@ -3036,7 +3146,6 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       length += QLineF(freehandPoints_.at(index - 1), freehandPoints_.at(index))
                     .length();
     if (length > 4) {
-      recordEdit();
       const bool highlighter = tool_ == Tool::Highlighter;
       Annotation annotation;
       annotation.kind = highlighter ? Annotation::Kind::Highlighter
@@ -3046,13 +3155,12 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       annotation.color = annotationColor();
       annotation.size = annotationSize_;
       annotation.points = std::move(freehandPoints_);
-      annotations_.push_back(std::move(annotation));
       selectedAnnotation_ = -1;
       setStatus(
           highlighter
               ? QStringLiteral("Highlight added · Esc for select mode")
               : QStringLiteral("Stroke added · Esc for select mode"));
-      scheduleSnapshot();
+      commitAnnotate(std::move(annotation));
     }
     freehandPoints_.clear();
     dragging_ = false;
@@ -3077,7 +3185,6 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       (draggedRect.normalized().width() >= kMinimumRedactionExtent &&
        draggedRect.normalized().height() >= kMinimumRedactionExtent);
   if (QLineF(dragStart_, end).length() > 4 && validRedaction) {
-    recordEdit();
     Annotation annotation;
     if (tool_ == Tool::Redact) {
       annotation.kind = Annotation::Kind::Redaction;
@@ -3098,14 +3205,13 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     annotation.end = end;
     annotation.color = annotationColor();
     annotation.size = annotationSize_;
-    annotations_.push_back(std::move(annotation));
     selectedAnnotation_ = -1;
     const bool redacted = tool_ == Tool::Redact;
     setStatus(redacted
                   ? QStringLiteral("%1 redaction added · Esc for select mode")
                         .arg(redactionStyleName(redactionStyle_))
                   : QStringLiteral("Layer added · Esc for select mode"));
-    scheduleSnapshot();
+    commitAnnotate(std::move(annotation));
     updatePointerCursor();
   } else if (tool_ == Tool::Redact) {
     setStatus(QStringLiteral(
@@ -3136,14 +3242,13 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
     const qreal delta = step > 0 ? 0.25 : -0.25;
     const int hovered = hoveredSpotlightAt(event->position());
     if (hovered >= 0) {
-      recordEdit();
       Annotation &annotation = annotations_[hovered];
       annotation.magnification =
           std::clamp(annotation.magnification + delta, 1.0, 4.0);
       spotlightMagnification_ = annotation.magnification;
       setStatus(QStringLiteral("Spotlight magnification · %1× · wheel adjusts")
                     .arg(annotation.magnification, 0, 'f', 1));
-      scheduleSnapshot();
+      commitPatch({hovered});
     } else {
       spotlightMagnification_ =
           std::clamp(spotlightMagnification_ + delta, 1.0, 4.0);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -521,7 +521,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
   nudgePersistTimer_.setSingleShot(true);
   nudgePersistTimer_.setInterval(kNudgeCoalesceMs);
   connect(&nudgePersistTimer_, &QTimer::timeout, this,
-          [this] { scheduleSnapshot(); });
+          [this] { endNudgeRun(); });
   connect(
       textEditor_, &QLineEdit::textChanged, this, [this](const QString &text) {
         const QFontMetrics metrics(textEditor_->font());
@@ -1054,21 +1054,23 @@ void CaptureEditor::duplicateSelectedAnnotation() {
   if (dragging_ || textEditor_->isVisible() || selectedAnnotation_ < 0 ||
       selectedAnnotation_ >= annotations_.size())
     return;
-  recordEdit();
+  endNudgeRun();
   Annotation copy = annotations_.at(selectedAnnotation_);
+  copy.id = 0;
   translateAnnotation(
       copy, duplicateOffset(annotationBounds(copy), selection_.size()));
   if (copy.kind == Annotation::Kind::Marker)
-    copy.number = nextMarker_++;
+    copy.number = nextMarker_;
   if (copy.kind == Annotation::Kind::Redaction) {
     // A copy must not share the original's mosaic; give it its own seed.
     copy.redactionSeed = freshRedactionSeed();
   }
-  annotations_.push_back(std::move(copy));
-  selectedAnnotation_ = annotations_.size() - 1;
-  selectedAnnotations_ = {selectedAnnotation_};
+  commitAnnotate(std::move(copy));
+  if (!annotations_.isEmpty()) {
+    selectedAnnotation_ = annotations_.size() - 1;
+    selectedAnnotations_ = {selectedAnnotation_};
+  }
   setStatus(QStringLiteral("Duplicated · Alt+D again offsets further"));
-  scheduleSnapshot();
 }
 
 void CaptureEditor::scaleSelectedAnnotation(qreal factor) {
@@ -1182,7 +1184,7 @@ void CaptureEditor::nudgeSelectedAnnotation(const QPointF &delta) {
   // Presses in quick succession (a held key) share one undo entry and one
   // deferred snapshot.
   if (!nudgeTimer_.isValid() || nudgeTimer_.elapsed() > kNudgeCoalesceMs)
-    recordEdit();
+    endNudgeRun();
   nudgeTimer_.restart();
   translateAnnotation(annotations_[selectedAnnotation_], delta);
   setStatus(QStringLiteral("Nudged · arrows move 1 px · Shift 10 px"));
@@ -1190,11 +1192,13 @@ void CaptureEditor::nudgeSelectedAnnotation(const QPointF &delta) {
 }
 
 void CaptureEditor::endNudgeRun() {
+  const bool hadRun = nudgeTimer_.isValid();
   nudgeTimer_.invalidate();
-  if (nudgePersistTimer_.isActive()) {
+  if (nudgePersistTimer_.isActive())
     nudgePersistTimer_.stop();
-    scheduleSnapshot();
-  }
+  if (hadRun && selectedAnnotation_ >= 0 &&
+      selectedAnnotation_ < annotations_.size())
+    commitPatch({selectedAnnotation_});
 }
 
 QRectF CaptureEditor::colorPaletteRect() const {

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -35,6 +35,7 @@ public:
   explicit CaptureEditor(CaptureData capture,
                          CaptureMode mode = CaptureMode::Region,
                          QuickOutputMode quickOutput = QuickOutputMode::None,
+                         OperationLog log = {},
                          QWidget *parent = nullptr);
   ~CaptureEditor() override;
 
@@ -68,6 +69,12 @@ public:
   [[nodiscard]] QString measurementText() const;
   /** Current monitor data (background capture may be in flight). */
   const CaptureData &captureData() const { return capture_; }
+  [[nodiscard]] QRectF currentSelection() const { return selection_; }
+  [[nodiscard]] const QVector<Operation> &operationLog() const { return ops_; }
+  [[nodiscard]] int operationIndex() const { return opIndex_; }
+  [[nodiscard]] QString workingSourcePath() const { return snapshotPath_; }
+  [[nodiscard]] QString workingLogPath() const;
+  bool restoreOperationLog(const QString &path, QString &error);
 
   /**
    * Disables working-snapshot persistence. The hidden editor behind instant
@@ -228,9 +235,13 @@ private:
   void scheduleSnapshot();
   void startSnapshotRender();
   void pinSnapshot();
-  void startWindowCleanCapture(int index);
-  void pushUndoState(const EditState &state);
-  void recordEdit();
+  void commitOp(Operation op);
+  void commitAnnotate(Annotation annotation);
+  void commitPatch(const QVector<int> &indices);
+  void commitDelete(const QVector<int> &indices);
+  void commitCrop(const QRectF &crop);
+  void commitBackground(BackgroundStyle style);
+  void replayLog();
   void redoEdit();
   void selectWindowInDirection(int key);
   void finish(OutputMode mode);
@@ -334,6 +345,7 @@ private:
   // is written at default PNG compression instead of the fast edit encoding.
   bool snapshotOutputRequested_ = false;
   bool suppressSnapshots_ = false;
+  bool sourceWritten_ = false;
   // Background monitor capture fed to CaptureEditor::CaptureMode dispatch.
   struct CaptureJob {
     bool ok = false;
@@ -344,25 +356,17 @@ private:
   bool capturePending_ = false;
   bool captureStarted_ = false;
   CaptureMode pendingMode_ = CaptureMode::Region;
-  // Background clean window surface capture.
-  struct WindowJob {
-    bool ok = false;
-    QImage image;
-    QSize scaledSize;
-    QString error;
-  };
-  QFutureWatcher<WindowJob> windowWatcher_;
-  bool windowPending_ = false;
   // Background render for --pin.
   QFutureWatcher<QImage> pinWatcher_;
   bool pinPending_ = false;
   QString pendingPinPath_;
   QVector<Annotation> annotations_;
+  QVector<Operation> ops_;
+  int opIndex_ = 0;
+  quint64 nextAnnotationId_ = 1;
   int selectedAnnotation_ = -1;
   int editingAnnotation_ = -1;
   Annotation originalAnnotation_;
-  QVector<EditState> undoStack_;
-  QVector<EditState> redoStack_;
   EditState dragStartState_;
   bool dragStartStateValid_ = false;
   bool dragChanged_ = false;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -240,6 +240,7 @@ private:
   void commitPatch(const QVector<int> &indices);
   void commitDelete(const QVector<int> &indices);
   void commitCrop(const QRectF &crop);
+  void commitCut(CutOp cut);
   void commitBackground(BackgroundStyle style);
   void replayLog();
   void redoEdit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QDir>
+#include <QFile>
 #include <QGuiApplication>
 #include <QLockFile>
 #include <QScreen>
@@ -245,7 +246,7 @@ int main(int argc, char **argv) {
   QLockFile instanceLock(
       QDir(runtime).filePath(QStringLiteral("omasnap.instance")));
   // Every capture, quick output included, dismisses a running overlay instead
-  // of starting a second one: grim would otherwise photograph that overlay.
+  // of starting a second one: a late capture would otherwise photograph that overlay.
   // Editing an image always takes over so the requested editor can open.
   const InstanceLockResult lockResult = acquireInstanceLock(
       instanceLock, editingImage ? InstanceMode::EditFile
@@ -261,6 +262,7 @@ int main(int argc, char **argv) {
   }
 
   CaptureData capture;
+  OperationLog restoredLog;
   QString error;
   if (editingImage) {
     QImage image;
@@ -285,6 +287,13 @@ int main(int argc, char **argv) {
         return 1;
       }
       inputName = localFile;
+      const QString sidecar = operationLogPath(localFile);
+      if (QFile::exists(sidecar) &&
+          !loadOperationLog(sidecar, restoredLog, error)) {
+        qCritical().noquote()
+            << QStringLiteral("Could not restore operation log: %1").arg(error);
+        return 1;
+      }
     }
     capture.source = image;
     capture.previewSize = image.size();
@@ -319,7 +328,8 @@ int main(int argc, char **argv) {
     }
   }
 
-  CaptureEditor editor(std::move(capture), captureMode, editorQuickOutput);
+  CaptureEditor editor(std::move(capture), captureMode, editorQuickOutput,
+                       restoredLog);
   if (instantFullscreenOutput)
     editor.setSuppressSnapshots(true);
   QObject::connect(&editor, &CaptureEditor::captureReady, &editor,

--- a/src/surface-capture.cpp
+++ b/src/surface-capture.cpp
@@ -30,12 +30,18 @@ struct Toplevel {
   std::string identifier;
 };
 
+struct OutputInfo {
+  wl_output *output = nullptr;
+  std::string name;
+};
+
 struct CaptureState {
   wl_display *display = nullptr;
   wl_registry *registry = nullptr;
   wl_shm *shm = nullptr;
   ext_foreign_toplevel_list_v1 *toplevelList = nullptr;
   ext_foreign_toplevel_image_capture_source_manager_v1 *sourceManager = nullptr;
+  ext_output_image_capture_source_manager_v1 *outputSourceManager = nullptr;
   ext_image_copy_capture_manager_v1 *captureManager = nullptr;
   ext_image_capture_source_v1 *source = nullptr;
   ext_image_copy_capture_session_v1 *session = nullptr;
@@ -43,6 +49,7 @@ struct CaptureState {
   wl_shm_pool *pool = nullptr;
   wl_buffer *buffer = nullptr;
   std::vector<std::unique_ptr<Toplevel>> toplevels;
+  std::vector<std::unique_ptr<OutputInfo>> outputs;
   std::vector<uint32_t> shmFormats;
   uint32_t width = 0;
   uint32_t height = 0;
@@ -73,6 +80,12 @@ struct CaptureState {
     if (sourceManager)
       ext_foreign_toplevel_image_capture_source_manager_v1_destroy(
           sourceManager);
+    for (const auto &output : outputs) {
+      if (output->output)
+        wl_output_release(output->output);
+    }
+    if (outputSourceManager)
+      ext_output_image_capture_source_manager_v1_destroy(outputSourceManager);
     if (captureManager)
       ext_image_copy_capture_manager_v1_destroy(captureManager);
     if (buffer)
@@ -117,6 +130,19 @@ void listFinished(void *, ext_foreign_toplevel_list_v1 *) {}
 constexpr ext_foreign_toplevel_list_v1_listener kListListener{listToplevel,
                                                               listFinished};
 
+void outputGeometry(void *, wl_output *, int32_t, int32_t, int32_t, int32_t,
+                    int32_t, const char *, const char *, int32_t) {}
+void outputMode(void *, wl_output *, uint32_t, int32_t, int32_t, int32_t) {}
+void outputDone(void *, wl_output *) {}
+void outputScale(void *, wl_output *, int32_t) {}
+void outputName(void *data, wl_output *, const char *name) {
+  static_cast<OutputInfo *>(data)->name = name ? name : "";
+}
+void outputDescription(void *, wl_output *, const char *) {}
+constexpr wl_output_listener kOutputListener{outputGeometry, outputMode,
+                                             outputDone,     outputScale,
+                                             outputName,     outputDescription};
+
 void registryGlobal(void *data, wl_registry *registry, uint32_t name,
                     const char *interface, uint32_t version) {
   auto &state = *static_cast<CaptureState *>(data);
@@ -148,6 +174,23 @@ void registryGlobal(void *data, wl_registry *registry, uint32_t name,
         static_cast<ext_image_copy_capture_manager_v1 *>(wl_registry_bind(
             registry, name, &ext_image_copy_capture_manager_v1_interface,
             std::min(version, 1U)));
+  } else if (std::strcmp(
+                 interface,
+                 ext_output_image_capture_source_manager_v1_interface.name) ==
+             0) {
+    state.outputSourceManager =
+        static_cast<ext_output_image_capture_source_manager_v1 *>(
+            wl_registry_bind(
+                registry, name,
+                &ext_output_image_capture_source_manager_v1_interface,
+                std::min(version, 1U)));
+  } else if (std::strcmp(interface, wl_output_interface.name) == 0 &&
+             version >= 4) {
+    auto output = std::make_unique<OutputInfo>();
+    output->output = static_cast<wl_output *>(
+        wl_registry_bind(registry, name, &wl_output_interface, 4));
+    wl_output_add_listener(output->output, &kOutputListener, output.get());
+    state.outputs.push_back(std::move(output));
   }
 }
 void registryRemoved(void *, wl_registry *, uint32_t) {}
@@ -368,6 +411,51 @@ QImage normalizeWaylandCapture(const QImage &image, std::uint32_t transform) {
   }
 }
 
+static bool captureCurrentSource(CaptureState &state, QImage &image, QString &error,
+                          const QString &stoppedError,
+                          const QString &failedError,
+                          const QString &decodeError,
+                          const QString &transformError) {
+  state.session = ext_image_copy_capture_manager_v1_create_session(
+      state.captureManager, state.source, 0);
+  ext_image_copy_capture_session_v1_add_listener(state.session,
+                                                 &kSessionListener, &state);
+  if (!dispatchUntil(state, &state.constraintsDone, 2000, error))
+    return false;
+  if (state.stopped) {
+    error = stoppedError;
+    return false;
+  }
+  if (!createShmBuffer(state, error))
+    return false;
+
+  state.frame = ext_image_copy_capture_session_v1_create_frame(state.session);
+  ext_image_copy_capture_frame_v1_add_listener(state.frame, &kFrameListener,
+                                               &state);
+  ext_image_copy_capture_frame_v1_attach_buffer(state.frame, state.buffer);
+  ext_image_copy_capture_frame_v1_damage_buffer(
+      state.frame, 0, 0, static_cast<int32_t>(state.width),
+      static_cast<int32_t>(state.height));
+  ext_image_copy_capture_frame_v1_capture(state.frame);
+  if (!dispatchUntil(state, &state.frameDone, 2000, error) ||
+      !state.frameReady) {
+    if (error.isEmpty())
+      error = failedError;
+    return false;
+  }
+  const QImage captured = copyCapturedImage(state);
+  if (captured.isNull()) {
+    error = decodeError;
+    return false;
+  }
+  image = normalizeWaylandCapture(captured, state.transform);
+  if (image.isNull()) {
+    error = transformError;
+    return false;
+  }
+  return true;
+}
+
 bool captureWindowSurface(const WindowTarget &window, QImage &image,
                           QString &error) {
   if (window.stableId.isEmpty()) {
@@ -408,43 +496,56 @@ bool captureWindowSurface(const WindowTarget &window, QImage &image,
   state.source =
       ext_foreign_toplevel_image_capture_source_manager_v1_create_source(
           state.sourceManager, (*match)->handle);
-  state.session = ext_image_copy_capture_manager_v1_create_session(
-      state.captureManager, state.source, 0);
-  ext_image_copy_capture_session_v1_add_listener(state.session,
-                                                 &kSessionListener, &state);
-  if (!dispatchUntil(state, &state.constraintsDone, 2000, error))
-    return false;
-  if (state.stopped) {
-    error = QStringLiteral("Compositor stopped native window capture");
-    return false;
-  }
-  if (!createShmBuffer(state, error))
-    return false;
+  return captureCurrentSource(
+      state, image, error,
+      QStringLiteral("Compositor stopped native window capture"),
+      QStringLiteral("Compositor could not capture the selected window surface"),
+      QStringLiteral("Could not decode native window capture"),
+      QStringLiteral("Unsupported transform in native window capture"));
+}
 
-  state.frame = ext_image_copy_capture_session_v1_create_frame(state.session);
-  ext_image_copy_capture_frame_v1_add_listener(state.frame, &kFrameListener,
-                                               &state);
-  ext_image_copy_capture_frame_v1_attach_buffer(state.frame, state.buffer);
-  ext_image_copy_capture_frame_v1_damage_buffer(
-      state.frame, 0, 0, static_cast<int32_t>(state.width),
-      static_cast<int32_t>(state.height));
-  ext_image_copy_capture_frame_v1_capture(state.frame);
-  if (!dispatchUntil(state, &state.frameDone, 2000, error) ||
-      !state.frameReady) {
-    if (error.isEmpty())
-      error = QStringLiteral(
-          "Compositor could not capture the selected window surface");
+bool captureOutputSurface(const MonitorInfo &monitor, QImage &image,
+                          QString &error) {
+  if (monitor.name.isEmpty()) {
+    error = QStringLiteral("Focused monitor has no output name");
     return false;
   }
-  const QImage captured = copyCapturedImage(state);
-  if (captured.isNull()) {
-    error = QStringLiteral("Could not decode native window capture");
+
+  CaptureState state;
+  state.display = wl_display_connect(nullptr);
+  if (!state.display) {
+    error = QStringLiteral("Could not connect to Wayland for output capture");
     return false;
   }
-  image = normalizeWaylandCapture(captured, state.transform);
-  if (image.isNull()) {
-    error = QStringLiteral("Unsupported transform in native window capture");
+  state.registry = wl_display_get_registry(state.display);
+  wl_registry_add_listener(state.registry, &kRegistryListener, &state);
+  if (wl_display_roundtrip(state.display) < 0 ||
+      wl_display_roundtrip(state.display) < 0) {
+    error = QStringLiteral("Could not enumerate Wayland capture sources");
     return false;
   }
-  return true;
+  if (!state.shm || !state.outputSourceManager || !state.captureManager) {
+    error = QStringLiteral(
+        "Compositor does not expose ext-image-copy-capture output capture");
+    return false;
+  }
+
+  const auto match =
+      std::ranges::find_if(state.outputs, [&](const auto &output) {
+        return output->name == monitor.name.toStdString();
+      });
+  if (match == state.outputs.end()) {
+    error = QStringLiteral("Could not find Wayland output %1 for capture")
+                .arg(monitor.name);
+    return false;
+  }
+
+  state.source = ext_output_image_capture_source_manager_v1_create_source(
+      state.outputSourceManager, (*match)->output);
+  return captureCurrentSource(
+      state, image, error,
+      QStringLiteral("Compositor stopped native output capture"),
+      QStringLiteral("Compositor could not capture the focused output"),
+      QStringLiteral("Could not decode native output capture"),
+      QStringLiteral("Unsupported transform in native output capture"));
 }

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -3894,6 +3894,52 @@ bool runLayerHandlesSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+
+/**
+ * Selecting a line near mid-canvas must leave both endpoint handles visible.
+ * The help card flips away from the pointer; after Cut added a row it was
+ * tall enough that this click parked the card on the start handle.
+ */
+bool runLineHandleLegendSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+
+  CaptureEditor editor(capture);
+  editor.setSuppressSnapshots(true);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(650, 470), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(650, 470));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_L);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(260, 210));
+  QTest::mouseMove(&editor, QPoint(520, 265), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(520, 265));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_V);
+  application.processEvents();
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(390, 238));
+  application.processEvents();
+  const QImage ui = editor.grab().toImage();
+  const QColor handle(QStringLiteral("#0a84ff"));
+  if (ui.pixelColor(260, 210) != handle || ui.pixelColor(520, 265) != handle) {
+    error = QStringLiteral(
+        "Selected line start handle %1 end handle %2 (want #0a84ff)")
+                .arg(ui.pixelColor(260, 210).name(QColor::HexArgb),
+                     ui.pixelColor(520, 265).name(QColor::HexArgb));
+    return false;
+  }
+  editor.close();
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -4036,6 +4082,10 @@ int main(int argc, char **argv) {
   if (!runCutToolSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 95;
+  }
+  if (!runLineHandleLegendSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 89;
   }
   if (!runOpLogSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
@@ -4308,6 +4358,7 @@ int main(int argc, char **argv) {
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(390, 238));
   application.processEvents();
   const QImage lineSelectedUi = editor.grab().toImage();
+  // Handles stay visible even when this click would flip the help card.
   if (lineSelectedUi.pixelColor(260, 210) !=
           QColor(QStringLiteral("#0a84ff")) ||
       lineSelectedUi.pixelColor(520, 265) != QColor(QStringLiteral("#0a84ff")))

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -974,8 +974,9 @@ bool runQuickOutputChecks(QString &error) {
 }
 
 /**
- * Crash recovery: the working snapshot must reach disk while editing, must be
- * consumed by the save as a default-encoded file, and must not outlive a quit.
+ * Crash recovery: the original source plus op-log JSON must reach disk while
+ * editing, save still writes one flattened PNG, and quit removes the working
+ * document.
  */
 bool runCrashSnapshotChecks(const CaptureData &capture, QString &error) {
   QTemporaryDir directory;
@@ -1024,9 +1025,15 @@ bool runCrashSnapshotChecks(const CaptureData &capture, QString &error) {
     }
     editor.waitForSnapshot();
     const QImage current = editor.renderCurrentOutput();
+    const QString logPath = operationLogPath(snapshotPath);
+    OperationLog log;
+    QString logError;
     if (QImage(snapshotPath).convertToFormat(QImage::Format_ARGB32) !=
-        current.convertToFormat(QImage::Format_ARGB32)) {
-      error = QStringLiteral("Working snapshot did not reflect the edit");
+            capture.source.convertToFormat(QImage::Format_ARGB32) ||
+        !loadOperationLog(logPath, log, logError) || log.ops.isEmpty() ||
+        log.index <= 0) {
+      error = QStringLiteral(
+          "Working document did not keep the source image and op log");
       return false;
     }
     QByteArray reference;
@@ -1039,6 +1046,7 @@ bool runCrashSnapshotChecks(const CaptureData &capture, QString &error) {
         QDir(directory.path())
             .entryList({QStringLiteral("*.png")}, QDir::Files);
     if (files.size() != 1 || QFile::exists(snapshotPath) ||
+        QFile::exists(logPath) ||
         QFileInfo(QDir(directory.path()).filePath(files.constFirst())).size() >
             reference.size() * 3 / 2) {
       error = QStringLiteral(
@@ -1768,7 +1776,6 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
                   QFileDevice::ExeOwner);
   };
   const QString fakeHyprctl = QDir(commands.path()).filePath(QStringLiteral("hyprctl"));
-  const QString fakeGrim = QDir(commands.path()).filePath(QStringLiteral("grim"));
   const QByteArray hyprctlScript =
       QByteArrayLiteral("#!/usr/bin/env bash\n"
                         "if [[ \"$1 $2\" == \"monitors -j\" ]]; then\n"
@@ -1779,13 +1786,7 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
                         "else\n"
                         "  printf '[]\\n'\n"
                         "fi\n");
-  // grim streams the capture on stdout.
-  const QByteArray grimScript =
-      QByteArrayLiteral("#!/usr/bin/env bash\n"
-                        "set -euo pipefail\n"
-                        "cat -- \"$OMASNAP_TEST_PPM\"\n");
-  if (!writeExecutable(fakeHyprctl, hyprctlScript) ||
-      !writeExecutable(fakeGrim, grimScript)) {
+  if (!writeExecutable(fakeHyprctl, hyprctlScript)) {
     error = QStringLiteral("Could not create async capture commands");
     return false;
   }
@@ -1793,16 +1794,16 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
   QImage source(320, 240, QImage::Format_RGB32);
   source.fill(QColor(QStringLiteral("#28405c")));
   const QString sourcePath =
-      QDir(commands.path()).filePath(QStringLiteral("source.ppm"));
-  if (!source.save(sourcePath, "PPM")) {
+      QDir(commands.path()).filePath(QStringLiteral("source.png"));
+  if (!source.save(sourcePath, "PNG")) {
     error = QStringLiteral("Could not create async capture source");
     return false;
   }
 
   const QByteArray oldPath = qgetenv("PATH");
-  const QByteArray oldPpm = qgetenv("OMASNAP_TEST_PPM");
+  const QByteArray oldCapture = qgetenv("OMASNAP_TEST_CAPTURE");
   qputenv("PATH", commands.path().toUtf8() + ':' + oldPath);
-  qputenv("OMASNAP_TEST_PPM", sourcePath.toUtf8());
+  qputenv("OMASNAP_TEST_CAPTURE", sourcePath.toUtf8());
 
   CaptureData capture;
   capture.monitor.name = QStringLiteral("TEST");
@@ -1834,10 +1835,10 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
                 : captureError;
     editor.close();
     qputenv("PATH", oldPath);
-    if (oldPpm.isEmpty())
-      qunsetenv("OMASNAP_TEST_PPM");
+    if (oldCapture.isEmpty())
+      qunsetenv("OMASNAP_TEST_CAPTURE");
     else
-      qputenv("OMASNAP_TEST_PPM", oldPpm);
+      qputenv("OMASNAP_TEST_CAPTURE", oldCapture);
     return false;
   }
 
@@ -1849,10 +1850,10 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
   const QImage selected = editor.renderCurrentOutput();
   editor.close();
   qputenv("PATH", oldPath);
-  if (oldPpm.isEmpty())
-    qunsetenv("OMASNAP_TEST_PPM");
+  if (oldCapture.isEmpty())
+    qunsetenv("OMASNAP_TEST_CAPTURE");
   else
-    qputenv("OMASNAP_TEST_PPM", oldPpm);
+    qputenv("OMASNAP_TEST_CAPTURE", oldCapture);
 
   if (selected.size() != QSize(160, 150)) {
     error = QStringLiteral("Async capture region selection produced %1x%2")
@@ -1974,6 +1975,158 @@ bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
   QFile::remove(snapshotPath);
   return true;
 }
+
+/** Window crop, undo/redo replay, persist+reload, and redaction order. */
+bool runOpLogSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  const QColor backdrop(QStringLiteral("#204060"));
+  const QColor secret(QStringLiteral("#ff2040"));
+  capture.source.fill(backdrop);
+  {
+    QPainter painter(&capture.source);
+    painter.fillRect(QRect(200, 200, 100, 60), secret);
+  }
+  capture.previewSize = capture.source.size();
+  capture.windows = {
+      {{80, 80, 300, 220}, QStringLiteral("w1"), QStringLiteral("first")}};
+
+  {
+    const QImage original = capture.source.copy();
+    CaptureEditor editor(capture, CaptureEditor::CaptureMode::Window);
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 160));
+    application.processEvents();
+    if (editor.captureData().source != original ||
+        editor.currentSelection() != QRectF(80, 80, 300, 220) ||
+        editor.operationIndex() < 1) {
+      error = QStringLiteral("Window pick recaptured or did not crop the source");
+      return false;
+    }
+    editor.close();
+  }
+
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::Fullscreen);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_D);
+  QTest::keyClick(&editor, Qt::Key_D);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(230, 214));
+  QTest::mouseMove(&editor, QPoint(333, 285), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(333, 285));
+  QTest::keyClick(&editor, Qt::Key_5);
+  QTest::keyClick(&editor, Qt::Key_A);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(250, 250));
+  QTest::mouseMove(&editor, QPoint(312, 250), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(312, 250));
+  application.processEvents();
+  if (!editor.waitForSnapshot()) {
+    error = QStringLiteral("Op-log working document did not persist");
+    return false;
+  }
+  const QImage annotated = editor.renderCurrentOutput();
+  const int annotatedIndex = editor.operationIndex();
+  if (annotatedIndex < 2) {
+    error = QStringLiteral("Annotation tools did not append to the op log");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  const QImage undone = editor.renderCurrentOutput();
+  if (editor.operationIndex() != annotatedIndex - 1 || undone == annotated) {
+    error = QStringLiteral("Undo did not replay the op log");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.operationIndex() != annotatedIndex ||
+      editor.renderCurrentOutput() != annotated) {
+    error = QStringLiteral("Redo did not replay the op log");
+    return false;
+  }
+
+  QTemporaryDir directory;
+  if (!directory.isValid()) {
+    error = QStringLiteral("Could not create op-log reload directory");
+    return false;
+  }
+  const QString sourceCopy =
+      QDir(directory.path()).filePath(QStringLiteral("working.png"));
+  const QString logCopy = operationLogPath(sourceCopy);
+  if (!QFile::copy(editor.workingSourcePath(), sourceCopy) ||
+      !QFile::copy(editor.workingLogPath(), logCopy)) {
+    error = QStringLiteral("Could not copy the working document");
+    return false;
+  }
+  editor.close();
+
+  QImage restoredSource;
+  if (!restoredSource.load(sourceCopy)) {
+    error = QStringLiteral("Could not reload the persisted source image");
+    return false;
+  }
+  OperationLog log;
+  if (!loadOperationLog(logCopy, log, error))
+    return false;
+  CaptureData restored;
+  restored.source = restoredSource;
+  restored.previewSize = restoredSource.size();
+  restored.monitor.scale = 1.0;
+  restored.monitor.pixelSize = restoredSource.size();
+  restored.monitor.geometry = QRect(QPoint(), restoredSource.size());
+  CaptureEditor reopened(restored, CaptureEditor::CaptureMode::File,
+                         QuickOutputMode::None, log);
+  reopened.resize(800, 600);
+  reopened.show();
+  application.processEvents();
+  const QImage reloaded = reopened.renderCurrentOutput();
+  if (reopened.operationIndex() != annotatedIndex ||
+      reloaded.convertToFormat(QImage::Format_ARGB32) !=
+          annotated.convertToFormat(QImage::Format_ARGB32)) {
+    error = QStringLiteral("Reloading the op log did not restore the view");
+    return false;
+  }
+  QTest::keyClick(&reopened, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (reopened.renderCurrentOutput().convertToFormat(QImage::Format_ARGB32) !=
+      undone.convertToFormat(QImage::Format_ARGB32)) {
+    error = QStringLiteral("Reloaded undo did not keep working");
+    return false;
+  }
+  QTest::keyClick(&reopened, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+
+  const QImage replayed = reopened.renderCurrentOutput().convertToFormat(
+      QImage::Format_ARGB32);
+  const QColor covered = replayed.pixelColor(220, 210);
+  const QColor overlay = replayed.pixelColor(260, 230);
+  if (covered == secret || overlay == secret) {
+    error = QStringLiteral("Replay leaked source pixels through redaction");
+    return false;
+  }
+  if (covered != QColor(QStringLiteral("#121216"))) {
+    error = QStringLiteral("Replay did not keep the redaction layer (%1)")
+                .arg(covered.name());
+    return false;
+  }
+  if (overlay != QColor(QStringLiteral("#0a84ff"))) {
+    error = QStringLiteral(
+                "Replay did not keep default-layer annotations above "
+                "redaction (%1)")
+                .arg(overlay.name());
+    return false;
+  }
+  reopened.close();
+  return true;
+}
+
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
@@ -3759,6 +3912,10 @@ int main(int argc, char **argv) {
     qWarning().noquote() << snapshotError;
     return 95;
   }
+  if (!runOpLogSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 98;
+  }
   const QString outputRoot =
       argc > 1 ? QString::fromLocal8Bit(argv[1])
                : QDir(QDir::tempPath())
@@ -4330,21 +4487,27 @@ int main(int argc, char **argv) {
           outputRoot + QStringLiteral("-window-mode.png"), "PNG"))
     return 36;
 
-  CaptureData failedWindowCapture = capture;
-  failedWindowCapture.windows = {{{80, 80, 300, 220},
-                                  QStringLiteral("missing-stable-id"),
-                                  QStringLiteral("missing")}};
-  CaptureEditor failedWindowEditor(failedWindowCapture,
-                                   CaptureEditor::CaptureMode::Window);
-  failedWindowEditor.resize(800, 600);
-  failedWindowEditor.show();
-  QTest::mouseMove(&failedWindowEditor, QPoint(200, 160), 20);
-  QTest::keyClick(&failedWindowEditor, Qt::Key_Return);
+  CaptureData windowPickCapture = capture;
+  const QImage originalSource = windowPickCapture.source.copy();
+  CaptureEditor windowPickEditor(windowPickCapture,
+                                 CaptureEditor::CaptureMode::Window);
+  windowPickEditor.resize(800, 600);
+  windowPickEditor.show();
   application.processEvents();
-  if (failedWindowEditor.cursor().shape() != Qt::PointingHandCursor ||
-      !failedWindowEditor.grab().save(
-          outputRoot + QStringLiteral("-window-capture-failed.png"), "PNG"))
+  QTest::mouseClick(&windowPickEditor, Qt::LeftButton, Qt::NoModifier,
+                    QPoint(200, 160));
+  application.processEvents();
+  const QImage windowCrop = windowPickEditor.renderCurrentOutput();
+  const QImage expectedCrop = renderCapture(
+      capture, QRectF(80, 80, 300, 220), {}, BackgroundStyle::None);
+  if (windowPickEditor.captureData().source != originalSource ||
+      windowPickEditor.currentSelection() != QRectF(80, 80, 300, 220) ||
+      windowCrop.convertToFormat(QImage::Format_ARGB32) !=
+          expectedCrop.convertToFormat(QImage::Format_ARGB32) ||
+      !windowPickEditor.grab().save(
+          outputRoot + QStringLiteral("-window-pick-crop.png"), "PNG"))
     return 63;
+  windowPickEditor.close();
 
   CaptureData nativePreviewCapture = capture;
   nativePreviewCapture.monitor.scale = 2.0;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2127,6 +2127,131 @@ bool runOpLogSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Quotes the same way sendCaptureNotification builds --exec. */
+bool runShellQuoteCheck(QString &error) {
+  if (shellQuote(QStringLiteral("omasnap")) != QStringLiteral("'omasnap'")) {
+    error = QStringLiteral("shellQuote did not wrap a simple token");
+    return false;
+  }
+  if (shellQuote(QStringLiteral("omasnap /tmp/a.png")) !=
+      QStringLiteral("'omasnap /tmp/a.png'")) {
+    error = QStringLiteral("shellQuote did not keep spaces inside quotes");
+    return false;
+  }
+  if (shellQuote(QStringLiteral("it's")) != QStringLiteral("'it'\"'\"'s'")) {
+    error = QStringLiteral("shellQuote did not escape a single quote (%1)")
+                .arg(shellQuote(QStringLiteral("it's")));
+    return false;
+  }
+  sendCaptureNotification(QStringLiteral("smoke"));
+  return true;
+}
+
+/**
+ * Filling the 100-op cap used to drop the leading Crop, so replay started at
+ * the full monitor while later annotations stayed in cropped space.
+ */
+bool runOpLogCapKeepsLeadingCrop(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  const QColor outside(QStringLiteral("#102030"));
+  const QColor inside(QStringLiteral("#e8c040"));
+  capture.source.fill(outside);
+  {
+    QPainter painter(&capture.source);
+    painter.fillRect(QRect(80, 80, 300, 220), inside);
+  }
+  capture.previewSize = capture.source.size();
+
+  const QRectF crop(80, 80, 300, 220);
+  OperationLog log;
+  Operation cropOp;
+  cropOp.type = Operation::Type::Crop;
+  cropOp.crop = crop;
+  log.ops.push_back(cropOp);
+  for (int n = 1; n <= 99; ++n) {
+    Annotation marker;
+    marker.kind = Annotation::Kind::Marker;
+    marker.start = QPointF(40, 40);
+    marker.number = n;
+    marker.color = QColor(QStringLiteral("#ff375f"));
+    marker.size = 4.0;
+    marker.id = static_cast<quint64>(n);
+    Operation annotate;
+    annotate.type = Operation::Type::Annotate;
+    annotate.annotations = {marker};
+    log.ops.push_back(std::move(annotate));
+  }
+  log.index = log.ops.size();
+  log.nextId = 100;
+  log.nextMarker = 100;
+
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::File,
+                       QuickOutputMode::None, log);
+  editor.setSuppressSnapshots(true);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  if (editor.currentSelection() != crop || editor.operationLog().isEmpty() ||
+      editor.operationLog().constFirst().type != Operation::Type::Crop) {
+    error = QStringLiteral("Loaded log did not keep the leading crop");
+    return false;
+  }
+
+  QTest::keyClick(&editor, Qt::Key_C);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(400, 300));
+  application.processEvents();
+
+  if (editor.operationLog().size() != 100 ||
+      editor.operationLog().constFirst().type != Operation::Type::Crop ||
+      editor.currentSelection() != crop) {
+    error = QStringLiteral("Op-log cap dropped the initial crop");
+    return false;
+  }
+
+  const QImage exported = editor.renderCurrentOutput();
+  if (exported.size() != QSize(300, 220)) {
+    error = QStringLiteral("Capped replay left the full monitor (%1x%2)")
+                .arg(exported.width())
+                .arg(exported.height());
+    return false;
+  }
+  if (exported.pixelColor(10, 10) != inside) {
+    error = QStringLiteral("Capped replay did not stay in cropped space");
+    return false;
+  }
+
+  QTemporaryDir directory;
+  if (!directory.isValid()) {
+    error = QStringLiteral("Could not create op-log cap directory");
+    return false;
+  }
+  const QString logPath =
+      QDir(directory.path()).filePath(QStringLiteral("capped.json"));
+  OperationLog persisted;
+  persisted.ops = editor.operationLog();
+  persisted.index = editor.operationIndex();
+  persisted.nextId = 101;
+  persisted.nextMarker = 101;
+  if (!saveOperationLog(logPath, persisted, error))
+    return false;
+  OperationLog reloaded;
+  if (!loadOperationLog(logPath, reloaded, error))
+    return false;
+  if (reloaded.ops.isEmpty() ||
+      reloaded.ops.constFirst().type != Operation::Type::Crop ||
+      reloaded.ops.constFirst().crop != crop) {
+    error = QStringLiteral("Persisted capped log lost the leading crop");
+    return false;
+  }
+  editor.close();
+  return true;
+}
+
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
@@ -3915,6 +4040,14 @@ int main(int argc, char **argv) {
   if (!runOpLogSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 98;
+  }
+  if (!runShellQuoteCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 83;
+  }
+  if (!runOpLogCapKeepsLeadingCrop(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 84;
   }
   const QString outputRoot =
       argc > 1 ? QString::fromLocal8Bit(argv[1])

--- a/tests/transform-smoke.cpp
+++ b/tests/transform-smoke.cpp
@@ -49,8 +49,6 @@ bool runTransformSmoke(QString &error) {
   }
   const QString fakeHyprctl =
       QDir(fakeCommands.path()).filePath(QStringLiteral("hyprctl"));
-  const QString fakeGrim =
-      QDir(fakeCommands.path()).filePath(QStringLiteral("grim"));
   const QByteArray hyprctlScript = QByteArrayLiteral(
       "#!/usr/bin/env bash\n"
       "set -euo pipefail\n"
@@ -63,38 +61,26 @@ bool runTransformSmoke(QString &error) {
       "  printf '[{\"workspace\":{\"id\":7},\"at\":[0,0],\"size\":[100,100],"
       "\"title\":\"Test window\",\"stableId\":\"w1\"}]\\n'\n"
       "fi\n");
-  // grim streams the capture on stdout; the garbage mode exits cleanly with
-  // undecodable bytes so the decode failure path can be checked.
-  const QByteArray grimScript = QByteArrayLiteral(
-      "#!/usr/bin/env bash\n"
-      "set -euo pipefail\n"
-      "if [[ -n \"${OMASNAP_TEST_GRIM_GARBAGE:-}\" ]]; then\n"
-      "  printf 'not-a-ppm'\n"
-      "  exit 0\n"
-      "fi\n"
-      "cat -- \"$OMASNAP_TEST_PPM\"\n");
-  if (!writeExecutable(fakeHyprctl, hyprctlScript) ||
-      !writeExecutable(fakeGrim, grimScript)) {
+  if (!writeExecutable(fakeHyprctl, hyprctlScript)) {
     error = QStringLiteral("Could not create transform-test commands");
     return false;
   }
   QImage rotatedSource(300, 200, QImage::Format_RGB32);
   rotatedSource.fill(QColor(QStringLiteral("#123456")));
-  const QString ppmPath =
-      QDir(fakeCommands.path()).filePath(QStringLiteral("source.ppm"));
-  if (!rotatedSource.save(ppmPath, "PPM")) {
+  const QString capturePath =
+      QDir(fakeCommands.path()).filePath(QStringLiteral("source.png"));
+  if (!rotatedSource.save(capturePath, "PNG")) {
     error = QStringLiteral("Could not create transform-test capture");
     return false;
   }
 
   const QByteArray originalPath = qgetenv("PATH");
   qputenv("PATH", fakeCommands.path().toUtf8() + ':' + originalPath);
-  qputenv("OMASNAP_TEST_PPM", ppmPath.toUtf8());
+  qputenv("OMASNAP_TEST_CAPTURE", capturePath.toUtf8());
   const auto restoreEnvironment = [&originalPath] {
     qputenv("PATH", originalPath);
-    qunsetenv("OMASNAP_TEST_PPM");
+    qunsetenv("OMASNAP_TEST_CAPTURE");
     qunsetenv("OMASNAP_TEST_TRANSFORM");
-    qunsetenv("OMASNAP_TEST_GRIM_GARBAGE");
   };
   for (const int transform : {1, 3, 5, 7}) {
     qputenv("OMASNAP_TEST_TRANSFORM", QByteArray::number(transform));
@@ -123,15 +109,14 @@ bool runTransformSmoke(QString &error) {
     return false;
   }
 
-  // A grim that exits cleanly but streams undecodable bytes must still explain
-  // itself instead of reporting an empty error.
-  qputenv("OMASNAP_TEST_GRIM_GARBAGE", QByteArrayLiteral("1"));
-  CaptureData undecodable;
-  QString decodeError;
-  const bool decoded = captureFocusedMonitor(undecodable, false, decodeError);
-  qunsetenv("OMASNAP_TEST_GRIM_GARBAGE");
-  if (decoded || decodeError.isEmpty()) {
-    error = QStringLiteral("Undecodable capture data did not report an error");
+  // Without a test capture, missing output-capture protocol must fail clearly.
+  qunsetenv("OMASNAP_TEST_CAPTURE");
+  CaptureData missingProtocol;
+  QString protocolError;
+  const bool captured =
+      captureFocusedMonitor(missingProtocol, false, protocolError);
+  if (captured || protocolError.isEmpty()) {
+    error = QStringLiteral("Missing output capture did not report an error");
     restoreEnvironment();
     return false;
   }


### PR DESCRIPTION
## Summary
- Capture the focused monitor in-process through `ext-image-copy-capture` instead of shelling out to grim. Missing output-capture protocol fails clearly. Window pick is a crop of that frame (no second screenshot).
- The working document is the original source image plus a sidecar JSON operation log. Undo/redo walks the log; a bitmap is materialized only on save, copy, pin, and OCR. `--file` restores a sibling `.json` so undo still works after crash/reopen.
- Redactions stay on the bottom layer after replay. Final save/copy still writes a flattened PNG.

## Test plan
- [x] `cmake --build build --target omasnap-smoke` then `QT_QPA_PLATFORM=offscreen ./build/omasnap-smoke /tmp/omasnap-smoke` (exit 0)
- [ ] On Hyprland: region / window / fullscreen capture without grim
- [ ] Annotate, undo, kill the process, reopen the runtime source + sidecar JSON with `--file`, confirm undo still works
- [ ] Save/copy still produce a flattened PNG; working source+JSON are removed