### PR TITLE
build: reduce compile CPU and parallelize clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,34 @@ qt_add_resources(omasnap-core "capture-fonts"
   FILES "${CMAKE_CURRENT_SOURCE_DIR}/assets/Neucha.ttf"
 )
 
+# CXX-only: omasnap-core also compiles Wayland protocol .c files.
+target_precompile_headers(omasnap-core PRIVATE
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtWidgets/QWidget$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtWidgets/QApplication$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtGui/QPainter$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtGui/QPainterPath$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtGui/QImage$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtGui/QPixmap$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtGui/QFontDatabase$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtGui/QMouseEvent$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtGui/QKeyEvent$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtGui/QWheelEvent$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtConcurrent/QtConcurrentRun$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QFutureWatcher$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QProcess$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QFile$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QDir$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QFileInfo$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QJsonObject$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QJsonArray$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QJsonDocument$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QTimer$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QString$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QVector$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<algorithm$<ANGLE-R>>"
+  "$<$<COMPILE_LANGUAGE:CXX>:<cmath$<ANGLE-R>>"
+)
+
 target_include_directories(omasnap-core PUBLIC
   "${CMAKE_CURRENT_BINARY_DIR}"
   "${CMAKE_CURRENT_SOURCE_DIR}/src"
@@ -95,6 +123,7 @@ qt_add_executable(omasnap src/main.cpp src/pin.cpp src/pin.hpp)
 target_compile_options(omasnap PRIVATE -Wall -Wextra -Wpedantic)
 target_compile_definitions(omasnap PRIVATE OMASNAP_VERSION="${PROJECT_VERSION}")
 target_link_libraries(omasnap PRIVATE omasnap-core)
+target_precompile_headers(omasnap REUSE_FROM omasnap-core)
 
 if(BUILD_TESTING)
 qt_add_executable(omasnap-smoke
@@ -135,6 +164,7 @@ target_include_directories(omasnap-smoke PRIVATE
 )
 target_compile_options(omasnap-smoke PRIVATE -Wall -Wextra -Wpedantic)
 target_link_libraries(omasnap-smoke PRIVATE omasnap-core Qt6::Test)
+target_precompile_headers(omasnap-smoke REUSE_FROM omasnap-core)
 add_test(NAME omasnap-smoke COMMAND omasnap-smoke "${CMAKE_CURRENT_BINARY_DIR}/omasnap-smoke-output")
 set_tests_properties(omasnap-smoke PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endif()

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,9 @@ lint: build
 			"$$commands_dir/compile_commands.json"; \
 		sed -i 's/ -mno-direct-extern-access//g' \
 			"$$commands_dir/compile_commands.json"; \
-		for source in $(LINT_SOURCES); do \
+		printf '%s\n' $(LINT_SOURCES) | xargs -r -P "$$(nproc)" -n 1 \
 			"$(CLANG_TIDY)" -p "$$commands_dir" \
-				-checks="$(LINT_CHECKS)" -header-filter='.*' "$$source"; \
-		done; \
+			-checks="$(LINT_CHECKS)" -header-filter='.*'; \
 	else \
 		echo "make check: clang-tidy unavailable; skipping"; \
 	fi


### PR DESCRIPTION
## Summary

- Precompile the common Qt and standard-library headers used by `omasnap-core`.
- Restrict the PCH to C++ sources so the generated Wayland protocol C files remain unaffected.
- Reuse the core PCH for the application and smoke-test executables.
- Run clang-tidy across all available cores instead of processing translation units serially.

## Performance

Measured across three runs on a 32-core machine, comparing pristine v1.19 with this branch:

- Clean build CPU: 99.54 s → 66.09 s (**33.6% reduction**)
- Clean build wall time: 19.64 s → 21.74 s (**10.7% increase**)
- clang-tidy wall time: 156.48 s → 29.40 s (**5.32× faster**)

The PCH trades a small amount of clean-build wall time on a many-core desktop for substantially lower compile CPU usage. This is most useful on lower-core CI runners and laptops. Parallel clang-tidy provides the direct wall-time improvement.

## Validation

- `make check`
- Three pristine and three feature-branch clean build-and-smoke runs
- Three pristine serial and three feature-branch parallel clang-tidy runs
- No `-Winvalid-pch` warnings
- PCH-disabled v1.19 build and smoke suite pass
- Parallel clang-tidy preserves diagnostics and failure propagation
- `git diff --check`