### PR TITLE
feat(editor): Save As dialog on Ctrl+Shift+S

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Install the corresponding Tesseract language data before adding a language to
 | `Ctrl+Shift+Z`, `Ctrl+Y` | Redo |
 | `Ctrl+C` | Copy PNG only |
 | `Ctrl+S` | Save PNG only |
+| `Ctrl+Shift+S` | Save As: pick a destination in a file dialog; the editor stays open, and the chosen folder is remembered for the next Save As |
 | `Enter` | Copy and save |
 | `P` | Pin the capture on screen and close the editor |
 | `Esc` | Return to Select; press again to close |

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -168,11 +168,7 @@ QString runtimePath(const QString &name) {
 }
 
 QString screenshotTargetPath(QString &error) {
-  QString root = qEnvironmentVariable("OMASNAP_SCREENSHOT_DIR");
-  if (root.isEmpty())
-    root =
-        QDir(QStandardPaths::writableLocation(QStandardPaths::PicturesLocation))
-            .filePath(QStringLiteral("Screenshots"));
+  const QString root = screenshotRootDir();
   if (!QDir().mkpath(root)) {
     error =
         QStringLiteral("Could not create screenshot directory: %1").arg(root);
@@ -1042,6 +1038,21 @@ bool quickOutput(const QImage &image, QuickOutputMode mode, QString &error) {
     sendCaptureNotification(QStringLiteral("Screenshot copied to clipboard"));
   }
   return true;
+}
+
+QString screenshotRootDir() {
+  QString root = qEnvironmentVariable("OMASNAP_SCREENSHOT_DIR");
+  if (root.isEmpty())
+    root =
+        QDir(QStandardPaths::writableLocation(QStandardPaths::PicturesLocation))
+            .filePath(QStringLiteral("Screenshots"));
+  return root;
+}
+
+QString defaultScreenshotFileName() {
+  return QStringLiteral("screenshot-%1.png")
+      .arg(QDateTime::currentDateTime().toString(
+          QStringLiteral("yyyy-MM-dd_HH-mm-ss")));
 }
 
 QString moveSnapshotToScreenshots(const QString &sourcePath, QString &error) {

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -190,6 +190,10 @@ QImage applyRedactionsScaled(QImage image, const QVector<Annotation> &redactions
 [[nodiscard]] bool ensurePrivateDirectory(const QString &path);
 /** Returns Omasnap's private runtime directory, or empty on failure. */
 [[nodiscard]] QString secureRuntimeDirectory();
+/** Returns the screenshot output directory without creating it. */
+[[nodiscard]] QString screenshotRootDir();
+/** Returns a timestamped `screenshot-….png` file name. */
+[[nodiscard]] QString defaultScreenshotFileName();
 [[nodiscard]] QString moveSnapshotToScreenshots(const QString &sourcePath,
                                                 QString &error);
 [[nodiscard]] QString temporarySnapshotPath();

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -14,6 +14,7 @@
 #include <QDir>
 #include <QEvent>
 #include <QFile>
+#include <QFileDialog>
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QFontMetrics>
@@ -27,6 +28,7 @@
 #include <QRandomGenerator>
 #include <QScreen>
 #include <QScrollBar>
+#include <QSettings>
 #include <QTextDocument>
 #include <QThread>
 #include <QTimer>
@@ -2614,6 +2616,68 @@ void CaptureEditor::finish(OutputMode mode) {
   close();
 }
 
+void CaptureEditor::saveAs() {
+  // Ctrl+Shift+S: pick a destination, write a copy there, and keep the
+  // editor open so Enter/Ctrl+C/Ctrl+S still produce the default outputs.
+  if (busy_ || selection_.isEmpty())
+    return;
+  busy_ = true;
+  setStatus(QStringLiteral("Preparing screenshot…"));
+  snapshotOutputRequested_ = true;
+  scheduleSnapshot();
+  const bool snapshotOk = waitForSnapshot();
+  // Later mid-edit writes go back to the fast crash-recovery compression.
+  snapshotOutputRequested_ = false;
+  const QFileInfo snapshotFile(snapshotPath_);
+  if (!snapshotOk || snapshotPath_.isEmpty() || !snapshotFile.exists() ||
+      snapshotFile.size() <= 0) {
+    busy_ = false;
+    setStatus(QStringLiteral("Could not prepare screenshot snapshot"));
+    return;
+  }
+
+  QSettings settings(defaultPaletteConfigPath(), QSettings::IniFormat);
+  QString startDir =
+      settings.value(QStringLiteral("output/save_as_dir")).toString();
+  if (startDir.isEmpty() || !QDir(startDir).exists())
+    startDir = screenshotRootDir();
+  const QString suggested =
+      QDir(startDir).filePath(defaultScreenshotFileName());
+  // The editor is a fullscreen stays-on-top surface, so a dialog opened on
+  // top of it ends up buried behind it with no way to reach either window.
+  // Hide the overlay for the dialog's lifetime (parent nullptr keeps the
+  // dialog mapped while the editor is hidden), then restore it.
+  hide();
+  QString target = QFileDialog::getSaveFileName(
+      nullptr, QStringLiteral("Save screenshot as"), suggested,
+      QStringLiteral("PNG image (*.png)"));
+  show();
+  raise();
+  activateWindow();
+  if (target.isEmpty()) {
+    busy_ = false;
+    setStatus(QStringLiteral("Save As cancelled"));
+    return;
+  }
+  if (!target.endsWith(QStringLiteral(".png"), Qt::CaseInsensitive))
+    target += QStringLiteral(".png");
+  if (QFile::exists(target) && !QFile::remove(target)) {
+    busy_ = false;
+    setStatus(QStringLiteral("Could not overwrite: %1").arg(target));
+    return;
+  }
+  if (!QFile::copy(snapshotPath_, target)) {
+    busy_ = false;
+    setStatus(QStringLiteral("Could not save to: %1").arg(target));
+    return;
+  }
+  settings.setValue(QStringLiteral("output/save_as_dir"),
+                    QFileInfo(target).absolutePath());
+  busy_ = false;
+  setStatus(QStringLiteral("Saved to %1").arg(target));
+  sendCaptureNotification(QStringLiteral("Screenshot saved"), target);
+}
+
 void CaptureEditor::handleToolbar(const QString &action) {
   const Tool toolBefore = tool_;
   const QString statusBefore = status_;
@@ -2859,6 +2923,12 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     undoEdit();
   } else if (event->matches(QKeySequence::Copy)) {
     finish(OutputMode::Copy);
+    return;
+  } else if (event->matches(QKeySequence::SaveAs) ||
+             (event->key() == Qt::Key_S &&
+              event->modifiers().testFlag(Qt::ControlModifier) &&
+              event->modifiers().testFlag(Qt::ShiftModifier))) {
+    saveAs();
     return;
   } else if (event->matches(QKeySequence::Save)) {
     finish(OutputMode::Save);
@@ -4663,6 +4733,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
        {QStringLiteral("Enter"), QStringLiteral("Copy + save")},
        {QStringLiteral("Ctrl+C"), QStringLiteral("Copy only")},
        {QStringLiteral("Ctrl+S"), QStringLiteral("Save only")},
+       {QStringLiteral("Ctrl+Shift+S"), QStringLiteral("Save As…")},
        {QStringLiteral("Esc"), QStringLiteral("Arrow / twice close")}},
       keepVisible);
   if (hoveredButton) {

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -314,6 +314,7 @@ private:
   void redoEdit();
   void selectWindowInDirection(int key);
   void finish(OutputMode mode);
+  void saveAs();
   void handleEscape();
   void handleToolbar(const QString &action);
   void paintEdit(QPainter &painter);


### PR DESCRIPTION
Why this PR: Usually, saving to the default location is enough. But I have some screenshots that I take for certain things - then it's handy to save them directly there, or replace an existing image with a new, better one.

So here's an easy `Save as` option. The harder part was working around the overlay image, so it hides Omasnap when you choose the file location and opens back up after saving, so you can close it afterward, save to the default spot, or save to the clipboard.

## Claude Fable Summary
- Adds a **Save As** action (`Ctrl+Shift+S`) in the editor: opens a file dialog to pick a destination and writes a copy there.
- The editor stays open afterwards — `Enter`/`Ctrl+C`/`Ctrl+S` default outputs are unchanged.
- The chosen folder is remembered (`output/save_as_dir` in the config) and offered as the start directory next time.
- The fullscreen stays-on-top overlay is hidden while the dialog is up so the dialog isn't buried behind it, then restored.
- Listed in the hotkey legend and README.

## Test plan
- `make build` and lint pass.
- Manual: capture, annotate, `Ctrl+Shift+S`, pick a path — file written, editor still open, next Save As starts in the same folder. Cancel path leaves editor usable.