### PR TITLE
feat: add Neovim-powered code image mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ foreach(PROTOCOL_XML IN LISTS PROTOCOL_XMLS)
 endforeach()
 
 add_library(omasnap-core STATIC
+  src/code-image.cpp
+  src/code-image.hpp
   src/cli-path.cpp
   src/cli-path.hpp
   src/icons.cpp
@@ -82,6 +84,8 @@ target_link_libraries(omasnap PRIVATE omasnap-core LayerShellQt::Interface)
 
 if(BUILD_TESTING)
 qt_add_executable(omasnap-smoke
+  tests/code-image-smoke.cpp
+  tests/code-image-smoke.hpp
   tests/editor-smoke.cpp
   tests/clipboard-smoke.cpp
   tests/clipboard-smoke.hpp

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Verified PNG clipboard output through `wl-copy`/`wl-paste`, plus timestamped files
   under `~/Pictures/Screenshots` by default.
 - Open an image already on the clipboard directly in the annotation editor.
+- Turn copied code or a source file into a Neovim-highlighted image that follows
+  the current Omarchy theme, then annotate and share it through the same editor.
 - Correct native-pixel export on fractional or integer-scaled monitors.
 
 ## Platform scope
@@ -53,6 +55,8 @@ Runtime commands used by the application:
 - `hyprctl`
 - `wl-copy` and `wl-paste`
 - `tesseract`
+- `nvim` for code-to-image syntax highlighting. Omarchy installs it by default;
+  code mode shows a notification if it has been removed.
 - `omarchy-notification-send` when available; saved captures include a thumbnail and
   reopen in Omasnap when clicked. Notification failure does not invalidate output.
 
@@ -222,6 +226,43 @@ omasnap --clipboard
 
 The clipboard must offer readable image data. Text-only clipboard contents return an
 error instead of opening an empty editor.
+
+### Share code as an image
+
+Copy a snippet and open it as a themed code image:
+
+```bash
+omasnap --code
+```
+
+Or render a source file directly:
+
+```bash
+omasnap --code path/to/example.rs
+```
+
+The language is detected automatically and can be overridden. Omasnap first uses a
+source filename (including one found in the active window title), then asks Neovim to
+detect the filetype from the filename and recognizable content. A title is optional;
+when omitted, no title row is drawn:
+
+```bash
+omasnap --code --language rust
+omasnap --code --title "Retry worker"
+```
+
+Code input is limited to 32 KiB, 120 lines, and 240 characters per line so the
+result stays suitable for sharing.
+
+Code mode opens the normal annotation editor with an existing mesh-gradient backdrop
+enabled. Press `B` to cycle the same backdrop styles used for screenshots. The existing
+quick-output flags work too:
+
+```bash
+omasnap --code --copy
+omasnap --code path/to/example.rs --save
+omasnap --code --copy --save
+```
 
 File URLs are accepted too. A saved capture notification's "Click to edit" action launches
 `omasnap` on the finished screenshot, so it can be reopened and re-annotated. Captures copied

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1007,7 +1007,8 @@ bool copyImageToClipboard(const QImage &image, QString &error) {
   return copyToWaylandClipboard(QStringLiteral("image/png"), png, error);
 }
 
-bool quickOutput(const QImage &image, QuickOutputMode mode, QString &error) {
+bool quickOutput(const QImage &image, QuickOutputMode mode, QString &error,
+                 const QString &outputName) {
   if (image.isNull() || mode == QuickOutputMode::None) {
     error = QStringLiteral("Could not prepare screenshot snapshot");
     return false;
@@ -1015,7 +1016,8 @@ bool quickOutput(const QImage &image, QuickOutputMode mode, QString &error) {
   if (mode == QuickOutputMode::Copy) {
     if (!copyImageToClipboard(image, error))
       return false;
-    sendCaptureNotification(QStringLiteral("Screenshot copied to clipboard"));
+    sendCaptureNotification(
+        QStringLiteral("%1 copied to clipboard").arg(outputName));
     return true;
   }
   const QString path = temporarySnapshotPath();
@@ -1033,13 +1035,14 @@ bool quickOutput(const QImage &image, QuickOutputMode mode, QString &error) {
     if (saved.isEmpty())
       return false;
     if (mode == QuickOutputMode::Save)
-      sendCaptureNotification(QStringLiteral("Screenshot saved"), saved);
+      sendCaptureNotification(QStringLiteral("%1 saved").arg(outputName), saved);
     else
-      sendCaptureNotification(QStringLiteral("Screenshot saved and copied"),
-                              saved);
+      sendCaptureNotification(
+          QStringLiteral("%1 saved and copied").arg(outputName), saved);
   } else {
     QFile::remove(path);
-    sendCaptureNotification(QStringLiteral("Screenshot copied to clipboard"));
+    sendCaptureNotification(
+        QStringLiteral("%1 copied to clipboard").arg(outputName));
   }
   return true;
 }

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -154,7 +154,9 @@ enum class AnnotationLayer { Redaction, Default };
 [[nodiscard]] bool copyPngFileToClipboard(const QString &path, QString &error);
 [[nodiscard]] bool copyImageToClipboard(const QImage &image, QString &error);
 [[nodiscard]] bool quickOutput(const QImage &image, QuickOutputMode mode,
-                               QString &error);
+                               QString &error,
+                               const QString &outputName =
+                                   QStringLiteral("Screenshot"));
 [[nodiscard]] bool copyTextToClipboard(const QString &text, QString &error);
 void paintAnnotation(QPainter &painter, const Annotation &annotation);
 [[nodiscard]] QPainterPath spotlightPath(const Annotation &annotation);

--- a/src/code-image.cpp
+++ b/src/code-image.cpp
@@ -1,0 +1,469 @@
+#include "code-image.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include <QByteArray>
+#include <QColor>
+#include <QDir>
+#include <QFile>
+#include <QFileDevice>
+#include <QFileInfo>
+#include <QFont>
+#include <QFontDatabase>
+#include <QFontMetricsF>
+#include <QHash>
+#include <QIODevice>
+#include <QImage>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QPainter>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QStandardPaths>
+#include <QString>
+#include <QTemporaryDir>
+#include <QTextDocument>
+#include <QTextOption>
+#include <Qt>
+#include <QtMath>
+#include <QtNumeric>
+#include <QtTypes>
+
+namespace {
+constexpr qsizetype kMaximumCodeBytes = qsizetype{32} * 1024;
+constexpr qsizetype kMaximumCodeLines = 120;
+constexpr qsizetype kMaximumLineCharacters = 240;
+constexpr qsizetype kMaximumHighlightBytes = qsizetype{2} * 1024 * 1024;
+constexpr int kNeovimTimeoutMs = 10000;
+
+constexpr auto kHighlightScript = R"lua(
+local output = vim.env.OMASNAP_CODE_OUTPUT
+local requested = vim.env.OMASNAP_CODE_LANGUAGE or ""
+local source_name = vim.env.OMASNAP_CODE_SOURCE_NAME or "snippet.txt"
+local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+
+local filetype = requested
+if filetype == "" then
+  local args = { contents = lines }
+  if source_name ~= "snippet.txt" then args.filename = source_name end
+  filetype = vim.filetype.match(args) or ""
+end
+if filetype == "" then
+  local text = table.concat(lines, "\n")
+  local trimmed = vim.trim(text)
+  local json_ok, json_value = pcall(vim.json.decode, trimmed)
+  if json_ok and type(json_value) == "table" then
+    filetype = "json"
+  elseif text:match("^%s*package%s+[%w_.]+") and text:match("\n%s*func%s+[%w_]+") then
+    filetype = "go"
+  elseif text:match("#include%s*[<\"]") or text:match("%f[%w]std::") or text:match("%f[%w]int%s+main%s*%(") then
+    filetype = "cpp"
+  elseif text:match("%f[%w]fn%s+[%w_]+%s*%(") and (text:match("%f[%w]let%s+mut%f[%W]") or text:match("%f[%w]use%s+[%w_:]+") or text:match("%-%>%s*[%w_]+")) then
+    filetype = "rust"
+  elseif text:match("%f[%w]def%s+[%w_]+%s*%b()%s*:") or text:match("^%s*from%s+[%w_.]+%s+import%s+") then
+    filetype = "python"
+  elseif text:match("<!DOCTYPE%s+html") or text:match("<html[%s>]") or text:match("<[a-z][%w-]*[%s>]") then
+    filetype = "html"
+  elseif text:match("%f[%w]interface%s+[%w_]+%s*{") or text:match("%f[%w]type%s+[%w_]+%s*=") then
+    filetype = "typescript"
+  elseif text:match("%f[%w]const%s+[%w_$]+%s*=") or text:match("%f[%w]let%s+[%w_$]+%s*=") or text:match("=>") or text:match("%f[%w]function%s+[%w_$]*%s*%(") then
+    filetype = "javascript"
+  elseif text:match("^%s*[Ss][Ee][Ll][Ee][Cc][Tt]%s+") or text:match("^%s*[Ii][Nn][Ss][Ee][Rr][Tt]%s+") or text:match("^%s*[Uu][Pp][Dd][Aa][Tt][Ee]%s+") then
+    filetype = "sql"
+  elseif text:match("^%s*local%s+[%w_]+") and (text:match("%f[%w]function%f[%W]") or text:match("%f[%w]end%f[%W]")) then
+    filetype = "lua"
+  elseif text:match("[%w.#][%w%s.#,:>%[%]()-]*%s*{%s*[%w-]+%s*:") then
+    filetype = "css"
+  elseif text:match("^%s*#%s+[^#]") or text:match("\n%s*[-*]%s+%S") then
+    filetype = "markdown"
+  end
+end
+
+vim.opt_local.swapfile = false
+vim.opt_local.undofile = false
+vim.opt_local.modeline = false
+vim.cmd("syntax enable")
+if filetype ~= "" then vim.bo.syntax = filetype end
+
+vim.cmd("packadd nvim.tohtml")
+local exported = require("tohtml").tohtml(0, { number_lines = true })
+local html = table.concat(exported, "\n")
+local styles = html:match("<style>\n([%s%S]-)\n</style>") or ""
+local pre = html:match("<pre>\n([%s%S]-)\n</pre>") or ""
+pre = pre:gsub('class="CursorLineNr"', 'class="LineNr"')
+
+local function color(group, attribute)
+  local id = vim.fn.synIDtrans(vim.fn.hlID(group))
+  return vim.fn.synIDattr(id, attribute)
+end
+local payload = vim.json.encode({
+  filetype = filetype,
+  background = color("Normal", "bg#"),
+  foreground = color("Normal", "fg#"),
+  line_number = color("LineNr", "fg#"),
+  styles = styles,
+  pre = pre,
+})
+vim.fn.writefile({ payload }, output, "b")
+)lua";
+
+QHash<QString, QColor> omarchyThemeColors() {
+  QProcess process;
+  process.start(QStringLiteral("omarchy-theme-color"),
+                {QStringLiteral("--all")});
+  if (!process.waitForStarted(1000) || !process.waitForFinished(2000) ||
+      process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0)
+    return {};
+  QHash<QString, QColor> colors;
+  const QString output = QString::fromUtf8(process.readAllStandardOutput());
+  for (const QString &line : output.split(QChar('\n'))) {
+    const qsizetype separator = line.indexOf(QChar('\t'));
+    if (separator <= 0)
+      continue;
+    const QColor color(line.mid(separator + 1).trimmed());
+    if (color.isValid())
+      colors.insert(line.left(separator), color);
+  }
+  return colors;
+}
+
+QColor blend(const QColor &from, const QColor &to, qreal amount) {
+  return {qRound(from.red() + (to.red() - from.red()) * amount),
+          qRound(from.green() + (to.green() - from.green()) * amount),
+          qRound(from.blue() + (to.blue() - from.blue()) * amount)};
+}
+
+QString sourceNameFor(const CodeImageRequest &request) {
+  if (!request.sourceName.trimmed().isEmpty())
+    return QFileInfo(request.sourceName.trimmed()).fileName();
+  if (!request.language.trimmed().isEmpty())
+    return QStringLiteral("snippet.%1").arg(request.language.trimmed());
+  return QStringLiteral("snippet.txt");
+}
+
+bool writePrivateFile(const QString &path, const QByteArray &contents,
+                      QString &error) {
+  QSaveFile file(path);
+  file.setDirectWriteFallback(false);
+  if (!file.open(QIODevice::WriteOnly) ||
+      !file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner)) {
+    error = QStringLiteral("Could not prepare Neovim input");
+    return false;
+  }
+  if (file.write(contents) != contents.size() || !file.commit()) {
+    error = QStringLiteral("Could not write Neovim input");
+    return false;
+  }
+  return true;
+}
+
+QString plainTextFromHtml(const HighlightedCode &highlighted,
+                          const QFont &font) {
+  QTextDocument document;
+  document.setDefaultFont(font);
+  document.setHtml(
+      QStringLiteral("<pre>%1</pre>").arg(highlighted.preformattedHtml));
+  return document.toPlainText();
+}
+} // namespace
+
+bool loadCodeInput(const QString &path, QString &code, QString &error) {
+  QByteArray contents;
+  if (path.isEmpty()) {
+    QProcess clipboard;
+    clipboard.start(QStringLiteral("wl-paste"),
+                    {QStringLiteral("--no-newline"), QStringLiteral("--type"),
+                     QStringLiteral("text")});
+    if (!clipboard.waitForStarted(1000) || !clipboard.waitForFinished(3000) ||
+        clipboard.exitStatus() != QProcess::NormalExit ||
+        clipboard.exitCode() != 0) {
+      error = QStringLiteral("Could not read text from the clipboard");
+      return false;
+    }
+    contents = clipboard.readAllStandardOutput();
+  } else {
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+      error = QStringLiteral("Could not read code file: %1").arg(path);
+      return false;
+    }
+    if (file.size() > kMaximumCodeBytes) {
+      error = QStringLiteral("Code input is larger than 32 KiB");
+      return false;
+    }
+    contents = file.read(kMaximumCodeBytes + 1);
+  }
+  if (contents.size() > kMaximumCodeBytes) {
+    error = QStringLiteral("Code input is larger than 32 KiB");
+    return false;
+  }
+  code = QString::fromUtf8(contents);
+  return normalizeCodeInput(code, error);
+}
+
+QString activeCodeFilenameHint() {
+  QProcess process;
+  process.start(QStringLiteral("hyprctl"),
+                {QStringLiteral("activewindow"), QStringLiteral("-j")});
+  if (!process.waitForStarted(500) || !process.waitForFinished(1500) ||
+      process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0)
+    return {};
+  const QJsonDocument document =
+      QJsonDocument::fromJson(process.readAllStandardOutput());
+  const QString title =
+      document.object().value(QStringLiteral("title")).toString();
+  static const QRegularExpression filename(
+      QStringLiteral(
+          R"((?:^|[\s/\\|—–-])([\w@+.-]+\.(?:c|cc|cpp|cs|css|dart|ex|exs|fish|go|h|hpp|hs|html|java|jl|js|json|jsx|kt|lua|md|ml|nim|php|pl|proto|py|r|rb|rs|rst|scala|scss|sh|sql|svelte|swift|tf|toml|ts|tsx|vim|vue|xml|yaml|yml|zig|zsh))\b)"),
+      QRegularExpression::CaseInsensitiveOption);
+  const QRegularExpressionMatch match = filename.match(title);
+  return match.hasMatch() ? match.captured(1) : QString();
+}
+
+bool normalizeCodeInput(QString &code, QString &error) {
+  code.replace(QStringLiteral("\r\n"), QStringLiteral("\n"));
+  code.replace(QChar('\r'), QChar('\n'));
+  code.replace(QChar('\t'), QStringLiteral("    "));
+  while (code.endsWith(QChar('\n')))
+    code.chop(1);
+  if (code.trimmed().isEmpty()) {
+    error = QStringLiteral("No code found; copy a snippet or pass a file");
+    return false;
+  }
+  const QStringList lines = code.split(QChar('\n'));
+  if (lines.size() > kMaximumCodeLines) {
+    error = QStringLiteral("Code images are limited to 120 lines for sharing");
+    return false;
+  }
+  if (std::ranges::any_of(lines, [](const QString &line) {
+        return line.size() > kMaximumLineCharacters;
+      })) {
+    error = QStringLiteral("Code image lines are limited to 240 characters");
+    return false;
+  }
+  return true;
+}
+
+bool parseNeovimHighlights(const QByteArray &json, HighlightedCode &highlighted,
+                           QString &error) {
+  if (json.size() > kMaximumHighlightBytes) {
+    error = QStringLiteral("Neovim highlighting output is too large");
+    return false;
+  }
+  QJsonParseError parseError;
+  const QJsonDocument document = QJsonDocument::fromJson(json, &parseError);
+  if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+    error = QStringLiteral("Neovim returned invalid highlighting data");
+    return false;
+  }
+  const QJsonObject root = document.object();
+  HighlightedCode parsed;
+  parsed.preformattedHtml = root.value(QStringLiteral("pre")).toString();
+  parsed.styleSheet = root.value(QStringLiteral("styles")).toString();
+  parsed.background =
+      QColor(root.value(QStringLiteral("background")).toString());
+  parsed.foreground =
+      QColor(root.value(QStringLiteral("foreground")).toString());
+  parsed.lineNumber =
+      QColor(root.value(QStringLiteral("line_number")).toString());
+  parsed.filetype = root.value(QStringLiteral("filetype")).toString();
+  if (parsed.preformattedHtml.isEmpty()) {
+    error = QStringLiteral("Neovim returned no highlighted code");
+    return false;
+  }
+  highlighted = std::move(parsed);
+  return true;
+}
+
+bool highlightCodeWithNeovim(const CodeImageRequest &request,
+                             HighlightedCode &highlighted, QString &error) {
+  const QString neovim = QStandardPaths::findExecutable(QStringLiteral("nvim"));
+  if (neovim.isEmpty()) {
+    error = QStringLiteral("Neovim is required for code highlighting");
+    return false;
+  }
+  const QTemporaryDir temporary(QDir::tempPath() +
+                                QStringLiteral("/omasnap-code-XXXXXX"));
+  if (!temporary.isValid()) {
+    error = QStringLiteral("Could not create private code workspace");
+    return false;
+  }
+  const QString sourceName = sourceNameFor(request);
+  const QString inputPath = temporary.filePath(QStringLiteral("source.input"));
+  const QString scriptPath =
+      temporary.filePath(QStringLiteral("highlight.lua"));
+  const QString outputPath =
+      temporary.filePath(QStringLiteral("highlight.json"));
+  if (!writePrivateFile(inputPath, request.code.toUtf8(), error) ||
+      !writePrivateFile(scriptPath, QByteArray(kHighlightScript), error))
+    return false;
+
+  QProcess process;
+  process.setWorkingDirectory(temporary.path());
+  QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+  environment.insert(QStringLiteral("OMASNAP_CODE_OUTPUT"), outputPath);
+  environment.insert(QStringLiteral("OMASNAP_CODE_LANGUAGE"),
+                     request.language.trimmed());
+  environment.insert(QStringLiteral("OMASNAP_CODE_SOURCE_NAME"), sourceName);
+  environment.insert(QStringLiteral("OMASNAP_CODE_SCRIPT"), scriptPath);
+  process.setProcessEnvironment(environment);
+  process.start(
+      neovim,
+      {QStringLiteral("--headless"), QStringLiteral("-n"), QStringLiteral("-i"),
+       QStringLiteral("NONE"), QStringLiteral("--cmd"),
+       QStringLiteral("set noexrc nomodeline"), inputPath, QStringLiteral("-c"),
+       QStringLiteral("lua dofile(vim.env.OMASNAP_CODE_SCRIPT)"),
+       QStringLiteral("-c"), QStringLiteral("qa!")});
+  if (!process.waitForStarted(1000)) {
+    error = QStringLiteral("Could not start Neovim");
+    return false;
+  }
+  if (!process.waitForFinished(kNeovimTimeoutMs)) {
+    process.kill();
+    process.waitForFinished();
+    error = QStringLiteral("Neovim highlighting timed out");
+    return false;
+  }
+  QFile output(outputPath);
+  if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0 ||
+      !output.open(QIODevice::ReadOnly)) {
+    const QString detail =
+        QString::fromUtf8(process.readAllStandardError()).trimmed();
+    error = detail.isEmpty() ? QStringLiteral("Neovim highlighting failed")
+                             : QStringLiteral("Neovim highlighting failed: %1")
+                                   .arg(detail.left(240));
+    return false;
+  }
+  return parseNeovimHighlights(output.read(kMaximumHighlightBytes + 1),
+                               highlighted, error);
+}
+
+QImage renderCodePanel(const HighlightedCode &highlighted,
+                       const QString &title) {
+  const QHash<QString, QColor> theme = omarchyThemeColors();
+  QColor background = theme.value(QStringLiteral("background"));
+  if (!background.isValid())
+    background = highlighted.background;
+  if (!background.isValid())
+    background = QColor(QStringLiteral("#101318"));
+  QColor foreground = theme.value(QStringLiteral("foreground"));
+  if (!foreground.isValid())
+    foreground = highlighted.foreground;
+  if (!foreground.isValid())
+    foreground = background.lightnessF() > 0.5 ? Qt::black : Qt::white;
+  QFont codeFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+  codeFont.setPixelSize(28);
+  codeFont.setStyleHint(QFont::Monospace);
+  const QString plain = plainTextFromHtml(highlighted, codeFont);
+  qreal widest = 0;
+  QFontMetricsF metrics(codeFont);
+  for (const QString &line : plain.split(QChar('\n')))
+    widest = std::max(widest, metrics.horizontalAdvance(line));
+  constexpr int maximumPanelWidth = 2000;
+  constexpr int sidePadding = 54;
+  if (widest + sidePadding * 2 > maximumPanelWidth) {
+    const qreal available = maximumPanelWidth - sidePadding * 2;
+    codeFont.setPixelSize(
+        std::max(18, qFloor(codeFont.pixelSize() * available / widest)));
+    metrics = QFontMetricsF(codeFont);
+    widest = 0;
+    for (const QString &line : plain.split(QChar('\n')))
+      widest = std::max(widest, metrics.horizontalAdvance(line));
+  }
+
+  const int contentWidth =
+      std::clamp(qCeil(widest) + 8, 620, maximumPanelWidth - sidePadding * 2);
+  const int width = contentWidth + sidePadding * 2;
+  const QString shownTitle = title.trimmed();
+  const bool hasTitle = !shownTitle.isEmpty();
+  const int headerHeight = hasTitle ? 76 : 0;
+  const int topPadding = 38;
+  const int bottomPadding = 42;
+  QTextDocument document;
+  document.setDocumentMargin(0);
+  document.setDefaultFont(codeFont);
+  QTextOption textOption = document.defaultTextOption();
+  textOption.setWrapMode(QTextOption::NoWrap);
+  document.setDefaultTextOption(textOption);
+  QString fontFamily = codeFont.family();
+  fontFamily.replace(QChar('"'), QStringLiteral("\\\""));
+  const QString css =
+      highlighted.styleSheet +
+      QStringLiteral(
+          "\nbody, pre { background-color: transparent; color: %1; }"
+          "\npre { margin: 0; white-space: pre; font-family: \"%2\"; "
+          "font-size: %3px; }"
+          "\n.LineNr { color: %4; }")
+          .arg(foreground.name(), fontFamily,
+               QString::number(codeFont.pixelSize()),
+               highlighted.lineNumber.isValid()
+                   ? highlighted.lineNumber.name()
+                   : blend(background, foreground, 0.42).name());
+  document.setDefaultStyleSheet(css);
+  document.setHtml(
+      QStringLiteral("<pre>%1</pre>").arg(highlighted.preformattedHtml));
+  document.setTextWidth(contentWidth);
+  const int contentHeight = qCeil(document.size().height());
+  const int height = headerHeight + topPadding + contentHeight + bottomPadding;
+  QImage image(width, height, QImage::Format_ARGB32_Premultiplied);
+  image.fill(background);
+
+  QPainter painter(&image);
+  painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
+  if (hasTitle) {
+    const QColor header = blend(background, foreground,
+                                background.lightnessF() > 0.5 ? 0.025 : 0.045);
+    painter.fillRect(QRect(0, 0, width, headerHeight), header);
+    painter.setPen(blend(background, foreground, 0.12));
+    painter.drawLine(0, headerHeight - 1, width, headerHeight - 1);
+
+    QFont headerFont = codeFont;
+    headerFont.setPixelSize(std::clamp(codeFont.pixelSize() - 6, 14, 20));
+    headerFont.setBold(true);
+    painter.setFont(headerFont);
+    painter.setPen(blend(background, foreground, 0.78));
+    painter.drawText(QRect(120, 0, width - 240, headerHeight), Qt::AlignCenter,
+                     QFontMetrics(headerFont)
+                         .elidedText(shownTitle, Qt::ElideMiddle, width - 260));
+  }
+  painter.save();
+  painter.translate(sidePadding, headerHeight + topPadding);
+  document.drawContents(&painter, QRectF(0, 0, contentWidth, contentHeight));
+  painter.restore();
+  painter.end();
+  return image;
+}
+
+bool createCodeImage(CodeImageRequest request, QImage &image,
+                     QString &detectedLanguage, QString &error) {
+  if (!normalizeCodeInput(request.code, error))
+    return false;
+  static const QRegularExpression validFiletype(
+      QStringLiteral("^[A-Za-z0-9_+.-]{1,40}$"));
+  request.language = request.language.trimmed();
+  if (!request.language.isEmpty() &&
+      !validFiletype.match(request.language).hasMatch()) {
+    error = QStringLiteral("Language must be a valid Neovim filetype");
+    return false;
+  }
+  request.title = request.title.trimmed();
+  if (request.title.size() > 120 || request.title.contains(QChar('\n'))) {
+    error = QStringLiteral(
+        "Code image titles must be one line up to 120 characters");
+    return false;
+  }
+  HighlightedCode highlighted;
+  if (!highlightCodeWithNeovim(request, highlighted, error))
+    return false;
+  image = renderCodePanel(highlighted, request.title);
+  detectedLanguage = highlighted.filetype;
+  if (image.isNull()) {
+    error = QStringLiteral("Could not render code image");
+    return false;
+  }
+  return true;
+}

--- a/src/code-image.hpp
+++ b/src/code-image.hpp
@@ -1,0 +1,46 @@
+/** @fileoverview Neovim-backed source-code image rendering. */
+#pragma once
+
+#include <QColor>
+#include <QImage>
+#include <QString>
+
+struct HighlightedCode {
+  QString preformattedHtml;
+  QString styleSheet;
+  QColor background;
+  QColor foreground;
+  QColor lineNumber;
+  QString filetype;
+};
+
+struct CodeImageRequest {
+  QString code;
+  QString sourceName;
+  QString title;
+  QString language;
+};
+
+/** Reads UTF-8 code from `path`, or text from the Wayland clipboard when empty.
+ */
+[[nodiscard]] bool loadCodeInput(const QString &path, QString &code,
+                                 QString &error);
+/** Returns a filename found in the focused window title, when one is present.
+ */
+[[nodiscard]] QString activeCodeFilenameHint();
+/** Validates and normalizes a snippet before handing it to Neovim. */
+[[nodiscard]] bool normalizeCodeInput(QString &code, QString &error);
+/** Parses the private JSON contract emitted by the bundled Neovim script. */
+[[nodiscard]] bool parseNeovimHighlights(const QByteArray &json,
+                                         HighlightedCode &highlighted,
+                                         QString &error);
+/** Runs configured Neovim syntax highlighting without evaluating the snippet.
+ */
+[[nodiscard]] bool highlightCodeWithNeovim(const CodeImageRequest &request,
+                                           HighlightedCode &highlighted,
+                                           QString &error);
+/** Paints only the themed central code panel; Omasnap adds its own backdrop. */
+[[nodiscard]] QImage renderCodePanel(const HighlightedCode &highlighted,
+                                     const QString &title);
+[[nodiscard]] bool createCodeImage(CodeImageRequest request, QImage &image,
+                                   QString &detectedLanguage, QString &error);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -535,7 +535,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
                              QuickOutputMode quickOutput, OperationLog log,
                              QWidget *parent)
     : QWidget(parent), capture_(std::move(capture)),
-      quickOutputMode_(quickOutput) {
+      captureMode_(mode), quickOutputMode_(quickOutput) {
   pristineSource_ = capture_.source;
   pristineLogicalSize_ = capture_.previewSize;
   paletteConfig_ = loadPaletteConfig(defaultPaletteConfigPath());
@@ -709,6 +709,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
                   "Drag to select an area · Space selects a window"));
               break;
             case CaptureMode::File:
+            case CaptureMode::Code:
               break;
             }
             updatePointerCursor();
@@ -744,7 +745,8 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     capturePending_ = true;
     pendingMode_ = mode;
     setStatus(QStringLiteral("Capturing screen…"));
-  } else if (mode == CaptureMode::Fullscreen || mode == CaptureMode::File) {
+  } else if (mode == CaptureMode::Fullscreen || mode == CaptureMode::File ||
+             mode == CaptureMode::Code) {
     if (ops_.isEmpty())
       selection_ = QRectF(QPointF(), capture_.previewSize);
     else
@@ -752,6 +754,8 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     enterEdit(
         mode == CaptureMode::File
             ? QStringLiteral("Editing image from file · Copy/Save to output")
+        : mode == CaptureMode::Code
+            ? QStringLiteral("Code image · B changes backdrop · Copy/Save to output")
             : QStringLiteral("Full screen selected · native resolution · "
                              "outer handles crop"));
   } else if (mode == CaptureMode::Window) {
@@ -2753,13 +2757,17 @@ void CaptureEditor::finish(OutputMode mode) {
     snapshotPath_.clear();
   }
 
+  const QString outputName =
+      captureMode_ == CaptureMode::Code ? QStringLiteral("Code image")
+                                        : QStringLiteral("Screenshot");
   if (mode == OutputMode::Copy)
-    sendCaptureNotification(QStringLiteral("Screenshot copied to clipboard"));
+    sendCaptureNotification(
+        QStringLiteral("%1 copied to clipboard").arg(outputName));
   else if (mode == OutputMode::Save)
-    sendCaptureNotification(QStringLiteral("Screenshot saved"), saved);
+    sendCaptureNotification(QStringLiteral("%1 saved").arg(outputName), saved);
   else
-    sendCaptureNotification(QStringLiteral("Screenshot saved and copied"),
-                            saved);
+    sendCaptureNotification(
+        QStringLiteral("%1 saved and copied").arg(outputName), saved);
   close();
 }
 

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -34,7 +34,7 @@ class InlineTextEdit;
 class CaptureEditor final : public QWidget {
   Q_OBJECT
 public:
-  enum class CaptureMode { Region, Window, Fullscreen, File };
+  enum class CaptureMode { Region, Window, Fullscreen, File, Code };
 
   explicit CaptureEditor(CaptureData capture,
                          CaptureMode mode = CaptureMode::Region,
@@ -344,6 +344,7 @@ private:
   void updatePointerCursor();
 
   CaptureData capture_;
+  CaptureMode captureMode_ = CaptureMode::Region;
   // Untouched capture, kept alongside cuts_ so cuts can be recomposed from
   // scratch (undo/redo, in-progress cut preview) without accumulating error.
   QImage pristineSource_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "capture.hpp"
 #include "cli-path.hpp"
+#include "code-image.hpp"
 #include "editor.hpp"
 #include "instance-lock.hpp"
 #include "pin.hpp"
@@ -113,8 +114,8 @@ int main(int argc, char **argv) {
       "quit and the\nnew process exits without capturing, so the same hotkey "
       "opens and closes the\noverlay. Quick output (--copy, --save) dismisses "
       "it the same way instead of\nscreenshotting the overlay. With --file (or "
-      "an image path) or --clipboard, the running\ninstance is stopped and "
-      "the editor opens on that image instead.\n"
+      "an image path), --clipboard, or --code, the running\ninstance is stopped "
+      "and the editor opens on that content instead.\n"
       "\n"
       "Exit codes: 0 success, including dismissing a running overlay; 1 "
       "capture,\nimage, or single-instance lock failure; 2 usage error."));
@@ -151,6 +152,22 @@ int main(int argc, char **argv) {
       QStringLiteral("Open the current clipboard image in the annotation "
                      "editor instead of capturing the screen."));
   parser.addOption(clipboardOption);
+  const QCommandLineOption codeOption(
+      QStringLiteral("code"),
+      QStringLiteral("Turn a code file or the text clipboard into a themed "
+                     "image and open it in the editor."));
+  const QCommandLineOption languageOption(
+      QStringLiteral("language"),
+      QStringLiteral("Override automatic Neovim filetype detection for "
+                     "--code."),
+      QStringLiteral("filetype"));
+  const QCommandLineOption titleOption(
+      QStringLiteral("title"),
+      QStringLiteral("Override the optional title shown on a --code image."),
+      QStringLiteral("text"));
+  parser.addOption(codeOption);
+  parser.addOption(languageOption);
+  parser.addOption(titleOption);
   const QCommandLineOption pinOption(
       QStringLiteral("pin"),
       QStringLiteral("Show an image as a pinned always-visible layer."),
@@ -159,12 +176,15 @@ int main(int argc, char **argv) {
   parser.addPositionalArgument(
       QStringLiteral("target"),
       QStringLiteral("Capture mode (smart, region, windows, fullscreen) or the "
-                     "path of an image file to edit."),
+                     "path of an image file to edit; with --code, a source "
+                     "file to render."),
       QStringLiteral("[target]"));
   parser.process(application);
 
   QString filePath = parser.value(fileOption);
   const bool clipboardInput = parser.isSet(clipboardOption);
+  const bool codeInput = parser.isSet(codeOption);
+  QString codePath;
 
   QuickOutputMode quickOutputMode = QuickOutputMode::None;
   if (parser.isSet(copyOption) && parser.isSet(saveOption))
@@ -184,7 +204,9 @@ int main(int argc, char **argv) {
 
   const QStringList positional = parser.positionalArguments();
   if (parser.isSet(pinOption)) {
-    if (!filePath.isEmpty() || clipboardInput || requestedModes > 0 ||
+    if (!filePath.isEmpty() || clipboardInput || codeInput ||
+        parser.isSet(languageOption) || parser.isSet(titleOption) ||
+        requestedModes > 0 ||
         !positional.isEmpty() || quickOutputMode != QuickOutputMode::None) {
       qCritical()
           << "Pinned mode cannot be combined with capture or edit targets";
@@ -195,13 +217,26 @@ int main(int argc, char **argv) {
       pinPath = parser.value(pinOption);
     return runPinnedCapture(pinPath);
   }
+  if (!codeInput &&
+      (parser.isSet(languageOption) || parser.isSet(titleOption))) {
+    qCritical() << "--language and --title require --code";
+    return 2;
+  }
   if (positional.size() > 1) {
     qCritical() << "Only one capture target may be specified";
     return 2;
   }
   if (!positional.isEmpty()) {
     const QString localTarget = resolveLocalImagePath(positional.first());
-    if (filePath.isEmpty() && !localTarget.isEmpty()) {
+    if (codeInput) {
+      if (localTarget.isEmpty()) {
+        qCritical().noquote()
+            << QStringLiteral("Could not read code file: %1")
+                   .arg(positional.first());
+        return 2;
+      }
+      codePath = localTarget;
+    } else if (filePath.isEmpty() && !localTarget.isEmpty()) {
       filePath = localTarget;
     } else {
       ++requestedModes;
@@ -233,8 +268,14 @@ int main(int argc, char **argv) {
     qCritical() << "Clipboard input cannot be combined with another target";
     return 2;
   }
-  const bool editingImage = clipboardInput || !filePath.isEmpty();
-  if (editingImage && quickOutputMode != QuickOutputMode::None) {
+  if (codeInput &&
+      (!filePath.isEmpty() || clipboardInput || requestedModes > 0)) {
+    qCritical() << "Code input cannot be combined with a capture or image input";
+    return 2;
+  }
+  const bool editingContent = codeInput || clipboardInput || !filePath.isEmpty();
+  if (!codeInput && editingContent &&
+      quickOutputMode != QuickOutputMode::None) {
     qCritical()
         << "Quick output options cannot be combined with an image input";
     return 2;
@@ -254,8 +295,8 @@ int main(int argc, char **argv) {
   // of starting a second one: a late capture would otherwise photograph that overlay.
   // Editing an image always takes over so the requested editor can open.
   const InstanceLockResult lockResult = acquireInstanceLock(
-      instanceLock, editingImage ? InstanceMode::EditFile
-                                 : InstanceMode::Capture);
+      instanceLock, editingContent ? InstanceMode::EditFile
+                                   : InstanceMode::Capture);
   if (lockResult.signalledPid != 0)
     qInfo().noquote() << QStringLiteral("Asked the running omasnap (pid %1) to "
                                         "quit")
@@ -269,7 +310,47 @@ int main(int argc, char **argv) {
   CaptureData capture;
   OperationLog restoredLog;
   QString error;
-  if (editingImage) {
+  if (codeInput) {
+    CodeImageRequest request;
+    if (!loadCodeInput(codePath, request.code, error)) {
+      const QString message = QStringLiteral("Code image failed: %1").arg(error);
+      qCritical().noquote() << message;
+      sendCaptureNotification(message);
+      return 1;
+    }
+    request.language = parser.value(languageOption);
+    request.sourceName =
+        !codePath.isEmpty()
+            ? codePath
+            : request.language.trimmed().isEmpty() ? activeCodeFilenameHint()
+                                                   : QString();
+    request.title = parser.value(titleOption);
+    QString detectedLanguage;
+    if (!createCodeImage(request, capture.source, detectedLanguage, error)) {
+      const QString message =
+          error == QStringLiteral("Neovim is required for code highlighting")
+              ? QStringLiteral("Code image needs Neovim · reinstall nvim")
+              : QStringLiteral("Code image failed: %1").arg(error);
+      qCritical().noquote() << message;
+      sendCaptureNotification(message);
+      return 1;
+    }
+    capture.previewSize = capture.source.size();
+    capture.monitor.scale = 1.0;
+    capture.monitor.pixelSize = capture.source.size();
+    capture.monitor.geometry = QRect(QPoint(0, 0), capture.source.size());
+    captureMode = CaptureEditor::CaptureMode::Code;
+    Operation background;
+    background.type = Operation::Type::Background;
+    background.background = BackgroundStyle::Aurora;
+    restoredLog.ops = {background};
+    restoredLog.index = 1;
+    qInfo().noquote()
+        << QStringLiteral("Rendered %1 lines of %2 code with Neovim")
+               .arg(request.code.count(QChar('\n')) + 1)
+               .arg(detectedLanguage.isEmpty() ? QStringLiteral("plain text")
+                                               : detectedLanguage);
+  } else if (editingContent) {
     QImage image;
     QString inputName;
     if (clipboardInput) {
@@ -316,12 +397,24 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  if (codeInput && quickOutputMode != QuickOutputMode::None) {
+    const QImage output = renderCapture(
+        capture, QRectF(QPointF(), capture.previewSize), {},
+        BackgroundStyle::Aurora);
+    if (!quickOutput(output, quickOutputMode, error,
+                     QStringLiteral("Code image"))) {
+      qCritical().noquote() << error;
+      return 1;
+    }
+    return 0;
+  }
+
   // Grab the output before the layer exists. ext-image-copy-capture waits for
   // a composited frame, so mapping the dim overlay first photographs the veil.
   const bool instantFullscreenOutput =
-      !editingImage && captureMode == CaptureEditor::CaptureMode::Fullscreen &&
+      !editingContent && captureMode == CaptureEditor::CaptureMode::Fullscreen &&
       quickOutputMode != QuickOutputMode::None;
-  if (!editingImage &&
+  if (!editingContent &&
       !captureMonitorPixels(capture.monitor, capture,
                             !instantFullscreenOutput, error)) {
     qCritical().noquote() << error;
@@ -355,7 +448,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (!editingImage) {
+  if (!editingContent) {
     qInfo().noquote() << QStringLiteral(
                              "Captured %1 workspace %2 with %3 selectable "
                              "windows")

--- a/tests/code-image-smoke.cpp
+++ b/tests/code-image-smoke.cpp
@@ -1,0 +1,154 @@
+#include "code-image-smoke.hpp"
+
+#include "capture.hpp"
+#include "code-image.hpp"
+#include "editor.hpp"
+
+#include <utility>
+
+#include <QApplication>
+#include <QByteArray>
+#include <QImage>
+#include <QStandardPaths>
+#include <QTemporaryFile>
+#include <Qt>
+#include <QtGlobal>
+
+bool runCodeImageChecks(QApplication &application, QString &error) {
+  QString normalized = QStringLiteral("\tconst value = 42;\r\n\r\n");
+  if (!normalizeCodeInput(normalized, error) ||
+      normalized != QStringLiteral("    const value = 42;")) {
+    error =
+        QStringLiteral("Code normalization did not expand tabs and trim lines");
+    return false;
+  }
+
+  QString tooLong;
+  for (int line = 0; line < 121; ++line)
+    tooLong += QStringLiteral("line\n");
+  if (normalizeCodeInput(tooLong, error) ||
+      !error.contains(QStringLiteral("120"))) {
+    error = QStringLiteral("Code normalization accepted more than 120 lines");
+    return false;
+  }
+  QTemporaryFile oversized;
+  if (!oversized.open() ||
+      oversized.write(QByteArray(32 * 1024 + 1, 'x')) != 32 * 1024 + 1) {
+    error = QStringLiteral("Could not prepare oversized code input");
+    return false;
+  }
+  oversized.flush();
+  QString oversizedCode;
+  if (loadCodeInput(oversized.fileName(), oversizedCode, error) ||
+      !error.contains(QStringLiteral("32 KiB"))) {
+    error = QStringLiteral("Code input accepted more than 32 KiB");
+    return false;
+  }
+
+  static const QByteArray fixture = R"json({
+    "filetype":"cpp",
+    "background":"#101318",
+    "foreground":"#f3f4f6",
+    "line_number":"#667085",
+    "styles":".LineNr { color: #667085 } .Statement { color: #ff5a4a; font-weight: bold }",
+    "pre":"<span class=\"LineNr\">1  </span><span class=\"Statement\">return</span> 42;\n<span class=\"LineNr\">2  </span>你好 · こんにちは · 안녕하세요 · 🚀"
+  })json";
+  HighlightedCode highlighted;
+  if (!parseNeovimHighlights(fixture, highlighted, error) ||
+      highlighted.filetype != QStringLiteral("cpp") ||
+      !highlighted.preformattedHtml.contains(QStringLiteral("你好")) ||
+      !highlighted.preformattedHtml.contains(QStringLiteral("こんにちは")) ||
+      !highlighted.preformattedHtml.contains(QStringLiteral("안녕하세요")) ||
+      !highlighted.preformattedHtml.contains(QStringLiteral("🚀"))) {
+    error = QStringLiteral("Could not parse valid Neovim highlighting output");
+    return false;
+  }
+  const QImage fixtureImage =
+      renderCodePanel(highlighted, QStringLiteral("example.cpp"));
+  if (fixtureImage.isNull() || fixtureImage.width() < 700 ||
+      fixtureImage.height() < 180) {
+    error = QStringLiteral("Code panel renderer returned an invalid card");
+    return false;
+  }
+  const QImage untitledImage = renderCodePanel(highlighted, QString());
+  if (untitledImage.isNull() ||
+      untitledImage.height() >= fixtureImage.height()) {
+    error = QStringLiteral("An empty title still reserved a header row");
+    return false;
+  }
+  CaptureData capture;
+  capture.source = untitledImage;
+  capture.previewSize = untitledImage.size();
+  capture.monitor.geometry = QRect(QPoint(), untitledImage.size());
+  capture.monitor.pixelSize = untitledImage.size();
+  capture.monitor.scale = 1.0;
+  Operation background;
+  background.type = Operation::Type::Background;
+  background.background = BackgroundStyle::Aurora;
+  OperationLog log;
+  log.ops = {background};
+  log.index = 1;
+  CaptureEditor editor(std::move(capture), CaptureEditor::CaptureMode::Code,
+                       QuickOutputMode::None, log);
+  editor.resize(900, 700);
+  editor.show();
+  application.processEvents();
+  if (!editor.statusForTest().contains(QStringLiteral("Code image")) ||
+      editor.renderCurrentOutput().isNull()) {
+    error = QStringLiteral("Code mode did not enter the existing editor flow");
+    return false;
+  }
+  editor.close();
+  if (parseNeovimHighlights(QByteArrayLiteral("not json"), highlighted,
+                            error)) {
+    error = QStringLiteral("Invalid Neovim highlighting output was accepted");
+    return false;
+  }
+
+  const QByteArray originalPath = qgetenv("PATH");
+  qputenv("PATH", "/omasnap-missing-tools");
+  CodeImageRequest missingRequest;
+  missingRequest.code = QStringLiteral("const answer = 42;");
+  if (highlightCodeWithNeovim(missingRequest, highlighted, error) ||
+      !error.contains(QStringLiteral("Neovim"))) {
+    qputenv("PATH", originalPath);
+    error =
+        QStringLiteral("Missing Neovim did not produce an actionable error");
+    return false;
+  }
+  qputenv("PATH", originalPath);
+
+  if (!QStandardPaths::findExecutable(QStringLiteral("nvim")).isEmpty()) {
+    CodeImageRequest request;
+    request.code = QStringLiteral(
+        "#include <iostream>\n\nint main() {\n    std::cout << 42;\n}");
+    if (!highlightCodeWithNeovim(request, highlighted, error) ||
+        highlighted.filetype != QStringLiteral("cpp") ||
+        !highlighted.preformattedHtml.contains(QStringLiteral("iostream"))) {
+      error =
+          QStringLiteral("Configured Neovim did not highlight inferred C++");
+      return false;
+    }
+    request.code = QStringLiteral("package main\n\nimport \"fmt\"\n\nfunc "
+                                  "main() {\n    fmt.Println(\"你好\")\n}");
+    request.sourceName.clear();
+    if (!highlightCodeWithNeovim(request, highlighted, error) ||
+        highlighted.filetype != QStringLiteral("go") ||
+        highlighted.preformattedHtml.contains(QStringLiteral("golangci-lint"),
+                                              Qt::CaseInsensitive)) {
+      error = QStringLiteral(
+          "Neovim code mode leaked Go diagnostics into syntax output");
+      return false;
+    }
+    request.code =
+        QStringLiteral("alpha beta gamma\n你好 こんにちは 안녕하세요");
+    request.sourceName = QStringLiteral("snippet.unknown");
+    if (!highlightCodeWithNeovim(request, highlighted, error) ||
+        !highlighted.filetype.isEmpty() ||
+        !highlighted.preformattedHtml.contains(QStringLiteral("你好"))) {
+      error = QStringLiteral("Unknown code did not fall back to plain text");
+      return false;
+    }
+  }
+  return true;
+}

--- a/tests/code-image-smoke.hpp
+++ b/tests/code-image-smoke.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <QString>
+
+class QApplication;
+
+[[nodiscard]] bool runCodeImageChecks(QApplication &application,
+                                      QString &error);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2,6 +2,7 @@
  */
 #include "capture.hpp"
 #include "cli-path.hpp"
+#include "code-image-smoke.hpp"
 #include "clipboard-smoke.hpp"
 #include "cut-smoke.hpp"
 #include "editor.hpp"
@@ -4715,6 +4716,10 @@ int main(int argc, char **argv) {
   if (!runPositionalImageTargetCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 70;
+  }
+  if (!runCodeImageChecks(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 125;
   }
   if (!runTemporarySnapshotChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
## Summary

Add a native `--code` mode for turning a source file or copied snippet into a polished, shareable image without adding a separate syntax-highlighting runtime.

- `omasnap --code` reads text from the Wayland clipboard.
- `omasnap --code path/to/file.rs` renders a source file directly.
- Neovim detects the filetype and produces syntax spans using the user's existing Omarchy-synchronized configuration.
- `--language <filetype>` and `--title <text>` are optional overrides.
- With no `--title`, no header row is drawn. The card also has no traffic-light controls or visible language badge.
- The generated card opens in the existing Omasnap editor with the Aurora backdrop selected; `B`, annotations, copy, and save keep their existing behavior.
- `--copy`, `--save`, and `--copy --save` work as quick-output modes.

## Why Neovim

Omarchy already installs and configures Neovim, including keeping its colors aligned with the current Omarchy theme. Code mode starts a short-lived headless Neovim process and uses the built-in `nvim.tohtml` module, so Omasnap does not need to ship another parser, theme catalog, browser runtime, or highlighting dependency.

The snippet is opened in a private temporary directory with swap files, ShaDa, exrc, and modelines disabled. Only syntax highlighting is enabled; `FileType` hooks and LSP diagnostics are not activated, preventing editor diagnostics from leaking into the exported image. The Neovim process has a 10-second timeout.

If Neovim has been removed, code mode exits with an actionable desktop notification. If the language cannot be detected, rendering continues as plain text.

## Usage

```bash
# Clipboard text, automatic language detection
omasnap --code

# Source file, detected from filename and contents
omasnap --code path/to/example.rs

# Optional overrides
omasnap --code --language rust
omasnap --code path/to/example.rs --title "Retry worker"

# Existing quick-output flow
omasnap --code path/to/example.rs --copy
omasnap --code path/to/example.rs --save
```

Inputs are limited to 32 KiB, 120 lines, and 240 characters per line to keep the result suitable for social sharing.

## Omarchy theme coverage

The same TypeScript/CJK sample was rendered after switching through every theme returned by `omarchy theme list`. All 25 outputs were unique, and sampled card background pixels exactly matched `omarchy-theme-color` (for example Catppuccin `#1e1e2e`, Tokyo Night `#1a1b26`, and Osuki Light `#f7f3ec`).

<!-- THEME_MATRIX -->

## Testing

- `make check`
- Existing headless editor/capture smoke suite: region, window, fullscreen, file and clipboard inputs, annotations, copy/save, single-instance handover, HiDPI, pin, and OCR paths
- Real Wayland fullscreen quick-save regression
- 17-case CLI integration matrix covering old option conflicts and new code-mode combinations
- Missing-Neovim, invalid language/title, 32 KiB, 120-line, and plain-text fallback paths
- Neovim-backed detection checks for C++, Go, TypeScript clipboard hints, and manual filetype override
- Visual rendering for TypeScript, Python, Rust, Go, C++, Java, Ruby, Lua, Bash, and SQL, including Chinese, Japanese, Korean, and emoji content
