### PR TITLE
feat(editor): zoom out to a tenth

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1680,7 +1680,7 @@ QRectF CaptureEditor::baseImageRect() const {
 
 QRectF CaptureEditor::editImageRect() const {
   const QRectF base = baseImageRect();
-  if (base.isEmpty() || viewZoom_ <= 1.0)
+  if (base.isEmpty() || qFuzzyCompare(viewZoom_, 1.0))
     return base.translated(viewOffset_);
   const QSizeF shown = base.size() * viewZoom_;
   const QPointF center = base.center();
@@ -1720,7 +1720,9 @@ void CaptureEditor::clampViewOffset() {
 }
 
 void CaptureEditor::setViewZoom(qreal zoom, const QPointF &focus) {
-  const qreal clamped = std::clamp(zoom, 1.0, maxViewZoom());
+  // Down to a tenth: an overview of a tall stitch or a large capture is
+  // as legitimate as a closeup.
+  const qreal clamped = std::clamp(zoom, 0.10, maxViewZoom());
   if (qFuzzyCompare(clamped, viewZoom_))
     return;
   const QRectF before = editImageRect();

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1274,6 +1274,68 @@ bool runSpotlightAndSampleChecks(QString &error) {
   return true;
 }
 
+/** Ctrl+wheel down zooms out below fit, to a 10% floor, and Ctrl+0 comes
+ *  back to fit. */
+bool runZoomOutCheck(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(255, 220, 40));
+  capture.previewSize = capture.source.size();
+
+  CaptureEditor editor(capture);
+  editor.setSuppressSnapshots(true);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(650, 470), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(650, 470));
+  application.processEvents();
+
+  const auto ctrlWheel = [&](int deltaY) {
+    QWheelEvent wheel(QPointF(400, 300), QPointF(400, 300), {}, {0, deltaY},
+                      Qt::NoButton, Qt::ControlModifier, Qt::NoScrollPhase,
+                      false);
+    QApplication::sendEvent(&editor, &wheel);
+    application.processEvents();
+  };
+  // A point just inside the fitted image's corner is bright yellow at fit
+  // and stops being image once the view zooms out. Probed at the fit rect
+  // measured before any zoom, so the spot is geometry-independent.
+  const QPoint fitCorner =
+      (editor.editImageRectForTest().topLeft() + QPointF(5, 5)).toPoint();
+  const auto cornerIsImage = [&] {
+    const QColor color = editor.grab().toImage().pixelColor(fitCorner);
+    return color.red() > 200 && color.green() > 150 && color.blue() < 120;
+  };
+  if (!cornerIsImage()) {
+    error = QStringLiteral("Zoom fixture corner was not image at fit");
+    return false;
+  }
+  ctrlWheel(-120);
+  if (cornerIsImage()) {
+    error = QStringLiteral("Ctrl+wheel down did not zoom out below fit");
+    return false;
+  }
+  for (int step = 0; step < 30; ++step)
+    ctrlWheel(-120);
+  if (cornerIsImage()) {
+    error = QStringLiteral("Deep zoom out lost the floor");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_0, Qt::ControlModifier);
+  application.processEvents();
+  if (!cornerIsImage()) {
+    error = QStringLiteral("Ctrl+0 did not return to fit from a zoom out");
+    return false;
+  }
+  return true;
+}
+
 /** The draft's native caret is hidden; QPlainTextEdit actually reads cursorWidth. */
 bool runNativeCaretHiddenCheck(QApplication &application, QString &error) {
   CaptureData capture;
@@ -5969,6 +6031,10 @@ int main(int argc, char **argv) {
   if (!runSpotlightAndSampleChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 79;
+  }
+  if (!runZoomOutCheck(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 10;
   }
   if (!runNativeCaretHiddenCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
The view zoom stops at fit, so a tall stitched capture or anything larger than the screen has no overview. Ctrl+wheel now keeps going below fit down to a 10% floor. The image stays centered with no free pan below fit, since panning a view that already shows everything just loses the image, and Ctrl+0 snaps back to fit from either direction.

The first commit fixes something found while testing the other end of the range: zoomed far in, the toolbar tracked the content band all the way up and slid underneath the capture-kind tab strip, leaving both unusable. It now stops just below the strip; at fit it never reaches that high, so nothing else moves.

Both behaviors have render-level smoke checks, verified by breaking the code and watching the suite fail.
