### PR TITLE
feat(capture): R restores the last region drawn this session

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Install the corresponding Tesseract language data before adding a language to
 |---|---|
 | Drag | Select a region, with its native pixel size shown at the pointer |
 | `Space` | Toggle region/window selection |
+| `R` | Restore the last region drawn this session (same monitor) |
 | `SUPER + Arrow` | Move among windows in window mode |
 | `Enter` | Capture the highlighted window |
 | `Ctrl+A` | Select the full focused monitor |

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -74,6 +74,55 @@ constexpr qreal kToolbarWidth = 840;
 constexpr qreal kToolbarImageGap = 46;
 constexpr qreal kMinimumRedactionExtent = 5.0;
 constexpr int kBackdropDim = 143;
+
+/// Beside the snapshots and the instance lock, in the private runtime dir.
+/// Session scratch, not configuration: gone at reboot, and a region only
+/// means anything for the screen it was drawn on. Mirrors the scroll
+/// capture's stored region; the two can share helpers once both are in.
+QString storedCaptureRegionPath() {
+  const QString runtime = secureRuntimeDirectory();
+  if (runtime.isEmpty())
+    return {};
+  return QDir(runtime).filePath(QStringLiteral("capture-region"));
+}
+
+QString formatStoredRegion(const QString &monitor, const QSize &surface,
+                           const QRect &region) {
+  return QStringLiteral("%1 %2 %3 %4 %5 %6 %7")
+      .arg(monitor.isEmpty() ? QStringLiteral("?") : monitor)
+      .arg(surface.width())
+      .arg(surface.height())
+      .arg(region.x())
+      .arg(region.y())
+      .arg(region.width())
+      .arg(region.height());
+}
+
+/// The region in `line`, or a null rect when it was written for a different
+/// monitor or surface size, does not fit, or is not what we wrote. Anything
+/// unreadable is simply not offered; there is nothing to migrate.
+QRect parseStoredRegion(const QString &line, const QString &monitor,
+                        const QSize &surface) {
+  const QStringList fields = line.trimmed().split(QLatin1Char(' '));
+  if (fields.size() != 7)
+    return {};
+  if (fields.at(0) != (monitor.isEmpty() ? QStringLiteral("?") : monitor))
+    return {};
+  bool ok = true;
+  int values[6] = {};
+  for (int index = 0; index < 6; ++index) {
+    bool field = false;
+    values[index] = fields.at(index + 1).toInt(&field);
+    ok = ok && field;
+  }
+  if (!ok || QSize(values[0], values[1]) != surface)
+    return {};
+  const QRect region(values[2], values[3], values[4], values[5]);
+  if (region.width() < 32 || region.height() < 32 ||
+      !QRect(QPoint(), surface).contains(region))
+    return {};
+  return region;
+}
 constexpr qreal kNudgeStep = 1.0;
 constexpr qreal kNudgeStepShift = 10.0;
 
@@ -455,6 +504,11 @@ void drawHotkeyLegend(QPainter &painter, const QRect &bounds,
   const QRectF other = cursorWantsLeft ? right : left;
   if (hiddenCount(panel) > hiddenCount(other))
     panel = other;
+  // A surface narrower than the card has nowhere for the flip to go: both
+  // positions span the whole width, so the card would sit on whatever is
+  // being pointed at. Step aside entirely; on any real monitor it fits.
+  if (right.left() < left.left())
+    return;
 
   painter.setPen(QPen(QColor(255, 255, 255, 34), 1));
   painter.setBrush(QColor(13, 15, 20, 224));
@@ -2793,6 +2847,28 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
       chooseWindow(hoveredWindow_);
       return;
     }
+    if (!windowMode_ && !dragging_ && event->key() == Qt::Key_R &&
+        !event->modifiers()) {
+      // R brings back the last region drawn this session, written for this
+      // monitor at this size; anything else in the file is simply ignored.
+      const QString path = storedCaptureRegionPath();
+      if (!path.isEmpty()) {
+        QFile file(path);
+        if (file.open(QIODevice::ReadOnly)) {
+          const QRect region =
+              parseStoredRegion(QString::fromUtf8(file.readLine(256)),
+                                capture_.monitor.name, size());
+          if (!region.isEmpty()) {
+            selection_ = QRectF(region);
+            enterEdit(QStringLiteral("Last area restored · Select moves "
+                                     "layers · wheel zooms · outer handles "
+                                     "crop"));
+            update();
+          }
+        }
+      }
+      return;
+    }
     if (event->key() == Qt::Key_Space) {
       windowMode_ = !windowMode_;
       dragging_ = false;
@@ -3668,9 +3744,20 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
   if (phase_ == Phase::Select) {
     selection_ = normalizedSelection(dragStart_, event->position());
     dragging_ = false;
-    if (selection_.width() >= 2 && selection_.height() >= 2)
+    if (selection_.width() >= 2 && selection_.height() >= 2) {
+      // Remember the drawn region for this session, so R can bring it back
+      // on the next capture. A convenience, so failing to write is no error.
+      const QString path = storedCaptureRegionPath();
+      if (!path.isEmpty()) {
+        QFile file(path);
+        if (file.open(QIODevice::WriteOnly | QIODevice::Truncate))
+          file.write(formatStoredRegion(capture_.monitor.name, size(),
+                                        selection_.toRect())
+                         .toUtf8());
+      }
       enterEdit(QStringLiteral("Area selected · Select moves layers · wheel "
                                "zooms · outer handles crop"));
+    }
     updatePointerCursor();
     update();
     return;
@@ -4193,6 +4280,7 @@ void CaptureEditor::paintSelect(QPainter &painter) {
                    {{QStringLiteral("Drag"), QStringLiteral("Area")},
                     {QStringLiteral("Space"), QStringLiteral("Window")},
                     {QStringLiteral("Ctrl+A"), QStringLiteral("Fullscreen")},
+                    {QStringLiteral("R"), QStringLiteral("Last region")},
                     {QStringLiteral("Esc ×2"), QStringLiteral("Close")}});
   drawStatusPill(painter, rect(), status_);
   drawMeasureBadge(painter, rect(), cursor_, measurementText());

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4701,6 +4701,76 @@ bool runLayerWeightSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Checks that R restores the last drawn region on the same monitor and
+ *  ignores one stored for a different monitor. */
+bool runAreaLastRegionSmoke(QApplication &application, QString &error) {
+  const auto makeCapture = [](const QString &name) {
+    CaptureData capture;
+    capture.monitor.name = name;
+    capture.monitor.geometry = {0, 0, 800, 600};
+    capture.monitor.pixelSize = {800, 600};
+    capture.monitor.scale = 1.0;
+    capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+    capture.source.fill(QColor(QStringLiteral("#182030")));
+    capture.previewSize = capture.source.size();
+    return capture;
+  };
+
+  // Draw a region; committing it writes the session memory.
+  {
+    CaptureEditor editor(makeCapture(QStringLiteral("TEST")));
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(120, 140));
+    QTest::mouseMove(&editor, QPoint(520, 380), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(520, 380));
+    application.processEvents();
+    editor.close();
+    application.processEvents();
+  }
+
+  // A fresh overlay on the same monitor at the same size restores it with R.
+  {
+    CaptureEditor editor(makeCapture(QStringLiteral("TEST")));
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::keyClick(&editor, Qt::Key_R);
+    application.processEvents();
+    if (!editor.statusForTest().contains(QStringLiteral("Last area restored"))) {
+      error = QStringLiteral("R did not restore the last region");
+      return false;
+    }
+    const QImage out = editor.renderCurrentOutput();
+    if (out.size() != QSize(400, 240)) {
+      error = QStringLiteral("Restored region was not the drawn 400x240");
+      return false;
+    }
+    editor.close();
+    application.processEvents();
+  }
+
+  // A different monitor ignores it: R stays in the select phase.
+  {
+    CaptureEditor editor(makeCapture(QStringLiteral("OTHER")));
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::keyClick(&editor, Qt::Key_R);
+    application.processEvents();
+    if (editor.statusForTest().contains(QStringLiteral("Last area restored"))) {
+      error = QStringLiteral("R restored a region stored for another monitor");
+      return false;
+    }
+    editor.close();
+    application.processEvents();
+  }
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -4712,6 +4782,11 @@ int main(int argc, char **argv) {
   if (!loadCaptureFonts())
     return 17;
   QString snapshotError;
+  if (!runAreaLastRegionSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 119;
+  }
+
   if (!runPositionalImageTargetCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 70;


### PR DESCRIPTION
Reselecting the same area, usually to retake a capture after fixing whatever it showed, meant drawing the region again by hand every time.

Committing a region drag now writes one line beside the snapshots and the instance lock in the private runtime dir, and R during selection brings it back. It's session scratch rather than configuration: gone at reboot, only honored on the monitor it was drawn on at the same surface size, and anything unreadable is simply not offered. Same idiom as the scroll capture's R in #69; the two small helpers mirror each other and can be shared once both are in.

The select guide gains the R row. Adding a sixth entry also exposed that on a surface narrower than the card, the guide's cursor flip has nowhere to go, so it now steps aside entirely there; on any real monitor it fits. (#69 carries the identical two lines, so they merge clean in either order.)

`runAreaLastRegionSmoke` (exit 119): a drawn region restores in a fresh overlay on the same monitor, comes back at its exact size, and is refused on a different monitor.
