### PR TITLE
feat(editor): the wheel grows a filled shape instead of thickening it

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1369,6 +1369,29 @@ void CaptureEditor::adjustSelectedAnnotation(int step) {
   case Annotation::Kind::Ellipse:
     break;
   }
+  // A filled shape has no stroke showing, so weighing it would be a gesture
+  // that does nothing visible: it grows instead, like the redaction above,
+  // and says so.
+  if (annotation.filled && (annotation.kind == Annotation::Kind::Rectangle ||
+                            annotation.kind == Annotation::Kind::Ellipse)) {
+    const qreal factor = step > 0 ? 1.1 : 1.0 / 1.1;
+    const QRectF bounds = annotationBounds(annotation);
+    const QPointF center = bounds.center();
+    const qreal scale =
+        bounds.width() > 0 && bounds.height() > 0
+            ? std::max({factor, kMinimumRedactionExtent / bounds.width(),
+                        kMinimumRedactionExtent / bounds.height()})
+            : factor;
+    annotation.start = center + (annotation.start - center) * scale;
+    annotation.end = center + (annotation.end - center) * scale;
+    const QRectF grown = annotationBounds(annotation);
+    setStatus(QStringLiteral("Filled shape · %1 × %2 · R unfills it to set "
+                             "a thickness")
+                  .arg(qRound(grown.width()))
+                  .arg(qRound(grown.height())));
+    commitPatch({selectedAnnotation_});
+    return;
+  }
   annotation.size = weigh(annotation.size, 2.0, 30.0);
   setStatus(QStringLiteral("Selected layer · thickness %1 · handle resizes")
                 .arg(qRound(annotation.size)));

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4696,6 +4696,42 @@ bool runLayerWeightSmoke(QApplication &application, QString &error) {
                            "settled");
     return false;
   }
+  // A filled shape has no stroke to thicken, so its wheel grows it about its
+  // center instead of doing nothing visible.
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(650, 150));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_R);
+  QTest::keyClick(&editor, Qt::Key_R); // R again: fill on for the next shape
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(450, 350));
+  QTest::mouseMove(&editor, QPoint(550, 420), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(550, 420));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(500, 385));
+  application.processEvents();
+  {
+    // Filled interior: (350,265)-(450,335) in annotation space. Just outside
+    // the left edge is bare; two notches up must cover it, and two back down
+    // must uncover it again.
+    const QImage before = flushedSnapshot(editor, snapshotPath);
+    if (!ink(before, 360, 300) || ink(before, 340, 300)) {
+      error = QStringLiteral("Filled shape did not render where expected");
+      return false;
+    }
+    wheel(2);
+    const QImage grown = flushedSnapshot(editor, snapshotPath);
+    if (!ink(grown, 340, 300)) {
+      error = QStringLiteral("The wheel did not grow the filled shape");
+      return false;
+    }
+    wheel(-2);
+    const QImage back = flushedSnapshot(editor, snapshotPath);
+    if (ink(back, 340, 300)) {
+      error = QStringLiteral("The wheel did not shrink the filled shape back");
+      return false;
+    }
+  }
   editor.close();
   QFile::remove(snapshotPath);
   return true;


### PR DESCRIPTION
Small follow-up to the wheel-as-weight change. A filled rectangle or ellipse has no stroke showing, so turning the wheel on one thickened a stroke you couldn't see: the gesture did nothing visible.

It grows the shape about its center now, the way the redaction's wheel already does, with the same minimum-extent floor so it can't shrink into nothing. The status names the new size and points at R for anyone who actually wanted a stroke back.

The layer-weight smoke gains a filled case: the wheel covers a point just outside the shape's edge and uncovers it again on the way back down.
