### PR TITLE
feat(editor): outlined text as a third style in the T cycle

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -395,6 +395,21 @@ void drawAnnotation(QPainter &painter, const Annotation &annotation) {
   painter.setBrush(Qt::NoBrush);
   const QFontMetricsF metrics(font);
   const QStringList lines = annotation.text.split('\n');
+  if (annotation.textBackground == TextBackground::Outline) {
+    // A white halo whatever the color: screenshots are mostly light UI, where
+    // a dark halo reads as a drop shadow rather than a cut-out, and white
+    // holds any palette color together over a busy background.
+    QPainterPath glyphs;
+    for (qsizetype index = 0; index < lines.size(); ++index)
+      glyphs.addText(annotation.start +
+                         QPointF(0, index * metrics.lineSpacing()),
+                     font, lines.at(index));
+    painter.setPen(QPen(QColor(255, 255, 255, 235), font.pixelSize() * 0.17,
+                        Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter.drawPath(glyphs);
+    painter.fillPath(glyphs, annotation.color);
+    return;
+  }
   for (qsizetype index = 0; index < lines.size(); ++index)
     painter.drawText(annotation.start + QPointF(0, index * metrics.lineSpacing()),
                      lines.at(index));
@@ -1367,8 +1382,10 @@ QJsonObject annotationToJson(const Annotation &annotation) {
     object.insert(QStringLiteral("filled"), true);
   if (annotation.cornerRadius > 0.0)
     object.insert(QStringLiteral("cornerRadius"), annotation.cornerRadius);
-  if (annotation.textBackground != TextBackground::Pill)
+  if (annotation.textBackground == TextBackground::Plain)
     object.insert(QStringLiteral("textBackground"), QStringLiteral("plain"));
+  else if (annotation.textBackground == TextBackground::Outline)
+    object.insert(QStringLiteral("textBackground"), QStringLiteral("outline"));
   if (annotation.kind == Annotation::Kind::Spotlight) {
     object.insert(QStringLiteral("magnification"), annotation.magnification);
     object.insert(QStringLiteral("spotlightShape"),
@@ -1410,11 +1427,12 @@ bool annotationFromJson(const QJsonObject &object, Annotation &annotation,
   annotation.filled = object.value(QStringLiteral("filled")).toBool(false);
   annotation.cornerRadius =
       object.value(QStringLiteral("cornerRadius")).toDouble(0.0);
+  const QString textBackground =
+      object.value(QStringLiteral("textBackground")).toString();
   annotation.textBackground =
-      object.value(QStringLiteral("textBackground")).toString() ==
-              QStringLiteral("plain")
-          ? TextBackground::Plain
-          : TextBackground::Pill;
+      textBackground == QStringLiteral("plain")    ? TextBackground::Plain
+      : textBackground == QStringLiteral("outline") ? TextBackground::Outline
+                                                    : TextBackground::Pill;
   annotation.magnification =
       object.value(QStringLiteral("magnification")).toDouble(2.0);
   const QString spotlightShape =

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -48,7 +48,7 @@ enum class QuickOutputMode { None, Copy, Save, Both };
 
 enum class SpotlightShape { Ellipse, Rectangle, RoundedRectangle };
 enum class RedactionStyle { Solid, Pixelate };
-enum class TextBackground { Plain, Pill };
+enum class TextBackground { Plain, Pill, Outline };
 
 struct Annotation {
   enum class Kind {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -372,9 +372,28 @@ QString cornerName(qreal radius) {
                       : QStringLiteral("square corners");
 }
 
+TextBackground nextTextBackground(TextBackground background) {
+  switch (background) {
+  case TextBackground::Pill:
+    return TextBackground::Outline;
+  case TextBackground::Outline:
+    return TextBackground::Plain;
+  case TextBackground::Plain:
+    return TextBackground::Pill;
+  }
+  return TextBackground::Pill;
+}
+
 QString textBackgroundName(TextBackground background) {
-  return background == TextBackground::Pill ? QStringLiteral("Pill")
-                                            : QStringLiteral("Plain");
+  switch (background) {
+  case TextBackground::Pill:
+    return QStringLiteral("Pill");
+  case TextBackground::Outline:
+    return QStringLiteral("Outline");
+  case TextBackground::Plain:
+    return QStringLiteral("Plain");
+  }
+  return QStringLiteral("Pill");
 }
 
 QString redactionStyleName(RedactionStyle style) {
@@ -1499,19 +1518,15 @@ void CaptureEditor::toggleTextBackground() {
   if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
       annotations_.at(selectedAnnotation_).kind == Annotation::Kind::Text) {
     Annotation &text = annotations_[selectedAnnotation_];
-    text.textBackground = text.textBackground == TextBackground::Pill
-                              ? TextBackground::Plain
-                              : TextBackground::Pill;
-    setStatus(QStringLiteral("Selected text: %1 · T again toggles")
+    text.textBackground = nextTextBackground(text.textBackground);
+    setStatus(QStringLiteral("Selected text: %1 · T again cycles")
                   .arg(textBackgroundName(text.textBackground).toLower()));
     commitPatch({selectedAnnotation_});
     return;
   }
-  textBackground_ = textBackground_ == TextBackground::Pill
-                        ? TextBackground::Plain
-                        : TextBackground::Pill;
+  textBackground_ = nextTextBackground(textBackground_);
   selectedAnnotation_ = -1;
-  setStatus(QStringLiteral("Text: %1 · T again toggles")
+  setStatus(QStringLiteral("Text: %1 · T again cycles")
                 .arg(textBackgroundName(textBackground_).toLower()));
 }
 
@@ -1989,7 +2004,7 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(36, QStringLiteral("tool-cut"), {},
       QStringLiteral("Cut out a band · X · drag across"));
   add(36, QStringLiteral("tool-text"), {},
-      QStringLiteral("Neucha text · T · %1 · %2 · T again toggles pill · Wheel")
+      QStringLiteral("Neucha text · T · %1 · %2 · T again cycles style · Wheel")
           .arg(QString::fromLatin1(
               kTextSizeNames.at(static_cast<std::size_t>(textSizeIndex_))))
           .arg(textBackgroundName(textBackground_)));
@@ -5821,7 +5836,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         if (tool_ == Tool::Text) {
           tooltip = QStringLiteral(
                         "Neucha · S  M  L · current %1 · Scroll wheel · %2 · T "
-                        "again toggles pill")
+                        "again cycles style")
                         .arg(QString::fromLatin1(kTextSizeNames.at(
                             static_cast<std::size_t>(textSizeIndex_))))
                         .arg(textBackgroundName(textBackground_));

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1274,6 +1274,91 @@ bool runSpotlightAndSampleChecks(QString &error) {
   return true;
 }
 
+/** Outlined text renders a white halo around colored glyphs and survives
+ *  the op log; plain text renders no halo. */
+bool runTextOutlineCheck(QString &error) {
+  CaptureData capture;
+  capture.monitor.scale = 1.0;
+  capture.monitor.pixelSize = {400, 200};
+  capture.source = QImage(400, 200, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+
+  Annotation text;
+  text.kind = Annotation::Kind::Text;
+  text.start = {30, 50};
+  text.color = QColor(QStringLiteral("#ff375f"));
+  text.size = 5;
+  text.text = QStringLiteral("Ok");
+  text.textBackground = TextBackground::Outline;
+
+  const QRect band =
+      annotationTextBounds(text).toAlignedRect().adjusted(-6, -6, 6, 6);
+  const auto count = [&band](const QImage &frame, auto match) {
+    int hits = 0;
+    for (int y = band.top(); y <= band.bottom(); ++y)
+      for (int x = band.left(); x <= band.right(); ++x)
+        if (frame.rect().contains(x, y) && match(frame.pixelColor(x, y)))
+          ++hits;
+    return hits;
+  };
+  const auto halo = [](const QColor &c) {
+    return c.red() >= 225 && c.green() >= 225 && c.blue() >= 225;
+  };
+  const auto glyph = [](const QColor &c) {
+    return c.red() > 200 && c.green() < 120 && c.blue() < 140;
+  };
+
+  const QImage outlined = renderCapture(capture, QRectF(0, 0, 400, 200), {text},
+                                        BackgroundStyle::None);
+  if (count(outlined, halo) < 20) {
+    error = QStringLiteral("Outlined text drew no white halo");
+    return false;
+  }
+  if (count(outlined, glyph) < 20) {
+    error = QStringLiteral("Outlined text lost its glyph color");
+    return false;
+  }
+  text.textBackground = TextBackground::Plain;
+  const QImage plain = renderCapture(capture, QRectF(0, 0, 400, 200), {text},
+                                     BackgroundStyle::None);
+  if (count(plain, halo) != 0) {
+    error = QStringLiteral("Plain text grew a halo");
+    return false;
+  }
+
+  // The style survives a save and load of the op log, so reopening a capture
+  // does not quietly turn outlined text back into a pill.
+  text.textBackground = TextBackground::Outline;
+  text.id = 1;
+  OperationLog log;
+  Operation annotate;
+  annotate.type = Operation::Type::Annotate;
+  annotate.annotations = {text};
+  log.ops.push_back(std::move(annotate));
+  log.index = log.ops.size();
+  log.nextId = 2;
+  const QString logPath =
+      QDir(QDir::tempPath()).filePath(QStringLiteral("outline-oplog.json"));
+  OperationLog loaded;
+  QString logError;
+  if (!saveOperationLog(logPath, log, logError) ||
+      !loadOperationLog(logPath, loaded, logError)) {
+    QFile::remove(logPath);
+    error = QStringLiteral("Op log with outlined text failed to round-trip: %1")
+                .arg(logError);
+    return false;
+  }
+  QFile::remove(logPath);
+  if (loaded.ops.size() != 1 || loaded.ops.constFirst().annotations.isEmpty() ||
+      loaded.ops.constFirst().annotations.constFirst().textBackground !=
+          TextBackground::Outline) {
+    error = QStringLiteral("Outlined text came back as a different style");
+    return false;
+  }
+  return true;
+}
+
 /** The draft's native caret is hidden; QPlainTextEdit actually reads cursorWidth. */
 bool runNativeCaretHiddenCheck(QApplication &application, QString &error) {
   CaptureData capture;
@@ -4223,25 +4308,27 @@ bool runTextPillSmoke(QApplication &application, QString &error) {
     return false;
   }
 
-  // T again (tool still armed) switches the next text to plain.
+  // T twice more (tool still armed) cycles pill, outline, plain, so the next
+  // text lands on plain.
+  QTest::keyClick(&editor, Qt::Key_T);
   QTest::keyClick(&editor, Qt::Key_T);
   typeText(QPoint(300, 412), QStringLiteral("Plain"));
   const Annotation plain =
       text({200, 295}, QStringLiteral("Plain"), TextBackground::Plain);
   if (!snapshotMatches(expected({pill, plain}))) {
-    error = QStringLiteral("T again did not switch new text to plain");
+    error = QStringLiteral("T twice did not cycle new text to plain");
     return false;
   }
 
-  // T with a text layer selected toggles that layer, undoably.
+  // T with a text layer selected cycles that layer, undoably.
   QTest::keyClick(&editor, Qt::Key_V);
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(310, 302));
   QTest::keyClick(&editor, Qt::Key_T);
   application.processEvents();
-  Annotation pillNowPlain = pill;
-  pillNowPlain.textBackground = TextBackground::Plain;
-  if (!snapshotMatches(expected({pillNowPlain, plain}))) {
-    error = QStringLiteral("T did not toggle the selected text's pill");
+  Annotation pillNowOutline = pill;
+  pillNowOutline.textBackground = TextBackground::Outline;
+  if (!snapshotMatches(expected({pillNowOutline, plain}))) {
+    error = QStringLiteral("T did not cycle the selected text's style");
     return false;
   }
   if (editor.cursor().shape() != Qt::ArrowCursor) {
@@ -5969,6 +6056,10 @@ int main(int argc, char **argv) {
   if (!runSpotlightAndSampleChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 79;
+  }
+  if (!runTextOutlineCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 34;
   }
   if (!runNativeCaretHiddenCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
T now cycles pill, outline, plain. Outlined text strokes the glyph path with a white halo and fills it with the annotation color, so a label stays readable over a busy capture without covering it. White rather than a luminance rule: screenshots are mostly light UI, where a dark halo reads as a drop shadow rather than a cut-out. The style round-trips through the op log, and the pill smoke now walks the full cycle.

![Neucha outlined text over light, dark, and colorful backgrounds](https://github.com/user-attachments/assets/a58d7563-5a32-47eb-91ab-743664bf1985)
