### PR TITLE
fix(editor): hide the text draft's native caret

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -5494,7 +5494,10 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       const qreal baseline = cursor.top() + metrics.ascent();
       const qreal top = baseline - metrics.capHeight() * 1.15;
       const qreal bottom = baseline + metrics.descent() * 0.35;
-      painter.setPen(QPen(textColor_, std::max(1.0, box.height() / 18.0)));
+      // Scale the pen to one line, not the widget: the multiline editor grows
+      // taller with every Return, and the caret must not thicken with it.
+      const qreal lineBox = metrics.lineSpacing() + metrics.descent() + 4.0;
+      painter.setPen(QPen(textColor_, std::max(1.0, lineBox / 18.0)));
       painter.drawLine(QPointF(cursor.center().x(), top),
                        QPointF(cursor.center().x(), bottom));
     }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -31,7 +31,6 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QProcess>
-#include <QProxyStyle>
 #include <QRandomGenerator>
 #include <QScreen>
 #include <QScrollBar>
@@ -48,11 +47,14 @@
 
 /// The inline text editor: a multiline editor whose native caret is hidden (the
 /// editor paints a shorter one over Neucha's tall line box) and whose caret
-/// rectangle is exposed for that.
+/// rectangle is exposed for that. The caret is hidden through cursorWidth
+/// because QPlainTextEdit never consults PM_TextCursorWidth, so a proxy style
+/// zeroing that metric leaves the widget's own caret showing under the
+/// painted one.
 class InlineTextEdit final : public QPlainTextEdit {
 public:
   explicit InlineTextEdit(QWidget *parent) : QPlainTextEdit(parent) {
-    setStyle(&caretlessStyle_);
+    setCursorWidth(0);
     setFrameShape(QFrame::NoFrame);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -61,18 +63,6 @@ public:
   }
   using QPlainTextEdit::cursorRect;
   using QPlainTextEdit::setViewportMargins;
-
-private:
-  class CaretlessStyle final : public QProxyStyle {
-  public:
-    int pixelMetric(PixelMetric metric, const QStyleOption *option,
-                    const QWidget *widget) const override {
-      return metric == PM_TextCursorWidth
-                 ? 0
-                 : QProxyStyle::pixelMetric(metric, option, widget);
-    }
-  };
-  CaretlessStyle caretlessStyle_;
 };
 
 namespace {

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1305,6 +1305,26 @@ bool runNativeCaretHiddenCheck(QApplication &application, QString &error) {
     error = QStringLiteral("Text draft did not open for the caret check");
     return false;
   }
+  const auto caretInkWidth = [&editor, draft] {
+    const QRect caret = draft->cursorRect();
+    const QPoint origin = draft->viewport()->mapTo(&editor, caret.topLeft());
+    const QImage frame = editor.grab().toImage();
+    const int y = origin.y() + caret.height() / 2;
+    const auto red = [&frame](int x, int y) {
+      if (!frame.rect().contains(x, y))
+        return false;
+      const QColor color = frame.pixelColor(x, y);
+      return color.red() > 200 && color.green() < 120;
+    };
+    int left = origin.x();
+    while (red(left - 1, y))
+      --left;
+    int right = origin.x();
+    while (red(right + 1, y))
+      ++right;
+    return red(origin.x(), y) ? right - left + 1 : 0;
+  };
+  const int lonelyCaret = caretInkWidth();
   QTest::keyClicks(draft, QStringLiteral("Caret"));
   application.processEvents();
 
@@ -1329,6 +1349,22 @@ bool runNativeCaretHiddenCheck(QApplication &application, QString &error) {
   }
   if (!paintedCaretInk) {
     error = QStringLiteral("The painted caret did not show in the draft");
+    return false;
+  }
+
+  // Five more lines: the widget is now several times taller, and the caret
+  // on the empty last line must be as wide as it was on the first.
+  // Shift+Enter, because a plain Enter commits once the entry is out of
+  // room, and a clicked label starts with room for one line.
+  for (int line = 0; line < 5; ++line)
+    QTest::keyClick(draft, Qt::Key_Return, Qt::ShiftModifier);
+  application.processEvents();
+  const int tallDraftCaret = caretInkWidth();
+  if (lonelyCaret <= 0 || tallDraftCaret <= 0 ||
+      std::abs(tallDraftCaret - lonelyCaret) > 1) {
+    error = QStringLiteral("The caret thickened as lines were added: %1 vs %2")
+                .arg(lonelyCaret)
+                .arg(tallDraftCaret);
     return false;
   }
   return true;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1276,6 +1276,64 @@ bool runSpotlightAndSampleChecks(QString &error) {
   return true;
 }
 
+/** The draft's caret is the painted one alone; the widget's own stays hidden. */
+bool runNativeCaretHiddenCheck(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(Qt::white);
+  capture.previewSize = capture.source.size();
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(650, 470), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(650, 470));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_T);
+  // Low in the selection, clear of the key legend and the toolbar, so the
+  // only ink near the caret is the draft's own.
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(180, 300));
+  application.processEvents();
+  auto *draft = qobject_cast<QPlainTextEdit *>(QApplication::focusWidget());
+  if (!draft) {
+    error = QStringLiteral("Text draft did not open for the caret check");
+    return false;
+  }
+  QTest::keyClicks(draft, QStringLiteral("Caret"));
+  application.processEvents();
+
+  // Scan the caret's column in the grabbed frame. Over a white capture with a
+  // cream pill and the default red palette, near-black ink there can only be
+  // the widget's own caret; the painted caret reads as red-dominant.
+  const QRect caret = draft->cursorRect();
+  const QPoint origin = draft->viewport()->mapTo(&editor, caret.topLeft());
+  const QImage frame = editor.grab().toImage();
+  bool paintedCaretInk = false;
+  for (int x = origin.x() - 2; x <= origin.x() + 2; ++x) {
+    for (int y = origin.y(); y < origin.y() + caret.height(); ++y) {
+      if (!frame.rect().contains(x, y))
+        continue;
+      const QColor color = frame.pixelColor(x, y);
+      if (std::max({color.red(), color.green(), color.blue()}) < 90) {
+        error = QStringLiteral("The widget's own caret showed under the painted one");
+        return false;
+      }
+      paintedCaretInk = paintedCaretInk || color.red() - color.green() > 80;
+    }
+  }
+  if (!paintedCaretInk) {
+    error = QStringLiteral("The painted caret did not show in the draft");
+    return false;
+  }
+  return true;
+}
+
 /** Checks that clicking away commits in-progress text instead of losing it. */
 bool runTextClickAwayCommitCheck(QApplication &application, QString &error) {
   CaptureData capture;
@@ -5642,6 +5700,10 @@ int main(int argc, char **argv) {
   if (!runSpotlightAndSampleChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 79;
+  }
+  if (!runNativeCaretHiddenCheck(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 121;
   }
   if (!runTextClickAwayCommitCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
QPlainTextEdit never consults PM_TextCursorWidth, so the caretless proxy style was inert and the widget's own black caret showed under the painted one. Zero the widget's cursorWidth instead, the knob QPlainTextEdit actually reads, and drop the style.