### PR TITLE
fix(editor): Alt+wheel rounds the selected rectangle again

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1395,6 +1395,17 @@ bool CaptureEditor::adjustSelectedAnnotationRing(int step) {
   if (selectedAnnotation_ < 0 || selectedAnnotation_ >= annotations_.size())
     return false;
   Annotation &annotation = annotations_[selectedAnnotation_];
+  if (annotation.kind == Annotation::Kind::Rectangle) {
+    // The selected rectangle's own corners, undoably; the armed tool's
+    // default radius stays what it was.
+    annotation.cornerRadius =
+        std::clamp(annotation.cornerRadius + step * kCornerRadiusStep, 0.0,
+                   kMaximumCornerRadius);
+    setStatus(QStringLiteral("Rectangle · %1 · Alt+wheel adjusts")
+                  .arg(cornerName(annotation.cornerRadius)));
+    commitPatch({selectedAnnotation_});
+    return true;
+  }
   if (annotation.kind != Annotation::Kind::Spotlight)
     return false;
   annotation.size = std::clamp(annotation.size + step * 2.0, 0.0, 12.0);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -3577,6 +3577,28 @@ bool runShapeFillToolSmoke(QApplication &application, QString &error) {
     return false;
   }
 
+  // Alt+wheel on a selected rectangle rounds that rectangle, undoably,
+  // instead of retuning the armed tool's default.
+  QTest::keyClick(&editor, Qt::Key_V);
+  application.processEvents();
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(550, 250));
+  wheel(1, Qt::AltModifier);
+  Annotation roundedMore = rounded;
+  roundedMore.cornerRadius = 14;
+  if (!snapshotMatches(expected({hollow, filled, roundedMore, squareAgain}))) {
+    error = QStringLiteral("Alt+wheel did not round the selected rectangle");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(expected({hollow, filled, rounded, squareAgain}))) {
+    error = QStringLiteral("Rounding the selected rectangle was not undoable");
+    return false;
+  }
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(680, 480));
+  QTest::keyClick(&editor, Qt::Key_R);
+  application.processEvents();
+
   // Ellipses share the fill flag; E again toggles it back to hollow.
   QTest::keyClick(&editor, Qt::Key_E);
   QTest::keyClick(&editor, Qt::Key_E);


### PR DESCRIPTION
The wheel handler's comment promises Alt+wheel adjusts the selected spotlight's ring or the selected rectangle's corners, but only the spotlight case is implemented, so rounding the corners of a rectangle that is already on the canvas quietly does nothing. It works again: Alt+wheel steps the selected rectangle's corner radius between square and fully rounded, and it lands in the op log, so undo takes it back. Covered in the shapes smoke, verified by breaking the handler and watching the suite fail.
