### PR TITLE
fix(pin): record the logical size so editing a pin keeps its scale

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1146,7 +1146,9 @@ void prunePinnedSnapshots() {
     return;
   const QDateTime cutoff = QDateTime::currentDateTime().addDays(-1);
   const QFileInfoList stale =
-      QDir(runtime).entryInfoList({QStringLiteral("pin-*.png")}, QDir::Files);
+      QDir(runtime).entryInfoList({QStringLiteral("pin-*.png"),
+                                   QStringLiteral("pin-*.json")},
+                                  QDir::Files);
   for (const QFileInfo &entry : stale) {
     if (entry.lastModified() >= cutoff)
       continue;
@@ -1158,6 +1160,24 @@ void prunePinnedSnapshots() {
       QFile::remove(entry.absoluteFilePath());
     ::close(fd);
   }
+}
+
+bool savePinnedSnapshot(const QImage &image, const QString &path,
+                        const QSize &logicalSize, QString &error) {
+  if (!saveTemporarySnapshot(image, path, error))
+    return false;
+  // The snapshot holds device pixels; the sidecar records the logical size
+  // the capture was presented at, the same way a shelf entry's log does, so
+  // a later edit of the pin reconstructs the scale instead of opening the
+  // image blown up.
+  OperationLog sidecar;
+  sidecar.previewSize = logicalSize;
+  if (!logicalSize.isEmpty() &&
+      !saveOperationLog(operationLogPath(path), sidecar, error)) {
+    QFile::remove(path);
+    return false;
+  }
+  return true;
 }
 
 bool saveTemporarySnapshot(const QImage &image, QString path, QString &error,

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -261,6 +261,10 @@ void prunePinnedSnapshots();
  * quality knob, which maps inversely onto zlib levels: -1 keeps the default
  * level, higher values compress less and encode faster.
  */
+/** Saves a pinned snapshot plus a sidecar log recording the logical size,
+ *  so editing the pin later reopens at the captured scale. */
+[[nodiscard]] bool savePinnedSnapshot(const QImage &image, const QString &path,
+                                      const QSize &logicalSize, QString &error);
 [[nodiscard]] bool saveTemporarySnapshot(const QImage &image, QString path,
                                          QString &error, int quality = -1);
 [[nodiscard]] QString recognizeText(const QImage &image, QString &error);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -727,7 +727,8 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     const QString path = pendingPinPath_;
     const QImage image = pinWatcher_.result();
     QString error;
-    if (image.isNull() || !saveTemporarySnapshot(image, path, error)) {
+    if (image.isNull() ||
+        !savePinnedSnapshot(image, path, pendingPinLogicalSize_, error)) {
       --pinCount_;
       setStatus(error.isEmpty()
                     ? QStringLiteral("Could not render pinned capture")
@@ -737,6 +738,7 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     if (!QProcess::startDetached(QCoreApplication::applicationFilePath(),
                                  {QStringLiteral("--pin"), path})) {
       QFile::remove(path);
+      QFile::remove(operationLogPath(path));
       --pinCount_;
       setStatus(QStringLiteral("Could not start pinned capture"));
       return;
@@ -2440,6 +2442,7 @@ void CaptureEditor::pinSnapshot() {
     return;
   }
   pendingPinPath_ = path;
+  pendingPinLogicalSize_ = selection_.size().toSize();
   pinPending_ = true;
   setStatus(QStringLiteral("Preparing pinned capture…"));
   const CaptureData captureCopy = capture_;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -589,6 +589,7 @@ private:
   QFutureWatcher<QImage> pinWatcher_;
   bool pinPending_ = false;
   QString pendingPinPath_;
+  QSize pendingPinLogicalSize_;
   QVector<Annotation> annotations_;
   QVector<Operation> ops_;
   int opIndex_ = 0;

--- a/src/pin-file.cpp
+++ b/src/pin-file.cpp
@@ -35,8 +35,10 @@ PinSnapshotFile::~PinSnapshotFile() {
   const QFileInfo fileInfo(path_);
   const QString runtime = secureRuntimeDirectory();
   if (lastOwner && !runtime.isEmpty() && fileInfo.absolutePath() == runtime &&
-      internalName.match(fileInfo.fileName()).hasMatch())
+      internalName.match(fileInfo.fileName()).hasMatch()) {
     QFile::remove(path_);
+    QFile::remove(operationLogPath(path_));
+  }
   ::close(fd_);
 }
 

--- a/tests/pin-lifecycle-smoke.cpp
+++ b/tests/pin-lifecycle-smoke.cpp
@@ -24,8 +24,31 @@ bool runPinLifecycleSmoke(QString &error) {
 
   QImage image(8, 8, QImage::Format_ARGB32_Premultiplied);
   image.fill(Qt::white);
+
+  // Editing a pinned snapshot reopens at the captured scale: the pin save
+  // records the logical size in a sidecar the file editor reads back.
+  const QString scaledPath = pinnedSnapshotPath(987660);
+  if (!savePinnedSnapshot(image, scaledPath, QSize(4, 4), error))
+    return false;
+  OperationLog sidecar;
+  if (!loadOperationLog(operationLogPath(scaledPath), sidecar, error)) {
+    QFile::remove(scaledPath);
+    return false;
+  }
+  CaptureData reopened;
+  describeFileCapture(reopened, QImage(scaledPath), sidecar);
+  const bool scaleRestored = qFuzzyCompare(reopened.monitor.scale, 2.0) &&
+                             reopened.previewSize == QSize(4, 4);
+  QFile::remove(scaledPath);
+  QFile::remove(operationLogPath(scaledPath));
+  if (!scaleRestored) {
+    error = QStringLiteral(
+        "Pinned snapshot sidecar did not restore the captured scale");
+    return false;
+  }
+
   const QString closePath = pinnedSnapshotPath(987656);
-  if (!saveTemporarySnapshot(image, closePath, error))
+  if (!savePinnedSnapshot(image, closePath, QSize(4, 4), error))
     return false;
   {
     PinSnapshotFile file(closePath);
@@ -38,6 +61,11 @@ bool runPinLifecycleSmoke(QString &error) {
   if (QFileInfo::exists(closePath)) {
     error = QStringLiteral("Normal pin close did not remove its snapshot");
     QFile::remove(closePath);
+    return false;
+  }
+  if (QFileInfo::exists(operationLogPath(closePath))) {
+    error = QStringLiteral("Pin close left its scale sidecar behind");
+    QFile::remove(operationLogPath(closePath));
     return false;
   }
 
@@ -101,7 +129,7 @@ bool runPinLifecycleSmoke(QString &error) {
   QFile::remove(lockedPath);
 
   const QString reopenPath = pinnedSnapshotPath(987657);
-  if (!saveTemporarySnapshot(image, reopenPath, error))
+  if (!savePinnedSnapshot(image, reopenPath, QSize(4, 4), error))
     return false;
   {
     PinSnapshotFile file(reopenPath);
@@ -112,11 +140,15 @@ bool runPinLifecycleSmoke(QString &error) {
     }
     file.preserveForEditor();
   }
-  if (!QFileInfo::exists(reopenPath)) {
-    error = QStringLiteral("Reopened pin snapshot was not preserved");
+  if (!QFileInfo::exists(reopenPath) ||
+      !QFileInfo::exists(operationLogPath(reopenPath))) {
+    error = QStringLiteral("Reopened pin snapshot was not fully preserved");
+    QFile::remove(reopenPath);
+    QFile::remove(operationLogPath(reopenPath));
     return false;
   }
   QFile::remove(reopenPath);
+  QFile::remove(operationLogPath(reopenPath));
 
   const QString unrelatedPath =
       QDir(secureRuntimeDirectory()).filePath(QStringLiteral("manual.png"));


### PR DESCRIPTION
A pinned snapshot holds device pixels, and its edit button reopens the file with nothing to say what scale it was captured at, so on a scaled monitor every pin edit opens the image at twice its size. The shelf already solved this exact problem: its entries carry an op log whose previewSize lets describeFileCapture work the scale back out. Pins now write the same sidecar next to the snapshot when they are created, and reopening one lands at 100%.

The sidecar follows the snapshot's lifetime: the last pin to close removes it, handing the pin to the editor preserves it, the stale-pin pruner covers it, and a failed pin launch cleans it up. The round trip and the lifetime rules are in the pin lifecycle smoke, each verified by breaking the code and watching the suite fail.
