### PR TITLE
fix(editor): keep annotations attached to image content after recrops

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2232,9 +2232,22 @@ void CaptureEditor::replayLog() {
   for (int index = 0; index < opIndex_ && index < ops_.size(); ++index) {
     const Operation &op = ops_.at(index);
     switch (op.type) {
-    case Operation::Type::Crop:
+    case Operation::Type::Crop: {
+      // Annotations anchor to the image content, not to the crop frame: a
+      // recrop moves the frame's origin, so every layer shifts by the same
+      // delta to stay over the pixels it was drawn on. This matches what the
+      // live crop drag shows (mouseMoveEvent shifts the layers with the
+      // handle) and restores the committed behaviour the pre-op-log undo
+      // model had in 1.13.0. The leading crop replays over an empty layer
+      // list, so it is unaffected.
+      const QPointF originDelta = selection.topLeft() - op.crop.topLeft();
+      if (!originDelta.isNull()) {
+        for (Annotation &annotation : annotations)
+          translateAnnotation(annotation, originDelta);
+      }
       selection = op.crop;
       break;
+    }
     case Operation::Type::Background:
       background = op.background;
       break;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2793,6 +2793,123 @@ bool runOpLogCapKeepsLeadingCrop(QApplication &application, QString &error) {
   return true;
 }
 
+/**
+ * A recrop moves the frame, never the ink: annotations stay over the pixels
+ * they were drawn on when the top/left crop handles move the selection
+ * origin, through release, undo/redo, and an op-log reload. Guards the
+ * content-anchored behaviour the live crop drag previews (the bottom-right
+ * handle exercised elsewhere has a zero origin delta and cannot catch this).
+ */
+bool runCropKeepsAnnotationsAnchored(QApplication &application,
+                                     QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 400, 300};
+  capture.monitor.pixelSize = {400, 300};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(400, 300, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#112233")));
+  capture.previewSize = capture.source.size();
+
+  const auto lineAt = [](const QImage &image, int x, int y) {
+    const QColor pixel = image.pixelColor(x, y);
+    return pixel.red() > 200 && pixel.green() < 100;
+  };
+
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::File);
+  editor.setSuppressSnapshots(true);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  // The 400x300 image fits at scale 1, centered: widget (200,155) is
+  // annotation (0,0). Draw a line across annotation y=100.
+  QTest::keyClick(&editor, Qt::Key_L);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 255));
+  QTest::mouseMove(&editor, QPoint(500, 255), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(500, 255));
+  application.processEvents();
+  if (!lineAt(editor.renderCurrentOutput(), 150, 100)) {
+    error = QStringLiteral("Anchoring check could not draw its line");
+    return false;
+  }
+
+  // Drag the top-left crop handle (at the image corner minus its 7 px
+  // offset) inward by 43 logical px on both axes.
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseMove(&editor, QPoint(193, 148), 20);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(193, 148));
+  QTest::mouseMove(&editor, QPoint(220, 175), 20);
+  QTest::mouseMove(&editor, QPoint(243, 198), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(243, 198));
+  application.processEvents();
+  if (editor.currentSelection() != QRectF(43, 43, 357, 257)) {
+    error = QStringLiteral("Top-left crop drag did not land on (43,43)");
+    return false;
+  }
+  QImage cropped = editor.renderCurrentOutput();
+  if (!lineAt(cropped, 150, 57) || !lineAt(cropped, 70, 57) ||
+      lineAt(cropped, 280, 57) || lineAt(cropped, 150, 100)) {
+    error = QStringLiteral(
+        "Crop from the top-left moved the line off its content");
+    return false;
+  }
+
+  // Undo restores the full frame with the line back at y=100; redo re-crops
+  // and re-anchors.
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  const QImage uncropped = editor.renderCurrentOutput();
+  if (!lineAt(uncropped, 150, 100) || !lineAt(uncropped, 280, 100) ||
+      lineAt(uncropped, 70, 57)) {
+    error = QStringLiteral("Undoing the crop did not restore the line");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  cropped = editor.renderCurrentOutput();
+  if (!lineAt(cropped, 150, 57) || !lineAt(cropped, 70, 57) ||
+      lineAt(cropped, 280, 57) || lineAt(cropped, 150, 100)) {
+    error = QStringLiteral("Redoing the crop lost the content anchoring");
+    return false;
+  }
+
+  // A reload of the persisted op log replays to the same anchored result.
+  QTemporaryDir directory;
+  if (!directory.isValid()) {
+    error = QStringLiteral("Could not create crop-anchor directory");
+    return false;
+  }
+  const QString logPath =
+      QDir(directory.path()).filePath(QStringLiteral("anchored.json"));
+  OperationLog persisted;
+  persisted.ops = editor.operationLog();
+  persisted.index = editor.operationIndex();
+  if (!saveOperationLog(logPath, persisted, error))
+    return false;
+  OperationLog reloaded;
+  if (!loadOperationLog(logPath, reloaded, error))
+    return false;
+  editor.close();
+
+  CaptureEditor replayed(capture, CaptureEditor::CaptureMode::File,
+                         QuickOutputMode::None, reloaded);
+  replayed.setSuppressSnapshots(true);
+  replayed.resize(800, 600);
+  replayed.show();
+  application.processEvents();
+  const QImage restored = replayed.renderCurrentOutput();
+  if (replayed.currentSelection() != QRectF(43, 43, 357, 257) ||
+      !lineAt(restored, 150, 57) || !lineAt(restored, 70, 57) ||
+      lineAt(restored, 280, 57) || lineAt(restored, 150, 100)) {
+    error = QStringLiteral("Reloaded op log lost the crop anchoring");
+    return false;
+  }
+  replayed.close();
+  return true;
+}
+
 } // namespace
 /** Runs the interaction and rendering smoke checks. */
 /** Runs the interaction and rendering smoke checks. */
@@ -5863,6 +5980,10 @@ int main(int argc, char **argv) {
   if (!runOpLogCapKeepsLeadingCrop(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 84;
+  }
+  if (!runCropKeepsAnnotationsAnchored(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 125;
   }
   const QString outputRoot =
       argc > 1 ? QString::fromLocal8Bit(argv[1])


### PR DESCRIPTION
## Behavior question

When the top or left crop edge moves, where must existing annotations stay?
- Attached to the same image pixels, as in v1.13.
- At the same position inside the crop, as in current v1.19.1 after release.

Today the drag shows the first behavior and the release commits the second, so either answer needs a change; this PR is the first one. If the second behavior is correct, I will close this PR and change the drag instead.

Concrete example: draw an arrow to a logo in the top-left corner, then pull the top-left crop handle inward. During the drag the arrow follows the logo. 
On release it snaps back and points at different pixels.

 **Before the recrop - the arrow points at the workspace indicator:**
<img width="1195" height="699" alt="image" src="https://github.com/user-attachments/assets/b536655b-673c-4f5a-a718-7f5fc21c7bdf" />

**After recropping from the top-left (current v1.19.1) - the arrow stays in the corner and now points at empty sky:**
<img width="1331" height="676" alt="image" src="https://github.com/user-attachments/assets/dd37875d-2419-4426-bf6c-ceb68f1df1bf" />

With this PR the arrow keeps pointing at the same pixels; if its target is cropped away it points out of the frame, and undo restores it.


## Problem

v1.13 kept annotations attached to their image pixels, and the positions survived release and undo. The operation-log rewrite kept that translation in the drag preview, but `replayLog()` rebuilds annotations from their original coordinates, so the release drops it. As a result, an annotation can point to different image content after release, undo/redo, or a `--file` reopen.

## Summary

- `replayLog()` now translates existing annotations when a crop changes the top-left origin, with the same `translateAnnotation` helper that move, nudge, and duplicate already use.
- Release, undo, redo, and operation-log reload now match the drag preview.
- An annotation whose content is cropped away points out of the frame. It stays selectable, it can be dragged back, and undo restores the crop.
- The leading crop replays over an empty layer list, so region and window startup are unchanged.

## Validation

- Full `make check` passes (build, smoke suite, clang-tidy, clazy).
- New smoke test drags the top-left handle — the existing test uses the bottom-right handle, which has a zero origin delta and cannot catch this.
- The probes check both axes, across release, undo, redo, and an operation-log save and reload. An X-only or Y-only translation fails.
- The test fails without the production change (exit 125) and passes with it.
- `git diff --check` reports no errors.
