### PR TITLE
feat(editor): edit in a normal window, not only the overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ change where screenshots land or what they are called, create
 # overlay (default): the editor fills the screen as a fullscreen overlay.
 # window: the editor opens as a normal compositor window, tiled or floated
 # by the compositor, so a capture can be annotated next to another window.
-# --editor window|overlay overrides this per invocation.
+# W switches a live editor between the two either way, and --editor
+# window|overlay overrides this per invocation.
 mode = overlay
 # floating (default): a windowed editor asks the compositor to float it at
 # the capture's natural size. tiled: it joins the tiling layout instead.
@@ -385,6 +386,7 @@ without reaching for the pointer.
 | `B` | Cycle shadowed colors, window gray (shadowed and flat), and Off |
 | `Shift+B` | Toggle the screenshot card's drop shadow; on by default |
 | `G` / `Shift+G` | Cycle canvas boundaries forward/backward: Framed, Overflow, Image. Framed auto-grows with the normal frame; Overflow grows only the sides needed by annotations with no frame; Image clips at the original screenshot edge |
+| `W` | Re-present the editor as a normal compositor window, or back as the fullscreen overlay; selection, layers, and undo history carry over |
 | `1`–`8` | Set annotation color; `7` is black and `8` is white |
 | Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size (`Alt`+wheel: rectangle corner radius or spotlight border); while just viewing a zoomed capture, scroll it like a document |
 | `Shift`+wheel | Scroll a zoomed capture sideways (a wide stitch); never changes the zoom |

--- a/README.md
+++ b/README.md
@@ -270,6 +270,19 @@ change where screenshots land or what they are called, create
 `~/.config/omasnap/omasnap.conf` (INI format); every key is optional:
 
 ```ini
+[editor]
+# overlay (default): the editor fills the screen as a fullscreen overlay.
+# window: the editor opens as a normal compositor window, tiled or floated
+# by the compositor, so a capture can be annotated next to another window.
+# --editor window|overlay overrides this per invocation.
+mode = overlay
+# floating (default): a windowed editor asks the compositor to float it at
+# the capture's natural size. tiled: it joins the tiling layout instead.
+window = floating
+# opaque (default): a windowed editor paints a solid backdrop.
+# translucent: it keeps the overlay's see-through dim.
+backdrop = opaque
+
 [output]
 # Where saved screenshots go. Default: ~/Pictures/Screenshots
 directory = ~/Pictures/Captures

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1442,6 +1442,28 @@ void prunePinnedSnapshots() {
   }
 }
 
+QString editorHandoffPath() {
+  return runtimePath(QStringLiteral("edit-%1-%2.png")
+                         .arg(QCoreApplication::applicationPid())
+                         .arg(QRandomGenerator::global()->generate64(), 16, 16,
+                              QChar('0')));
+}
+
+void pruneEditorHandoffs() {
+  const QString runtime = secureRuntimeDirectory();
+  if (runtime.isEmpty())
+    return;
+  const QDateTime cutoff = QDateTime::currentDateTime().addDays(-1);
+  const QFileInfoList stale =
+      QDir(runtime).entryInfoList({QStringLiteral("edit-*.png"),
+                                   QStringLiteral("edit-*.json")},
+                                  QDir::Files);
+  for (const QFileInfo &entry : stale) {
+    if (entry.lastModified() < cutoff)
+      QFile::remove(entry.absoluteFilePath());
+  }
+}
+
 QSize editorWindowSize(const QSize &preview, const QSize &available,
                        int legendHeight) {
   // The capture at its natural size plus the editor's chrome: the key

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1457,6 +1457,8 @@ QSize editorWindowSize(const QSize &preview, const QSize &available,
   if (size.width() > room.width() || size.height() > room.height())
     size.scale(room, Qt::KeepAspectRatio);
   return {std::max(size.width(), 640), std::max(size.height(), 420)};
+}
+
 bool savePinnedSnapshot(const QImage &image, const QString &path,
                         const QSize &logicalSize, QString &error) {
   if (!saveTemporarySnapshot(image, path, error))

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1442,6 +1442,21 @@ void prunePinnedSnapshots() {
   }
 }
 
+QSize editorWindowSize(const QSize &preview, const QSize &available,
+                       int legendHeight) {
+  // The capture at its natural size plus the editor's chrome: the key
+  // guide band as measured, the toolbar and handle clearance, the status
+  // band below, and the mat margins, so the image reads at 100% in a
+  // window that hugs it and the guide never covers anything. Clamped to
+  // the screen for captures too large to hug.
+  QSize size(preview.width() + 128, preview.height() + legendHeight + 210);
+  const QSize room = available.isEmpty()
+                         ? QSize(1728, 1080)
+                         : QSize(qRound(available.width() * 0.9),
+                                 qRound(available.height() * 0.9));
+  if (size.width() > room.width() || size.height() > room.height())
+    size.scale(room, Qt::KeepAspectRatio);
+  return {std::max(size.width(), 640), std::max(size.height(), 420)};
 bool savePinnedSnapshot(const QImage &image, const QString &path,
                         const QSize &logicalSize, QString &error) {
   if (!saveTemporarySnapshot(image, path, error))

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -20,6 +20,7 @@
 #include <QPainterPath>
 #include <QProcess>
 #include <QRandomGenerator>
+#include <QRegularExpression>
 #include <QSaveFile>
 #include <QStandardPaths>
 
@@ -1447,6 +1448,19 @@ QString editorHandoffPath() {
                          .arg(QCoreApplication::applicationPid())
                          .arg(QRandomGenerator::global()->generate64(), 16, 16,
                               QChar('0')));
+}
+
+bool removeEditorHandoff(const QString &path) {
+  const QString runtime = secureRuntimeDirectory();
+  const QFileInfo file(path);
+  static const QRegularExpression name(QStringLiteral("^edit-[0-9]+-[0-9a-f]{16}\\.png$"));
+  if (runtime.isEmpty() || file.absolutePath() != runtime ||
+      !name.match(file.fileName()).hasMatch())
+    return false;
+  const QString log = operationLogPath(path);
+  const bool sourceRemoved = !QFile::exists(path) || QFile::remove(path);
+  const bool logRemoved = !QFile::exists(log) || QFile::remove(log);
+  return sourceRemoved && logRemoved;
 }
 
 void pruneEditorHandoffs() {

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -318,6 +318,8 @@ QImage applyRedactionsScaled(QImage image, const QVector<Annotation> &redactions
 void prunePinnedSnapshots();
 /** Private runtime path for handing a live edit to the other editor
  *  presentation (overlay to window or back). */
+[[nodiscard]] QString editorHandoffPath();
+void pruneEditorHandoffs();
 /** Window size for a windowed editor: the capture at its logical size
  *  plus the chrome, where `legendHeight` is the measured key guide band,
  *  scaled down to fit inside `available` with a little margin, never

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -316,6 +316,15 @@ QImage applyRedactionsScaled(QImage image, const QVector<Annotation> &redactions
 [[nodiscard]] QString temporarySnapshotPath();
 [[nodiscard]] QString pinnedSnapshotPath(int index);
 void prunePinnedSnapshots();
+/** Private runtime path for handing a live edit to the other editor
+ *  presentation (overlay to window or back). */
+/** Window size for a windowed editor: the capture at its logical size
+ *  plus the chrome, where `legendHeight` is the measured key guide band,
+ *  scaled down to fit inside `available` with a little margin, never
+ *  smaller than a usable floor. */
+[[nodiscard]] QSize editorWindowSize(const QSize &preview,
+                                     const QSize &available,
+                                     int legendHeight);
 /**
  * Writes `image` into the private runtime directory. `quality` is the Qt PNG
  * quality knob, which maps inversely onto zlib levels: -1 keeps the default

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -320,6 +320,8 @@ void prunePinnedSnapshots();
  *  presentation (overlay to window or back). */
 [[nodiscard]] QString editorHandoffPath();
 void pruneEditorHandoffs();
+/** Removes a consumed private handoff pair; never removes ordinary image files. */
+bool removeEditorHandoff(const QString &path);
 /** Window size for a windowed editor: the capture at its logical size
  *  plus the chrome, where `legendHeight` is the measured key guide band,
  *  scaled down to fit inside `available` with a little margin, never

--- a/src/cli-path.cpp
+++ b/src/cli-path.cpp
@@ -105,6 +105,10 @@ void configureCaptureCommandLine(QCommandLineParser &parser, bool beforeQt) {
                      "editor between the two."),
       QStringLiteral("mode"));
   parser.addOption(editorOption);
+  QCommandLineOption handoffMonitor(QStringLiteral("handoff-monitor"), QString(),
+                                     QStringLiteral("name"));
+  handoffMonitor.setFlags(QCommandLineOption::HiddenFromHelp);
+  parser.addOption(handoffMonitor);
   const QCommandLineOption scrollOption(
       QStringLiteral("scroll"),
       QStringLiteral("Capture a scrolling region and stitch it into one tall "

--- a/src/cli-path.cpp
+++ b/src/cli-path.cpp
@@ -1,3 +1,5 @@
+#include <QCommandLineParser>
+#include <QCommandLineOption>
 /** @fileoverview Resolves local image targets accepted by the command line. */
 #include "cli-path.hpp"
 
@@ -21,4 +23,89 @@ QString resolveLocalImagePath(const QString &target) {
 
   const QFileInfo file(path);
   return file.isFile() ? file.absoluteFilePath() : QString{};
+}
+
+void configureCaptureCommandLine(QCommandLineParser &parser) {
+  parser.setApplicationDescription(QStringLiteral(
+      "Native Wayland screenshot and annotation overlay for Hyprland and "
+      "Omarchy.\n"
+      "\n"
+      "Only one capture overlay runs at a time. Starting omasnap again while "
+      "an\noverlay is open dismisses it: the running instance is asked to "
+      "quit and the\nnew process exits without capturing, so the same hotkey "
+      "opens and closes the\noverlay. Quick output (--copy, --save) dismisses "
+      "it the same way instead of\nscreenshotting the overlay. With --file (or "
+      "an image path) or --clipboard, the running\ninstance is stopped and "
+      "the editor opens on that image instead.\n"
+      "\n"
+      "Exit codes: 0 success, including dismissing a running overlay; 1 "
+      "capture,\nimage, or single-instance lock failure; 2 usage error."));
+  parser.addHelpOption();
+  parser.addVersionOption();
+  const QCommandLineOption fullscreenOption(
+      QStringLiteral("capture-fullscreen"),
+      QStringLiteral("Start with the entire focused monitor selected."));
+  const QCommandLineOption windowOption(
+      {QStringLiteral("capture-window"), QStringLiteral("capture-windows")},
+      QStringLiteral("Start in window selection mode."));
+  const QCommandLineOption regionOption(
+      QStringLiteral("capture-region"),
+      QStringLiteral("Start in freeform region selection mode (default)."));
+  parser.addOption(fullscreenOption);
+  parser.addOption(windowOption);
+  parser.addOption(regionOption);
+  const QCommandLineOption copyOption(
+      QStringLiteral("copy"),
+      QStringLiteral("Copy the capture directly without opening the editor."));
+  const QCommandLineOption saveOption(
+      QStringLiteral("save"),
+      QStringLiteral("Save the capture directly without opening the editor."));
+  parser.addOption(copyOption);
+  parser.addOption(saveOption);
+  const QCommandLineOption fileOption(
+      QStringLiteral("file"),
+      QStringLiteral("Open an existing image file in the annotation editor "
+                     "instead of capturing the screen."),
+      QStringLiteral("path"));
+  parser.addOption(fileOption);
+  const QCommandLineOption clipboardOption(
+      QStringLiteral("clipboard"),
+      QStringLiteral("Open the current clipboard image in the annotation "
+                     "editor instead of capturing the screen."));
+  parser.addOption(clipboardOption);
+  const QCommandLineOption pinOption(
+      QStringLiteral("pin"),
+      QStringLiteral("Show an image as a pinned always-visible layer."),
+      QStringLiteral("path"));
+  parser.addOption(pinOption);
+  const QCommandLineOption editorOption(
+      QStringLiteral("editor"),
+      QStringLiteral("Editor presentation: overlay (fullscreen, default) or "
+                     "window (a normal compositor window). Also configurable "
+                     "as [editor] mode in omasnap.conf; W switches a live "
+                     "editor between the two."),
+      QStringLiteral("mode"));
+  parser.addOption(editorOption);
+  const QCommandLineOption scrollOption(
+      QStringLiteral("scroll"),
+      QStringLiteral("Capture a scrolling region and stitch it into one tall "
+                     "image, then open it in the editor."));
+  parser.addOption(scrollOption);
+  parser.addPositionalArgument(
+      QStringLiteral("target"),
+      QStringLiteral("Capture mode (smart, region, windows, fullscreen) or the "
+                     "path of an image file to edit."),
+      QStringLiteral("[target]"));
+}
+
+bool windowedEditorRequested(const QCommandLineParser &parser, bool defaultWindow) {
+  const QString mode = parser.value(QStringLiteral("editor")).trimmed().toLower();
+  const bool window = mode.isEmpty() ? defaultWindow : mode == QStringLiteral("window");
+  if (!window || parser.isSet(QStringLiteral("pin")))
+    return false;
+  if (!parser.value(QStringLiteral("file")).isEmpty() ||
+      parser.isSet(QStringLiteral("clipboard")))
+    return true;
+  const QStringList positional = parser.positionalArguments();
+  return positional.size() == 1 && !resolveLocalImagePath(positional.first()).isEmpty();
 }

--- a/src/cli-path.cpp
+++ b/src/cli-path.cpp
@@ -25,7 +25,26 @@ QString resolveLocalImagePath(const QString &target) {
   return file.isFile() ? file.absoluteFilePath() : QString{};
 }
 
-void configureCaptureCommandLine(QCommandLineParser &parser) {
+void configureCaptureCommandLine(QCommandLineParser &parser, bool beforeQt) {
+  // QApplication consumes these before the normal parse. Recognize them in
+  // the early shell-role parse too, without exposing or applying them here.
+  if (beforeQt) {
+    parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+    for (const char *name : {"platform", "platformpluginpath", "platformtheme",
+                             "plugin", "qmljsdebugger", "qwindowgeometry",
+                             "qwindowicon", "qwindowtitle", "session",
+                             "style", "stylesheet"}) {
+      QCommandLineOption option(QString::fromLatin1(name), QString(),
+                                 QStringLiteral("value"));
+      option.setFlags(QCommandLineOption::HiddenFromHelp);
+      parser.addOption(option);
+    }
+    for (const char *name : {"reverse", "widgetcount"}) {
+      QCommandLineOption option(QString::fromLatin1(name));
+      option.setFlags(QCommandLineOption::HiddenFromHelp);
+      parser.addOption(option);
+    }
+  }
   parser.setApplicationDescription(QStringLiteral(
       "Native Wayland screenshot and annotation overlay for Hyprland and "
       "Omarchy.\n"

--- a/src/cli-path.hpp
+++ b/src/cli-path.hpp
@@ -8,5 +8,5 @@ QString resolveLocalImagePath(const QString &target);
 
 class QCommandLineParser;
 /** Shared by the pre-QApplication shell choice and normal CLI validation. */
-void configureCaptureCommandLine(QCommandLineParser &parser);
+void configureCaptureCommandLine(QCommandLineParser &parser, bool beforeQt = false);
 bool windowedEditorRequested(const QCommandLineParser &parser, bool defaultWindow);

--- a/src/cli-path.hpp
+++ b/src/cli-path.hpp
@@ -5,3 +5,8 @@
 
 /** Returns an existing local path for a raw path or local file URL. */
 QString resolveLocalImagePath(const QString &target);
+
+class QCommandLineParser;
+/** Shared by the pre-QApplication shell choice and normal CLI validation. */
+void configureCaptureCommandLine(QCommandLineParser &parser);
+bool windowedEditorRequested(const QCommandLineParser &parser, bool defaultWindow);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1821,6 +1821,13 @@ qreal CaptureEditor::imageTopMargin() const {
                     kToolbarImageGap);
 }
 
+qreal CaptureEditor::chromeAnchorTop() const {
+  // Zoomed past fit the content fills the viewport band, so anchoring to the
+  // centered fit rect would float the chrome over it. Anchor to the band.
+  const qreal base = baseImageRect().top();
+  return viewZoom_ > 1.0 ? std::min<qreal>(base, 68.0) : base;
+}
+
 qreal CaptureEditor::contentBandTop() const {
   if (!windowedPresentation_)
     return 60;
@@ -1868,6 +1875,17 @@ QRectF CaptureEditor::editImageRect() const {
       .translated(viewOffset_);
 }
 
+QRectF CaptureEditor::visibleEditImageRect() const {
+  const QRectF image = editImageRect();
+  if (viewZoom_ <= 1.0)
+    return image;
+  const qreal bandTop =
+      windowedPresentation_ ? contentBandTop() : imageTopMargin();
+  const qreal bandBottom = windowedPresentation_ ? 64 : 58;
+  return image.intersected(QRectF(
+      0, bandTop, width(), std::max<qreal>(1, height() - bandTop - bandBottom)));
+}
+
 qreal CaptureEditor::maxViewZoom() const {
   const QRectF base = baseImageRect();
   if (base.isEmpty() || canvasRect_.width() <= 0)
@@ -1881,8 +1899,12 @@ void CaptureEditor::clampViewOffset() {
   if (base.isEmpty())
     return;
   const QSizeF shown = base.size() * viewZoom_;
-  const QRectF available(30, 68, std::max(1, width() - 60),
-                         std::max(1, height() - 126));
+  const qreal bandTop = windowedPresentation_ ? contentBandTop() : 68;
+  const qreal bandBottom = windowedPresentation_ ? 64 : 58;
+  const QRectF available(
+      windowedPresentation_ ? 0 : 30, bandTop,
+      std::max<qreal>(1, width() - (windowedPresentation_ ? 0 : 60)),
+      std::max<qreal>(1, height() - bandTop - bandBottom));
   // Keep the image covering the viewport where it is larger, and centered
   // (no free pan) on any axis where it is smaller.
   const auto clampAxis = [](qreal shownLen, qreal availLen, qreal &offset) {
@@ -1939,7 +1961,8 @@ void CaptureEditor::resetView() {
 }
 
 QVector<QRectF> CaptureEditor::cropHandleRects() const {
-  const QRectF image = sourceFrameWidgetRect();
+  const QRectF image = sourceFrameWidgetRect().intersected(
+      visibleEditImageRect());
   if (image.isEmpty())
     return {};
   constexpr qreal outside = 7;
@@ -3339,7 +3362,7 @@ void CaptureEditor::paintOcrOverlay(QPainter &painter, const QRectF &image,
                     qreal(kOcrSweepMs);
     const qreal bandHeight = std::clamp(region.height() * 0.35, 18.0, 64.0);
     const qreal y = region.top() - bandHeight + t * (region.height() + bandHeight);
-    painter.setClipRect(region);
+    painter.setClipRect(region, Qt::IntersectClip);
     painter.fillRect(region, QColor(accent.red(), accent.green(), accent.blue(), 36));
     QLinearGradient gradient(0, y, 0, y + bandHeight);
     gradient.setColorAt(0.0, QColor(accent.red(), accent.green(), accent.blue(), 0));
@@ -6168,6 +6191,41 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   // image, the toolbar, a popup) simply covers it wherever they overlap.
   if (!windowedPresentation_)
     drawHotkeyLegend(painter, rect(), editorHotkeyEntries());
+  const QRectF image = editImageRect();
+  const QRectF visibleImage = visibleEditImageRect();
+  const QRectF sourceImage = sourceFrameWidgetRect();
+  const QRectF visibleSourceImage = sourceImage.intersected(visibleImage);
+  const bool grown = canvasGrown();
+  const BackgroundStyle background = effectiveBackgroundStyle();
+  const bool hasBackground =
+      background != BackgroundStyle::None &&
+      background != BackgroundStyle::Off &&
+      (background != BackgroundStyle::Custom || !customBackdrop_.isNull());
+  const bool framedBackground =
+      hasBackground && canvasBoundaryMode_ == CanvasBoundaryMode::Framed;
+  if (opaqueBackdrop && !hasBackground && !visibleSourceImage.isEmpty()) {
+    // Two shadows, the macOS model: a tight even ambient halo that sits
+    // the source card on the mat, and a wider key shadow offset downward.
+    // The expanded canvas is not itself a card and never gets a shadow.
+    // Drawn around the visible source rect and before the viewport clip,
+    // the shadow still frames the band when zooming moves its real edges
+    // off-screen.
+    painter.setPen(Qt::NoPen);
+    for (int layer = 14; layer > 0; --layer) {
+      const qreal spread = layer * (40.0 / 14.0);
+      painter.setBrush(QColor(0, 0, 0, 8));
+      painter.drawRoundedRect(visibleSourceImage.adjusted(
+                                  -spread, -spread + 14, spread, spread + 14),
+                              spread, spread);
+    }
+    for (int layer = 8; layer > 0; --layer) {
+      const qreal spread = layer * (12.0 / 8.0);
+      painter.setBrush(QColor(0, 0, 0, 8));
+      painter.drawRoundedRect(visibleSourceImage.adjusted(
+                                  -spread, -spread, spread, spread),
+                              spread, spread);
+    }
+  }
   // When zoomed past fit the image is larger than the viewport; clip content
   // to the band between the toolbar and the status so it cannot overdraw them.
   const bool clipViewport = viewZoom_ > 1.0;
@@ -6181,36 +6239,6 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     painter.setClipRect(QRectF(0, bandTop, width(),
                                std::max<qreal>(1, height() - bandTop -
                                                       bandBottom)));
-  }
-  const QRectF image = editImageRect();
-  const QRectF sourceImage = sourceFrameWidgetRect();
-  const bool grown = canvasGrown();
-  const BackgroundStyle background = effectiveBackgroundStyle();
-  const bool hasBackground =
-      background != BackgroundStyle::None &&
-      background != BackgroundStyle::Off &&
-      (background != BackgroundStyle::Custom || !customBackdrop_.isNull());
-  const bool framedBackground =
-      hasBackground && canvasBoundaryMode_ == CanvasBoundaryMode::Framed;
-  if (opaqueBackdrop && !hasBackground) {
-    // Two shadows, the macOS model: a tight even ambient halo that sits
-    // the source card on the mat, and a wider key shadow offset downward.
-    // The expanded canvas is not itself a card and never gets a shadow.
-    painter.setPen(Qt::NoPen);
-    for (int layer = 14; layer > 0; --layer) {
-      const qreal spread = layer * (40.0 / 14.0);
-      painter.setBrush(QColor(0, 0, 0, 8));
-      painter.drawRoundedRect(sourceImage.adjusted(
-                                  -spread, -spread + 14, spread, spread + 14),
-                              spread, spread);
-    }
-    for (int layer = 8; layer > 0; --layer) {
-      const qreal spread = layer * (12.0 / 8.0);
-      painter.setBrush(QColor(0, 0, 0, 8));
-      painter.drawRoundedRect(
-          sourceImage.adjusted(-spread, -spread, spread, spread), spread,
-          spread);
-    }
   }
   if (grown) {
     // Extension is the canvas itself, while the source remains the image card
@@ -6271,7 +6299,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   }
 
   painter.save();
-  painter.setClipPath(clip);
+  painter.setClipPath(clip, Qt::IntersectClip);
   if (!redactionLayer.isNull())
     painter.drawImage(sourceImage, redactionLayer);
   else
@@ -6289,7 +6317,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   // While a layer is being carried, let it remain visible over the surround;
   // the background settles to its final integer bounds once on release.
   if (!dragging_)
-    painter.setClipRect(canvasRect_);
+    painter.setClipRect(canvasRect_, Qt::IntersectClip);
   QVector<Annotation> defaultAnnotations;
   defaultAnnotations.reserve(annotations_.size() + 1);
   for (int index = 0; index < annotations_.size(); ++index) {
@@ -6551,24 +6579,6 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   }
   painter.restore();
   paintOcrOverlay(painter, sourceImage, editScale());
-
-  // Screenshot chrome means "crop this source", not "this is another
-  // selected object". Keep it out of the layer-selection state entirely;
-  // clicking empty canvas puts the layers down and brings cropping back.
-  if (tool_ == Tool::Select && selectedAnnotations_.isEmpty()) {
-    painter.setPen(QPen(QColor(QStringLiteral("#0a84ff")), 1, Qt::DashLine));
-    painter.setBrush(Qt::NoBrush);
-    painter.drawRect(image.adjusted(-1, -1, 1, 1));
-    if (grown) {
-      painter.setPen(QPen(QColor(10, 132, 255, 100), 1, Qt::DashLine));
-      painter.drawRect(sourceImage);
-    }
-    painter.setPen(QPen(QColor(QStringLiteral("#0a84ff")), 2));
-    painter.setBrush(QColor(QStringLiteral("#f5f5f7")));
-    for (const QRectF &handle : cropHandleRects())
-      painter.drawRoundedRect(handle, 3, 3);
-  }
-
   if (shapeMenuOpen_) {
     painter.setPen(QPen(QColor(255, 255, 255, 34), 1));
     painter.setBrush(QColor(22, 22, 28, 248));
@@ -6652,6 +6662,25 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   }
   if (clipViewport)
     painter.restore();
+
+  // Screenshot chrome means "crop this source", not "this is another
+  // selected object". Keep it out of the layer-selection state entirely;
+  // clicking empty canvas puts the layers down and brings cropping back.
+  // This is deliberately above the viewport clip so zoomed chrome frames
+  // the part of the source and canvas that is actually visible.
+  if (tool_ == Tool::Select && selectedAnnotations_.isEmpty()) {
+    painter.setPen(QPen(QColor(QStringLiteral("#0a84ff")), 1, Qt::DashLine));
+    painter.setBrush(Qt::NoBrush);
+    painter.drawRect(visibleImage.adjusted(-1, -1, 1, 1));
+    if (grown && !visibleSourceImage.isEmpty()) {
+      painter.setPen(QPen(QColor(10, 132, 255, 100), 1, Qt::DashLine));
+      painter.drawRect(visibleSourceImage);
+    }
+    painter.setPen(QPen(QColor(QStringLiteral("#0a84ff")), 2));
+    painter.setBrush(QColor(QStringLiteral("#f5f5f7")));
+    for (const QRectF &handle : cropHandleRects())
+      painter.drawRoundedRect(handle, 3, 3);
+  }
 
   const QString currentTool = toolAction(tool_);
   const QFont buttonFont = chromeFont(11, true);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1796,6 +1796,15 @@ QRectF CaptureEditor::normalizedSelection(const QPointF &first,
 }
 
 qreal CaptureEditor::toolbarTop() const {
+  if (windowedPresentation_) {
+    // Pinned under the key guide, leaving a band tall enough for the tool
+    // hint pill that hangs above the toolbar. On a resized window the free
+    // space belongs to the canvas below, not to a drifting toolbar.
+    return 14 +
+           hotkeyLegendAnchoredSize(editorHotkeyEntries(), width() - 28.0)
+               .height() +
+           42;
+  }
   // Just under the tab strip's fixed bottom edge — independent of the image,
   // so the two can never overlap regardless of window size or image shape.
   return kCaptureTabBarBottom + kTabToolbarGap;
@@ -1812,12 +1821,29 @@ qreal CaptureEditor::imageTopMargin() const {
                     kToolbarImageGap);
 }
 
+qreal CaptureEditor::contentBandTop() const {
+  if (!windowedPresentation_)
+    return 60;
+  return 14 +
+         hotkeyLegendAnchoredSize(editorHotkeyEntries(), width() - 28.0)
+             .height() +
+         42 + 36;
+}
+
 QRectF CaptureEditor::baseImageRect() const {
   if (selection_.isEmpty() || canvasRect_.isEmpty())
     return {};
-  const qreal top = imageTopMargin();
-  const QRectF available(30, top, std::max(1, width() - 60),
-                         std::max<qreal>(1, height() - top - 58));
+  // A windowed editor stacks the key guide above the toolbar, so its top
+  // band is as tall as the guide actually is at this width, plus the
+  // toolbar, the row the color dropdown and its popover peers hang into,
+  // and clearance for the selection's top handles; the capture keeps a
+  // generous mat margin on the other three sides.
+  const qreal top =
+      windowedPresentation_ ? contentBandTop() + 54 : imageTopMargin();
+  const qreal side = windowedPresentation_ ? 64 : 30;
+  const qreal bottom = windowedPresentation_ ? 64 : 58;
+  const QRectF available(side, top, std::max<qreal>(1, width() - 2 * side),
+                         std::max<qreal>(1, height() - top - bottom));
   const qreal scale =
       std::min<qreal>({1.0, available.width() / canvasRect_.width(),
                        available.height() / canvasRect_.height()});
@@ -6107,41 +6133,54 @@ qreal selectionBoundsRadius(const Annotation &annotation, qreal inset) {
   return 0.0;
 }
 
+QVector<QPair<QString, QString>> editorHotkeyEntries() {
+  return {{QStringLiteral("V"), QStringLiteral("Select / move layer")},
+          {QStringLiteral("A"), QStringLiteral("Arrow")},
+          {QStringLiteral("L"), QStringLiteral("Line")},
+          {QStringLiteral("F / H"), QStringLiteral("Freehand / Highlighter")},
+          {QStringLiteral("C"), QStringLiteral("Marker")},
+          {QStringLiteral("R / E"), QStringLiteral("Rectangle / Ellipse")},
+          {QStringLiteral("X"), QStringLiteral("Cut out a band")},
+          {QStringLiteral("T"), QStringLiteral("Text")},
+          {QStringLiteral("Double click"), QStringLiteral("Edit text layer")},
+          {QStringLiteral("1–8"), QStringLiteral("Color")},
+          {QStringLiteral("Wheel"), QStringLiteral("Zoom selected / tool size")},
+          {QStringLiteral("D / O"), QStringLiteral("Redact / OCR text")},
+          {QStringLiteral("B / P"), QStringLiteral("Backdrop / Pin on screen")},
+          {QStringLiteral("Ctrl+Z"), QStringLiteral("Undo")},
+          {QStringLiteral("Ctrl+Shift+Z"), QStringLiteral("Redo")},
+          {QStringLiteral("Enter"), QStringLiteral("Copy + save")},
+          {QStringLiteral("Ctrl+C"), QStringLiteral("Copy only")},
+          {QStringLiteral("Ctrl+S"), QStringLiteral("Save only")},
+          {QStringLiteral("Esc"), QStringLiteral("Arrow / twice close")}};
+}
+
 void CaptureEditor::paintEdit(QPainter &painter) {
   painter.setCompositionMode(QPainter::CompositionMode_Source);
-  painter.fillRect(rect(), QColor(0, 0, 0, 160));
+  // The overlay dims the screen it covers; a windowed editor has its own
+  // backdrop, a solid gray mat by default so the desktop does not bleed
+  // through and the capture reads as a picture on a table.
+  const bool opaqueBackdrop = windowedPresentation_ && windowedBackdropOpaque_;
+  painter.fillRect(rect(), opaqueBackdrop ? QColor(36, 36, 36)
+                                          : QColor(0, 0, 0, 160));
   painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
   // Drawn first, low-opacity, no card: anything painted afterward (the
   // image, the toolbar, a popup) simply covers it wherever they overlap.
-  drawHotkeyLegend(
-      painter, rect(),
-      {{QStringLiteral("V"), QStringLiteral("Select / move layer")},
-       {QStringLiteral("A"), QStringLiteral("Arrow")},
-       {QStringLiteral("L"), QStringLiteral("Line")},
-       {QStringLiteral("F / H"), QStringLiteral("Freehand / Highlighter")},
-       {QStringLiteral("C"), QStringLiteral("Marker")},
-       {QStringLiteral("R / E"), QStringLiteral("Rectangle / Ellipse")},
-       {QStringLiteral("X"), QStringLiteral("Cut out a band")},
-       {QStringLiteral("T"), QStringLiteral("Text")},
-       {QStringLiteral("Double click"), QStringLiteral("Edit text layer")},
-       {QStringLiteral("1–8"), QStringLiteral("Color")},
-       {QStringLiteral("Wheel"), QStringLiteral("Zoom selected / tool size")},
-       {QStringLiteral("D / O"), QStringLiteral("Redact / OCR text")},
-       {QStringLiteral("B / P"), QStringLiteral("Backdrop / Pin on screen")},
-       {QStringLiteral("Ctrl+Z"), QStringLiteral("Undo")},
-       {QStringLiteral("Ctrl+Shift+Z"), QStringLiteral("Redo")},
-       {QStringLiteral("Enter"), QStringLiteral("Copy + save")},
-       {QStringLiteral("Ctrl+C"), QStringLiteral("Copy only")},
-       {QStringLiteral("Ctrl+S"), QStringLiteral("Save only")},
-       {QStringLiteral("Esc"), QStringLiteral("Arrow / twice close")}});
+  if (!windowedPresentation_)
+    drawHotkeyLegend(painter, rect(), editorHotkeyEntries());
   // When zoomed past fit the image is larger than the viewport; clip content
   // to the band between the toolbar and the status so it cannot overdraw them.
   const bool clipViewport = viewZoom_ > 1.0;
   if (clipViewport) {
     painter.save();
-    const qreal top = imageTopMargin();
-    painter.setClipRect(
-        QRectF(0, top, width(), std::max<qreal>(1, height() - top - 58)));
+    // The band between the pinned chrome above and the status below; zoomed
+    // content must not overdraw either.
+    const qreal bandTop =
+        windowedPresentation_ ? contentBandTop() : imageTopMargin();
+    const qreal bandBottom = windowedPresentation_ ? 64 : 58;
+    painter.setClipRect(QRectF(0, bandTop, width(),
+                               std::max<qreal>(1, height() - bandTop -
+                                                      bandBottom)));
   }
   const QRectF image = editImageRect();
   const QRectF sourceImage = sourceFrameWidgetRect();
@@ -6153,6 +6192,26 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       (background != BackgroundStyle::Custom || !customBackdrop_.isNull());
   const bool framedBackground =
       hasBackground && canvasBoundaryMode_ == CanvasBoundaryMode::Framed;
+  if (opaqueBackdrop && !hasBackground) {
+    // Two shadows, the macOS model: a tight even ambient halo that sits
+    // the source card on the mat, and a wider key shadow offset downward.
+    // The expanded canvas is not itself a card and never gets a shadow.
+    painter.setPen(Qt::NoPen);
+    for (int layer = 14; layer > 0; --layer) {
+      const qreal spread = layer * (40.0 / 14.0);
+      painter.setBrush(QColor(0, 0, 0, 8));
+      painter.drawRoundedRect(sourceImage.adjusted(
+                                  -spread, -spread + 14, spread, spread + 14),
+                              spread, spread);
+    }
+    for (int layer = 8; layer > 0; --layer) {
+      const qreal spread = layer * (12.0 / 8.0);
+      painter.setBrush(QColor(0, 0, 0, 8));
+      painter.drawRoundedRect(
+          sourceImage.adjusted(-spread, -spread, spread, spread), spread,
+          spread);
+    }
+  }
   if (grown) {
     // Extension is the canvas itself, while the source remains the image card
     // floating above it. Never shadow the expanded canvas edge.
@@ -6687,6 +6746,16 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     painter.drawText(pill, Qt::AlignCenter, QStringLiteral("SCROLL CAPTURE"));
   }
   drawStatusPill(painter, rect(), status_);
+  // A windowed editor has no clear margin for the overlay's key column; the
+  // guide spreads as a card over the reserved band above the toolbar.
+  if (windowedPresentation_) {
+    QRectF legendAnchor;
+    for (const ToolbarButton &button : buttons)
+      legendAnchor = legendAnchor.isNull() ? button.rect
+                                           : legendAnchor.united(button.rect);
+    drawAnchoredHotkeyLegend(painter, rect(), editorHotkeyEntries(),
+                             legendAnchor);
+  }
   if (hoveredButton) {
     drawInstantTooltip(painter, rect(), hoveredButton->rect,
                        hoveredButton->tooltip);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2924,6 +2924,53 @@ void CaptureEditor::waitForExport() {
     QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
 }
 
+bool CaptureEditor::prepareHandoff(QString &path, QString &error) {
+  scheduleSnapshot();
+  if (!waitForSnapshot()) {
+    error = QStringLiteral("Could not flush the working document");
+    return false;
+  }
+  pruneEditorHandoffs();
+  path = editorHandoffPath();
+  if (path.isEmpty()) {
+    error = QStringLiteral("Could not create private runtime directory");
+    return false;
+  }
+  if (!QFile::copy(snapshotPath_, path) ||
+      !QFile::copy(workingLogPath(), operationLogPath(path))) {
+    QFile::remove(path);
+    QFile::remove(operationLogPath(path));
+    error = QStringLiteral("Could not copy the working document");
+    return false;
+  }
+  return true;
+}
+
+void CaptureEditor::handOffEditor(bool toWindow) {
+  if (busy_)
+    return;
+  QString path;
+  QString error;
+  if (!prepareHandoff(path, error)) {
+    setStatus(error);
+    return;
+  }
+  // The presentation is a property of the process (the shell integration is
+  // chosen before Qt connects), so switching means handing the working
+  // document to a fresh process and closing this one. The op log carries the
+  // selection, the layers, and the undo history across.
+  if (!QProcess::startDetached(
+          QCoreApplication::applicationFilePath(),
+          {path, QStringLiteral("--editor"),
+           toWindow ? QStringLiteral("window") : QStringLiteral("overlay")})) {
+    QFile::remove(path);
+    QFile::remove(operationLogPath(path));
+    setStatus(QStringLiteral("Could not start omasnap"));
+    return;
+  }
+  close();
+}
+
 void CaptureEditor::waitForReopen() {
   while (reopenWatcher_.isRunning()) {
     QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
@@ -3005,6 +3052,10 @@ void CaptureEditor::enterEdit(QString status) {
     commitCrop(selection_);
   else
     scheduleSnapshot();
+  if (windowedHandoffOnEdit_ && captureMode_ != CaptureMode::Scroll) {
+    windowedHandoffOnEdit_ = false;
+    handOffEditor(true);
+  }
 }
 
 void CaptureEditor::enterSelectedCapture(QString editStatus) {
@@ -3992,6 +4043,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if (event->key() == Qt::Key_G) {
     cycleCanvasBoundary(
         event->modifiers().testFlag(Qt::ShiftModifier));
+  } else if (event->key() == Qt::Key_W) {
+    handOffEditor(!windowedPresentation_);
+    return;
   } else if (event->key() == Qt::Key_B) {
     if (event->modifiers().testFlag(Qt::ShiftModifier)) {
       const bool next = !imageShadow_;
@@ -6170,6 +6224,7 @@ QVector<QPair<QString, QString>> editorHotkeyEntries() {
           {QStringLiteral("Wheel"), QStringLiteral("Zoom selected / tool size")},
           {QStringLiteral("D / O"), QStringLiteral("Redact / OCR text")},
           {QStringLiteral("B / P"), QStringLiteral("Backdrop / Pin on screen")},
+          {QStringLiteral("W"), QStringLiteral("Editor to window / overlay")},
           {QStringLiteral("Ctrl+Z"), QStringLiteral("Undo")},
           {QStringLiteral("Ctrl+Shift+Z"), QStringLiteral("Redo")},
           {QStringLiteral("Enter"), QStringLiteral("Copy + save")},

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2930,6 +2930,10 @@ void CaptureEditor::handOffEditor(bool toWindow) {
     return;
   endNudgeRun();
   acceptText();
+  const bool snapshotsSuppressed = suppressSnapshots_;
+  suppressSnapshots_ = true;
+  snapshotDirty_ = false;
+  QFuture<bool> pendingSnapshot = snapshotWatcher_.future();
   busy_ = true;
   setEnabled(false);
   setStatus(toWindow ? QStringLiteral("Preparing editor window…")
@@ -2942,17 +2946,24 @@ void CaptureEditor::handOffEditor(bool toWindow) {
   const QString program = QCoreApplication::applicationFilePath();
   const auto launcher = handoffLauncher_;
   auto *watcher = new QFutureWatcher<QString>(this);
-  connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher] {
+  connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher, snapshotsSuppressed] {
     const QString error = watcher->result();
     watcher->deleteLater();
     busy_ = false;
     setEnabled(true);
     if (error.isEmpty())
       close();
-    else
+    else {
+      suppressSnapshots_ = snapshotsSuppressed;
+      scheduleSnapshot();
       setStatus(error);
+    }
   });
-  watcher->setFuture(QtConcurrent::run([source, log, program, toWindow, launcher] {
+  watcher->setFuture(QtConcurrent::run([source, log, program, toWindow, launcher, pendingSnapshot]() mutable {
+    // A replacement process waits only briefly for the instance lock.
+    // Finish existing persistence here, without blocking the GUI, before it
+    // can ask this process to exit. Coalesced autosaves are suppressed above.
+    pendingSnapshot.waitForFinished();
     pruneEditorHandoffs();
     const QString path = editorHandoffPath();
     if (path.isEmpty())

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1796,14 +1796,22 @@ QRectF CaptureEditor::normalizedSelection(const QPointF &first,
   return QRectF(a, b).normalized();
 }
 
+QSizeF CaptureEditor::windowLegendSize() const {
+  // Chrome fonts are pinned in code; only available width changes layout.
+  if (legendWidth_ != width()) {
+    legendWidth_ = width();
+    legendSize_ = hotkeyLegendAnchoredSize(editorHotkeyEntries(), width() - 28.0);
+  }
+  return legendSize_;
+}
+
 qreal CaptureEditor::toolbarTop() const {
   if (windowedPresentation_) {
     // Pinned under the key guide, leaving a band tall enough for the tool
     // hint pill that hangs above the toolbar. On a resized window the free
     // space belongs to the canvas below, not to a drifting toolbar.
     return 14 +
-           hotkeyLegendAnchoredSize(editorHotkeyEntries(), width() - 28.0)
-               .height() +
+           windowLegendSize().height() +
            42;
   }
   // Just under the tab strip's fixed bottom edge — independent of the image,
@@ -1833,8 +1841,7 @@ qreal CaptureEditor::contentBandTop() const {
   if (!windowedPresentation_)
     return 60;
   return 14 +
-         hotkeyLegendAnchoredSize(editorHotkeyEntries(), width() - 28.0)
-             .height() +
+         windowLegendSize().height() +
          42 + 36;
 }
 
@@ -2945,6 +2952,8 @@ void CaptureEditor::handOffEditor(bool toWindow) {
                          pristineLogicalSize_};
   const QString program = QCoreApplication::applicationFilePath();
   const auto launcher = handoffLauncher_;
+  const QString monitor = windowedPresentation_ && screen()
+                              ? screen()->name() : capture_.monitor.name;
   auto *watcher = new QFutureWatcher<QString>(this);
   connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher, snapshotsSuppressed] {
     const QString error = watcher->result();
@@ -2959,7 +2968,7 @@ void CaptureEditor::handOffEditor(bool toWindow) {
       setStatus(error);
     }
   });
-  watcher->setFuture(QtConcurrent::run([source, log, program, toWindow, launcher, pendingSnapshot]() mutable {
+  watcher->setFuture(QtConcurrent::run([source, log, program, toWindow, launcher, pendingSnapshot, monitor]() mutable {
     // A replacement process waits only briefly for the instance lock.
     // Finish existing persistence here, without blocking the GUI, before it
     // can ask this process to exit. Coalesced autosaves are suppressed above.
@@ -2974,7 +2983,8 @@ void CaptureEditor::handOffEditor(bool toWindow) {
       const QStringList arguments{QStringLiteral("--file"), path,
                                    QStringLiteral("--editor"),
                                    toWindow ? QStringLiteral("window")
-                                            : QStringLiteral("overlay")};
+                                            : QStringLiteral("overlay"),
+                                   QStringLiteral("--handoff-monitor"), monitor};
       const bool launched = launcher ? launcher(program, arguments)
                                     : QProcess::startDetached(program, arguments);
       if (launched)
@@ -5332,8 +5342,8 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
   if (tool_ == Tool::Select && !layerSelected) {
     if (viewZoom_ > 1.0) {
       const QSizeF shown = baseImageRect().size() * viewZoom_;
-      const bool verticalSlack = shown.height() > std::max(1, height() - 126);
-      const bool horizontalSlack = shown.width() > std::max(1, width() - 60);
+      const bool verticalSlack = shown.height() > editViewportRect().height();
+      const bool horizontalSlack = shown.width() > editViewportRect().width();
       QPointF pan = scrollDelta;
       if (!verticalSlack && horizontalSlack && pan.x() == 0.0)
         pan = QPointF(pan.y(), 0);
@@ -6282,7 +6292,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       (background != BackgroundStyle::Custom || !customBackdrop_.isNull());
   const bool framedBackground =
       hasBackground && canvasBoundaryMode_ == CanvasBoundaryMode::Framed;
-  if (opaqueBackdrop && !hasBackground && !visibleSourceImage.isEmpty()) {
+  if (imageShadow_ && opaqueBackdrop && !hasBackground && !visibleSourceImage.isEmpty()) {
     // Two shadows, the macOS model: a tight even ambient halo that sits
     // the source card on the mat, and a wider key shadow offset downward.
     // The expanded canvas is not itself a card and never gets a shadow.

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1969,9 +1969,9 @@ void CaptureEditor::resetView() {
 }
 
 QVector<QRectF> CaptureEditor::cropHandleRects() const {
-  const QRectF image = sourceFrameWidgetRect().intersected(
-      visibleEditImageRect());
-  if (image.isEmpty())
+  const QRectF image = sourceFrameWidgetRect();
+  const QRectF visible = image.intersected(visibleEditImageRect());
+  if (visible.isEmpty())
     return {};
   constexpr qreal outside = 7;
   constexpr qreal size = 12;
@@ -1985,10 +1985,21 @@ QVector<QRectF> CaptureEditor::cropHandleRects() const {
       QPointF(image.center().x(), image.bottom() + outside),
       image.bottomLeft() + QPointF(-outside, outside),
       QPointF(image.left() - outside, image.center().y())};
+  const std::array<QPointF, 8> edges{
+      image.topLeft(), QPointF(image.center().x(), image.top()), image.topRight(),
+      QPointF(image.right(), image.center().y()), image.bottomRight(),
+      QPointF(image.center().x(), image.bottom()), image.bottomLeft(),
+      QPointF(image.left(), image.center().y())};
   QVector<QRectF> handles;
   handles.reserve(static_cast<qsizetype>(centers.size()));
-  for (const QPointF &center : centers)
-    handles.push_back({center.x() - half, center.y() - half, size, size});
+  for (size_t index = 0; index < centers.size(); ++index) {
+    const QPointF center = centers[index];
+    // Keep handle indices stable, but never invent an edge at the viewport
+    // boundary: dragging maps against the real, unclipped source rectangle.
+    handles.push_back(visible.contains(edges[index])
+                          ? QRectF(center.x() - half, center.y() - half, size, size)
+                          : QRectF());
+  }
   return handles;
 }
 
@@ -3445,6 +3456,7 @@ void CaptureEditor::paintOcrOverlay(QPainter &painter, const QRectF &image,
                     qreal(kOcrSweepMs);
     const qreal bandHeight = std::clamp(region.height() * 0.35, 18.0, 64.0);
     const qreal y = region.top() - bandHeight + t * (region.height() + bandHeight);
+    painter.save();
     painter.setClipRect(region, Qt::IntersectClip);
     painter.fillRect(region, QColor(accent.red(), accent.green(), accent.blue(), 36));
     QLinearGradient gradient(0, y, 0, y + bandHeight);
@@ -3453,7 +3465,7 @@ void CaptureEditor::paintOcrOverlay(QPainter &painter, const QRectF &image,
     gradient.setColorAt(1.0, QColor(255, 255, 255, 230));
     painter.fillRect(QRectF(region.left(), y, region.width(), bandHeight),
                      gradient);
-    painter.setClipping(false);
+    painter.restore();
     painter.setPen(QPen(accent, 1.5));
     painter.setBrush(Qt::NoBrush);
     painter.drawRect(region);
@@ -3526,7 +3538,7 @@ void CaptureEditor::paintOcrOverlay(QPainter &painter, const QRectF &image,
   const QRectF textRect(card.left() + kPad,
                         card.top() + kPad + headerHeight + kHeaderGap,
                         textWidth, textBounds.height());
-  painter.setClipRect(textRect);
+  painter.setClipRect(textRect, Qt::IntersectClip);
   painter.drawText(textRect, flags, ocrResultText_);
   painter.restore();
 }
@@ -6761,7 +6773,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     painter.setPen(QPen(QColor(QStringLiteral("#0a84ff")), 2));
     painter.setBrush(QColor(QStringLiteral("#f5f5f7")));
     for (const QRectF &handle : cropHandleRects())
-      painter.drawRoundedRect(handle, 3, 3);
+      if (!handle.isEmpty())
+        painter.drawRoundedRect(handle, 3, 3);
   }
 
   const QString currentTool = toolAction(tool_);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2924,51 +2924,54 @@ void CaptureEditor::waitForExport() {
     QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
 }
 
-bool CaptureEditor::prepareHandoff(QString &path, QString &error) {
-  scheduleSnapshot();
-  if (!waitForSnapshot()) {
-    error = QStringLiteral("Could not flush the working document");
-    return false;
-  }
-  pruneEditorHandoffs();
-  path = editorHandoffPath();
-  if (path.isEmpty()) {
-    error = QStringLiteral("Could not create private runtime directory");
-    return false;
-  }
-  if (!QFile::copy(snapshotPath_, path) ||
-      !QFile::copy(workingLogPath(), operationLogPath(path))) {
-    QFile::remove(path);
-    QFile::remove(operationLogPath(path));
-    error = QStringLiteral("Could not copy the working document");
-    return false;
-  }
-  return true;
-}
-
 void CaptureEditor::handOffEditor(bool toWindow) {
   if (busy_)
     return;
-  QString path;
-  QString error;
-  if (!prepareHandoff(path, error)) {
-    setStatus(error);
-    return;
-  }
-  // The presentation is a property of the process (the shell integration is
-  // chosen before Qt connects), so switching means handing the working
-  // document to a fresh process and closing this one. The op log carries the
-  // selection, the layers, and the undo history across.
-  if (!QProcess::startDetached(
-          QCoreApplication::applicationFilePath(),
-          {path, QStringLiteral("--editor"),
-           toWindow ? QStringLiteral("window") : QStringLiteral("overlay")})) {
+  endNudgeRun();
+  acceptText();
+  busy_ = true;
+  setEnabled(false);
+  setStatus(QStringLiteral("Preparing editor window…"));
+  // Persist a value snapshot directly: waiting for the autosave and copying
+  // its files would block input and race later coalesced snapshot writes.
+  const QImage source = pristineSource_;
+  const OperationLog log{ops_, opIndex_, nextAnnotationId_, nextMarker_,
+                         pristineLogicalSize_};
+  const QString program = QCoreApplication::applicationFilePath();
+  const auto launcher = handoffLauncher_;
+  auto *watcher = new QFutureWatcher<QString>(this);
+  connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher] {
+    const QString error = watcher->result();
+    watcher->deleteLater();
+    busy_ = false;
+    setEnabled(true);
+    if (error.isEmpty())
+      close();
+    else
+      setStatus(error);
+  });
+  watcher->setFuture(QtConcurrent::run([source, log, program, toWindow, launcher] {
+    pruneEditorHandoffs();
+    const QString path = editorHandoffPath();
+    if (path.isEmpty())
+      return QStringLiteral("Could not create private runtime directory");
+    QString error;
+    if (saveTemporarySnapshot(source, path, error, -1) &&
+        saveOperationLog(operationLogPath(path), log, error)) {
+      const QStringList arguments{QStringLiteral("--file"), path,
+                                   QStringLiteral("--editor"),
+                                   toWindow ? QStringLiteral("window")
+                                            : QStringLiteral("overlay")};
+      const bool launched = launcher ? launcher(program, arguments)
+                                    : QProcess::startDetached(program, arguments);
+      if (launched)
+        return QString();
+      error = QStringLiteral("Could not start omasnap");
+    }
     QFile::remove(path);
     QFile::remove(operationLogPath(path));
-    setStatus(QStringLiteral("Could not start omasnap"));
-    return;
-  }
-  close();
+    return error;
+  }));
 }
 
 void CaptureEditor::waitForReopen() {
@@ -3727,7 +3730,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     if (key == Qt::Key_Escape)
       return;
   }
-  if (phase_ == Phase::Export) {
+  if (phase_ == Phase::Export || busy_) {
     event->accept();
     return;
   }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -624,9 +624,10 @@ QPointF centeredCreationStart(CaptureEditor::Tool tool, const QPointF &center,
 
 CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
                              QuickOutputMode quickOutput, OperationLog log,
-                             QWidget *parent)
+                             QWidget *parent, bool windowedHandoff)
     : QWidget(parent), capture_(std::move(capture)),
       quickOutputMode_(quickOutput) {
+  windowedHandoffOnEdit_ = windowedHandoff;
   startupTimingMark("CaptureEditor constructor entered");
   pristineSource_ = capture_.source;
   pristineLogicalSize_ = capture_.previewSize;
@@ -1090,7 +1091,7 @@ CaptureEditor::selectedHandleAt(const QPointF &point) const {
 }
 
 CaptureEditor::Interaction CaptureEditor::pointerHandle() const {
-  if (!editImageRect().contains(cursor_))
+  if (!visibleEditImageRect().contains(cursor_))
     return Interaction::None;
   return selectedHandleAt(toAnnotationPoint(cursor_));
 }
@@ -1442,7 +1443,7 @@ bool CaptureEditor::toolGrabsLayer(int index) const {
 }
 
 bool CaptureEditor::pointerGrabsLayer() const {
-  return editImageRect().contains(cursor_) &&
+  return visibleEditImageRect().contains(cursor_) &&
          toolGrabsLayer(annotationEdgeAt(toAnnotationPoint(cursor_)));
 }
 
@@ -1476,7 +1477,7 @@ int CaptureEditor::annotationEdgeAt(const QPointF &point) const {
 }
 
 int CaptureEditor::hoveredSpotlightAt(const QPointF &position) const {
-  if (dragging_ || !editImageRect().contains(position))
+  if (dragging_ || !visibleEditImageRect().contains(position))
     return -1;
   const int index = annotationAt(toAnnotationPoint(position));
   if (index < 0 || annotations_.at(index).kind != Annotation::Kind::Spotlight)
@@ -1875,15 +1876,15 @@ QRectF CaptureEditor::editImageRect() const {
       .translated(viewOffset_);
 }
 
+QRectF CaptureEditor::editViewportRect() const {
+  const qreal top = windowedPresentation_ ? contentBandTop() : imageTopMargin();
+  const qreal bottom = windowedPresentation_ ? 64 : 58;
+  return {0, top, static_cast<qreal>(width()),
+          std::max<qreal>(1, height() - top - bottom)};
+}
+
 QRectF CaptureEditor::visibleEditImageRect() const {
-  const QRectF image = editImageRect();
-  if (viewZoom_ <= 1.0)
-    return image;
-  const qreal bandTop =
-      windowedPresentation_ ? contentBandTop() : imageTopMargin();
-  const qreal bandBottom = windowedPresentation_ ? 64 : 58;
-  return image.intersected(QRectF(
-      0, bandTop, width(), std::max<qreal>(1, height() - bandTop - bandBottom)));
+  return editImageRect().intersected(editViewportRect());
 }
 
 qreal CaptureEditor::maxViewZoom() const {
@@ -2931,7 +2932,8 @@ void CaptureEditor::handOffEditor(bool toWindow) {
   acceptText();
   busy_ = true;
   setEnabled(false);
-  setStatus(QStringLiteral("Preparing editor window…"));
+  setStatus(toWindow ? QStringLiteral("Preparing editor window…")
+                     : QStringLiteral("Preparing editor overlay…"));
   // Persist a value snapshot directly: waiting for the autosave and copying
   // its files would block input and race later coalesced snapshot writes.
   const QImage source = pristineSource_;
@@ -3055,9 +3057,15 @@ void CaptureEditor::enterEdit(QString status) {
     commitCrop(selection_);
   else
     scheduleSnapshot();
-  if (windowedHandoffOnEdit_ && captureMode_ != CaptureMode::Scroll) {
-    windowedHandoffOnEdit_ = false;
-    handOffEditor(true);
+  if (windowedHandoffOnEdit_) {
+    // Fullscreen can enter Edit in the constructor. Defer launching until
+    // construction and the caller's surface setup have completed.
+    QTimer::singleShot(0, this, [this] {
+      if (windowedHandoffOnEdit_ && phase_ == Phase::Edit) {
+        windowedHandoffOnEdit_ = false;
+        handOffEditor(true);
+      }
+    });
   }
 }
 
@@ -4209,7 +4217,7 @@ QRegion CaptureEditor::pointerMotionRegion(const QPointF &point) const {
            QRegion(widgetBounds);
   };
 
-  if (tool_ == Tool::Marker && !dragging_ && editImageRect().contains(point) &&
+  if (tool_ == Tool::Marker && !dragging_ && visibleEditImageRect().contains(point) &&
       !pointerGrabsLayer()) {
     Annotation marker;
     marker.kind = Annotation::Kind::Marker;
@@ -4608,7 +4616,7 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
 
 void CaptureEditor::mouseDoubleClickEvent(QMouseEvent *event) {
   if (phase_ != Phase::Edit || event->button() != Qt::LeftButton ||
-      !editImageRect().contains(event->position()))
+      !visibleEditImageRect().contains(event->position()))
     return;
   const int index = annotationAt(toAnnotationPoint(event->position()));
   if (index < 0 || annotations_.at(index).kind != Annotation::Kind::Text)
@@ -4649,7 +4657,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
   }
   if (event->button() == Qt::MiddleButton) {
     if (phase_ == Phase::Edit && viewZoom_ > 1.0 &&
-        !textEditing()) {
+        editViewportRect().contains(event->position()) && !textEditing()) {
       panning_ = true;
       panAnchor_ = event->position();
       setCursor(Qt::ClosedHandCursor);
@@ -4744,10 +4752,12 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       return;
     }
   }
+  if (!editViewportRect().contains(cursor_))
+    return;
   // A layer that ran off the capture keeps its handles and body live outside
   // the canvas, so it can be resized or dragged back in instead of being
   // stranded. Anything else outside the canvas stays inert.
-  const bool insideImage = editImageRect().contains(cursor_);
+  const bool insideImage = visibleEditImageRect().contains(cursor_);
   const QPointF point = insideImage ? toAnnotationPoint(cursor_)
                                     : toUnclampedAnnotationPoint(cursor_);
   if (!insideImage &&
@@ -5501,7 +5511,7 @@ void CaptureEditor::updatePointerCursor() {
       if (dragging_) {
         highlighterPreview_ = highlighterLock_;
         highlighterPreviewPoint_.reset();
-      } else if (editImageRect().contains(cursor_)) {
+      } else if (visibleEditImageRect().contains(cursor_)) {
         scheduleHighlighterProbe(toAnnotationPoint(cursor_));
       } else {
         clearHighlighterPreview();
@@ -6289,14 +6299,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   const bool clipViewport = viewZoom_ > 1.0;
   if (clipViewport) {
     painter.save();
-    // The band between the pinned chrome above and the status below; zoomed
-    // content must not overdraw either.
-    const qreal bandTop =
-        windowedPresentation_ ? contentBandTop() : imageTopMargin();
-    const qreal bandBottom = windowedPresentation_ ? 64 : 58;
-    painter.setClipRect(QRectF(0, bandTop, width(),
-                               std::max<qreal>(1, height() - bandTop -
-                                                      bandBottom)));
+    painter.setClipRect(editViewportRect());
   }
   if (grown) {
     // Extension is the canvas itself, while the source remains the image card
@@ -6424,7 +6427,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
                        ? highlighterLock_->annotationSize
                        : annotationSize_;
     defaultAnnotations.push_back(std::move(preview));
-  } else if (tool_ == Tool::Marker && image.contains(cursor_) && !dragging_ &&
+  } else if (tool_ == Tool::Marker && visibleEditImageRect().contains(cursor_) && !dragging_ &&
              !pointerGrabsLayer()) {
     // The ghost counter shows where the next one would land, so it belongs
     // only where the press would actually place one: over another counter the

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -278,6 +278,20 @@ public:
   }
   /// The layer surface this editor lives on. The scroll state toggles its
   /// keyboard interactivity and input mask while the page underneath is live.
+  /** The editor runs as a normal compositor window, not the overlay. */
+  void setWindowedPresentation(bool windowed) {
+    windowedPresentation_ = windowed;
+  }
+  /** A windowed editor's backdrop: solid, or the overlay's see-through
+   *  dim. Solid also drops the translucent surface: an alpha window shows
+   *  the desktop through any repaint gap while resizing or zooming. */
+  void setWindowedBackdropOpaque(bool opaque) {
+    windowedBackdropOpaque_ = opaque;
+    if (windowedPresentation_ && opaque)
+      setAttribute(Qt::WA_TranslucentBackground, false);
+  }
+  /** Top of the content band (below the pinned chrome in a window). */
+  [[nodiscard]] qreal contentBandTop() const;
   void setLayerWindow(LayerShellQt::Window *layer) { layer_ = layer; }
   /// Whether the select phase is in scroll mode. Test accessor.
   [[nodiscard]] bool scrollModeForTest() const { return scrollMode_; }
@@ -403,6 +417,8 @@ private:
   [[nodiscard]] int hoveredSpotlightAt(const QPointF &position) const;
   [[nodiscard]] QRectF normalizedSelection(const QPointF &first,
                                            const QPointF &second) const;
+  /// Top edge of the toolbar row: pinned under the key guide when
+  /// windowed, hugging the canvas on the overlay. Popovers anchor to it.
   [[nodiscard]] QRectF colorPaletteRect() const;
   [[nodiscard]] QRectF customColorPanelRect() const;
   [[nodiscard]] QRectF shapeMenuRect() const;
@@ -593,6 +609,8 @@ private:
   QImage pristineSource_;
   QSize pristineLogicalSize_;
   QVector<CutOp> cuts_;
+  bool windowedPresentation_ = false;
+  bool windowedBackdropOpaque_ = true;
   Phase phase_ = Phase::Select;
   Tool tool_ = Tool::Select;
   /// Set by the first key event, which carries a fresh modifier snapshot.

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -290,8 +290,20 @@ public:
     if (windowedPresentation_ && opaque)
       setAttribute(Qt::WA_TranslucentBackground, false);
   }
+  /** Hand a fresh capture straight to a windowed editor when it enters the
+   *  edit phase (the [editor] mode = window flow). */
+  void setWindowedHandoffOnEdit(bool handoff) {
+    windowedHandoffOnEdit_ = handoff;
+  }
   /** Top of the content band (below the pinned chrome in a window). */
   [[nodiscard]] qreal contentBandTop() const;
+  /** Flushes the working document and copies it to a private handoff path
+   *  with the selection recorded as a leading crop. Public for the smoke:
+   *  the round trip back through file mode is what proves the handoff. */
+  [[nodiscard]] bool prepareHandoff(QString &path, QString &error);
+  /** Re-presents this edit in the other editor (window or overlay) by
+   *  spawning it on the handoff document and closing this one. */
+  void handOffEditor(bool toWindow);
   void setLayerWindow(LayerShellQt::Window *layer) { layer_ = layer; }
   /// Whether the select phase is in scroll mode. Test accessor.
   [[nodiscard]] bool scrollModeForTest() const { return scrollMode_; }
@@ -617,6 +629,7 @@ private:
   QSize pristineLogicalSize_;
   QVector<CutOp> cuts_;
   bool windowedPresentation_ = false;
+  bool windowedHandoffOnEdit_ = false;
   bool windowedBackdropOpaque_ = true;
   Phase phase_ = Phase::Select;
   Tool tool_ = Tool::Select;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -41,6 +41,10 @@ class Window;
 [[nodiscard]] QString spotlightStatusForTest(SpotlightShape shape,
                                              qreal magnification, qreal border);
 
+/// The edit-phase key guide entries, shared by painting and by the
+/// windowed layout that reserves room for the guide.
+[[nodiscard]] QVector<QPair<QString, QString>> editorHotkeyEntries();
+
 class CaptureEditor final : public QWidget {
   Q_OBJECT
 public:

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -433,6 +433,13 @@ private:
   /// How much vertical room the tab strip and toolbar actually need, at the
   /// current window width — the image's top margin, not a guessed constant.
   [[nodiscard]] qreal imageTopMargin() const;
+  /// editImageRect clipped to the viewport band. Zoomed past fit the image
+  /// runs beyond the band; the chrome that frames it (crop outline, handles,
+  /// shadow) frames what is visible, not the off-screen edges.
+  [[nodiscard]] QRectF visibleEditImageRect() const;
+  /// Top edge the chrome (toolbar, popovers) anchors above: the fit rect at
+  /// zoom 1, the viewport band once zoomed (the content fills it then).
+  [[nodiscard]] qreal chromeAnchorTop() const;
   /// baseImageRect transformed by the current view zoom and pan (content and
   /// annotations map through this). Equals baseImageRect at zoom 1.
   [[nodiscard]] QRectF editImageRect() const;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -279,8 +279,6 @@ public:
   [[nodiscard]] int selectedCountForTest() const {
     return static_cast<int>(selectedAnnotations_.size());
   }
-  /// The layer surface this editor lives on. The scroll state toggles its
-  /// keyboard interactivity and input mask while the page underneath is live.
   /** The editor runs as a normal compositor window, not the overlay. */
   void setWindowedPresentation(bool windowed) {
     windowedPresentation_ = windowed;
@@ -295,6 +293,12 @@ public:
   }
   /** Top of the content band (below the pinned chrome in a window). */
   [[nodiscard]] qreal contentBandTop() const;
+  void setOcrOverlayForTest(const QRectF &region, const QString &text) {
+    ocrRegion_ = region;
+    ocrResultText_ = text;
+    ocrClock_.restart();
+    update();
+  }
   /// Injects the process launcher for a smoke test of the actual W action.
   void setSnapshotFutureForTest(const QFuture<bool> &future) {
     snapshotBusy_ = true;
@@ -307,6 +311,8 @@ public:
   /** Re-presents this edit in the other editor (window or overlay) by
    *  spawning it on the handoff document and closing this one. */
   void handOffEditor(bool toWindow);
+  /// The layer surface this editor lives on. The scroll state toggles its
+  /// keyboard interactivity and input mask while the page underneath is live.
   void setLayerWindow(LayerShellQt::Window *layer) { layer_ = layer; }
   /// Whether the select phase is in scroll mode. Test accessor.
   [[nodiscard]] bool scrollModeForTest() const { return scrollMode_; }

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -51,11 +51,13 @@ class CaptureEditor final : public QWidget {
 public:
   enum class CaptureMode { Region, Scroll, Window, Fullscreen, File };
 
+  /// windowedHandoff applies to fresh captures once they enter the edit phase.
   explicit CaptureEditor(CaptureData capture,
                          CaptureMode mode = CaptureMode::Region,
                          QuickOutputMode quickOutput = QuickOutputMode::None,
                          OperationLog log = {},
-                         QWidget *parent = nullptr);
+                         QWidget *parent = nullptr,
+                         bool windowedHandoff = false);
   ~CaptureEditor() override;
 
 signals:
@@ -291,11 +293,6 @@ public:
     if (windowedPresentation_ && opaque)
       setAttribute(Qt::WA_TranslucentBackground, false);
   }
-  /** Hand a fresh capture straight to a windowed editor when it enters the
-   *  edit phase (the [editor] mode = window flow). */
-  void setWindowedHandoffOnEdit(bool handoff) {
-    windowedHandoffOnEdit_ = handoff;
-  }
   /** Top of the content band (below the pinned chrome in a window). */
   [[nodiscard]] qreal contentBandTop() const;
   /// Injects the process launcher for a smoke test of the actual W action.
@@ -451,6 +448,7 @@ private:
   /// runs beyond the band; the chrome that frames it (crop outline, handles,
   /// shadow) frames what is visible, not the off-screen edges.
   [[nodiscard]] QRectF visibleEditImageRect() const;
+  [[nodiscard]] QRectF editViewportRect() const;
   /// Top edge the chrome (toolbar, popovers) anchors above: the fit rect at
   /// zoom 1, the viewport band once zoomed (the content fills it then).
   [[nodiscard]] qreal chromeAnchorTop() const;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -296,6 +296,10 @@ public:
   /** Top of the content band (below the pinned chrome in a window). */
   [[nodiscard]] qreal contentBandTop() const;
   /// Injects the process launcher for a smoke test of the actual W action.
+  void setSnapshotFutureForTest(const QFuture<bool> &future) {
+    snapshotBusy_ = true;
+    snapshotWatcher_.setFuture(future);
+  }
   void setHandoffLauncherForTest(
       std::function<bool(const QString &, const QStringList &)> launcher) {
     handoffLauncher_ = std::move(launcher);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -444,6 +444,9 @@ private:
   [[nodiscard]] QRectF baseImageRect() const;
   /// Top of the toolbar row: just under the tab strip's fixed bottom edge,
   /// independent of the image, so the two can never overlap.
+  [[nodiscard]] QSizeF windowLegendSize() const;
+  mutable int legendWidth_ = -1;
+  mutable QSizeF legendSize_;
   [[nodiscard]] qreal toolbarTop() const;
   /// How much vertical room the tab strip and toolbar actually need, at the
   /// current window width — the image's top margin, not a guessed constant.

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -1,3 +1,4 @@
+#include <functional>
 #pragma once
 
 #include "background-config.hpp"
@@ -297,10 +298,11 @@ public:
   }
   /** Top of the content band (below the pinned chrome in a window). */
   [[nodiscard]] qreal contentBandTop() const;
-  /** Flushes the working document and copies it to a private handoff path
-   *  with the selection recorded as a leading crop. Public for the smoke:
-   *  the round trip back through file mode is what proves the handoff. */
-  [[nodiscard]] bool prepareHandoff(QString &path, QString &error);
+  /// Injects the process launcher for a smoke test of the actual W action.
+  void setHandoffLauncherForTest(
+      std::function<bool(const QString &, const QStringList &)> launcher) {
+    handoffLauncher_ = std::move(launcher);
+  }
   /** Re-presents this edit in the other editor (window or overlay) by
    *  spawning it on the handoff document and closing this one. */
   void handOffEditor(bool toWindow);
@@ -629,6 +631,7 @@ private:
   QSize pristineLogicalSize_;
   QVector<CutOp> cuts_;
   bool windowedPresentation_ = false;
+  std::function<bool(const QString &, const QStringList &)> handoffLauncher_;
   bool windowedHandoffOnEdit_ = false;
   bool windowedBackdropOpaque_ = true;
   Phase phase_ = Phase::Select;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "cli-path.hpp"
 #include "editor.hpp"
 #include "instance-lock.hpp"
+#include "output-config.hpp"
 #include "overlay-chrome.hpp"
 #include "pin.hpp"
 #include "recent-snaps.hpp"
@@ -10,8 +11,17 @@
 #include <LayerShellQt/Window>
 
 
+#include <QFileInfo>
 #include <QImageReader>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QProcess>
+#include <QTimer>
 #include <QApplication>
+
+#include <algorithm>
+#include <memory>
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QDir>
@@ -100,7 +110,47 @@ int main(int argc, char **argv) {
   QCoreApplication::setApplicationName(QStringLiteral("omasnap"));
   QCoreApplication::setApplicationVersion(QString::fromLatin1(OMASNAP_VERSION));
   QCoreApplication::setOrganizationName(QStringLiteral("Omarchy"));
-  qputenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell");
+  // The overlay is a layer surface, but a windowed editor is an ordinary
+  // compositor window the compositor tiles and floats; the shell
+  // integration must be chosen before Qt connects, so the decision reads
+  // the arguments and the config by hand. Only a file edit can be
+  // windowed: a fresh capture always selects on the fullscreen overlay and
+  // hands off afterward.
+  bool editorWindowArg = false;
+  bool editorOverlayArg = false;
+  bool fileEditArg = false;
+  for (int index = 1; index < argc; ++index) {
+    const char *arg = argv[index];
+    if (qstrcmp(arg, "--editor") == 0 && index + 1 < argc) {
+      editorWindowArg = editorWindowArg || qstrcmp(argv[index + 1], "window") == 0;
+      editorOverlayArg =
+          editorOverlayArg || qstrcmp(argv[index + 1], "overlay") == 0;
+      ++index;
+    } else if (qstrcmp(arg, "--pin") == 0) {
+      ++index;
+    } else if (qstrcmp(arg, "--file") == 0) {
+      fileEditArg = true;
+      ++index;
+    } else if (qstrcmp(arg, "--clipboard") == 0) {
+      fileEditArg = true;
+    } else if (arg[0] != '-') {
+      fileEditArg =
+          fileEditArg || (qstrcmp(arg, "smart") != 0 &&
+                          qstrcmp(arg, "region") != 0 &&
+                          qstrcmp(arg, "windows") != 0 &&
+                          qstrcmp(arg, "fullscreen") != 0);
+    }
+  }
+  const bool windowedEditorProcess =
+      !editorOverlayArg && fileEditArg &&
+      (editorWindowArg || loadEditorWindowMode(defaultConfigPath()));
+  if (windowedEditorProcess) {
+    // Unset rather than merely not set: a windowed editor spawned from the
+    // overlay inherits the overlay's environment, layer-shell included.
+    qunsetenv("QT_WAYLAND_SHELL_INTEGRATION");
+  } else {
+    qputenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell");
+  }
   // Omarchy exports QT_QPA_PLATFORMTHEME=gtk3 session-wide. Honouring it
   // loads the qgtk3 plugin, which initialises GTK inside this process
   // (measured 81-112 ms of QApplication construction, plus ~20-24 MiB of
@@ -178,6 +228,14 @@ int main(int argc, char **argv) {
       QStringLiteral("Show an image as a pinned always-visible layer."),
       QStringLiteral("path"));
   parser.addOption(pinOption);
+  const QCommandLineOption editorOption(
+      QStringLiteral("editor"),
+      QStringLiteral("Editor presentation: overlay (fullscreen, default) or "
+                     "window (a normal compositor window). Also configurable "
+                     "as [editor] mode in omasnap.conf; W switches a live "
+                     "editor between the two."),
+      QStringLiteral("mode"));
+  parser.addOption(editorOption);
   const QCommandLineOption scrollOption(
       QStringLiteral("scroll"),
       QStringLiteral("Capture a scrolling region and stitch it into one tall "
@@ -193,6 +251,17 @@ int main(int argc, char **argv) {
 
   QString filePath = parser.value(fileOption);
   const bool clipboardInput = parser.isSet(clipboardOption);
+
+  const QString editorModeArg = parser.value(editorOption).trimmed().toLower();
+  if (!editorModeArg.isEmpty() &&
+      editorModeArg != QStringLiteral("window") &&
+      editorModeArg != QStringLiteral("overlay")) {
+    qCritical() << "--editor takes window or overlay";
+    return 2;
+  }
+  const bool editorWindowMode =
+      editorModeArg == QStringLiteral("window") ||
+      (editorModeArg.isEmpty() && loadEditorWindowMode(defaultConfigPath()));
 
   QuickOutputMode quickOutputMode = QuickOutputMode::None;
   if (parser.isSet(copyOption) && parser.isSet(saveOption))
@@ -401,10 +470,138 @@ int main(int argc, char **argv) {
                              .arg(capture.windows.size());
   }
 
+  const QSize editingPreview = capture.previewSize;
   CaptureEditor editor(std::move(capture), captureMode, quickOutputMode,
                        restoredLog);
   startupTimingMark("CaptureEditor constructed");
   editor.setScreen(targetScreen);
+  if (windowedEditorProcess && editingImage) {
+    // An ordinary compositor window: the compositor manages it, and its own
+    // float toggle works either way. The overlay chrome carries over
+    // unchanged; only the surface role differs.
+    editor.setWindowedPresentation(true);
+    editor.setWindowedBackdropOpaque(
+        loadEditorWindowBackdropOpaque(defaultConfigPath()));
+    editor.setWindowTitle(
+        filePath.isEmpty() ? QStringLiteral("omasnap")
+                           : QStringLiteral("omasnap %1")
+                                 .arg(QFileInfo(filePath).fileName()));
+    // Size to the visible selection, not the pristine canvas: a handed-off
+    // capture keeps its whole monitor underneath, but the window should hug
+    // what is actually being annotated.
+    const QSizeF selectionSize = editor.currentSelection().size();
+    const QSize hugged =
+        selectionSize.isEmpty() ? editingPreview : selectionSize.toSize();
+    // The guide band's height depends on how wide the card may be, so
+    // measure it at the width this window will have.
+    const int legendHeight =
+        hotkeyLegendAnchoredSize(editorHotkeyEntries(),
+                                 std::max(392, hugged.width() + 100))
+            .height();
+    const QSize naturalSize =
+        editorWindowSize(hugged, targetScreen->availableGeometry().size(),
+                         legendHeight);
+    // A hard floor clamps interactive floating resizes where the toolbar
+    // still reads; a tiled window's compositor overrides the hint, and
+    // that path is accepted as the tiled look.
+    editor.setMinimumSize(640, 420);
+    editor.resize(naturalSize);
+    // Both rules registered before the window maps, so the compositor
+    // floats, centers, and keeps it opaque from the first frame instead of
+    // tiling briefly and popping out.
+    const bool floatingWindow = loadEditorWindowFloating(defaultConfigPath());
+    QProcess::execute(QStringLiteral("hyprctl"),
+                      {QStringLiteral("eval"),
+                       editorFloatRuleScript(floatingWindow)});
+    // Exempt from the desktop's window-opacity rules: an editor whose mat
+    // and capture ghost translucent when unfocused reads as broken.
+    QProcess::execute(
+        QStringLiteral("hyprctl"),
+        {QStringLiteral("eval"),
+         QStringLiteral("hl.window_rule({ name = \"omasnap-editor-opaque\", "
+                        "match = { title = \"^omasnap( .+)?$\" }, "
+                        "opacity = 1 })")});
+    editor.show();
+    editor.setFocus(Qt::ActiveWindowFocusReason);
+    if (floatingWindow) {
+      // Floating at the capture's natural size unless the config says
+      // tiled. Dispatched once the compositor lists the window: asked too
+      // early, a dispatch reports success and does nothing.
+      auto attempts = std::make_shared<int>(0);
+      QTimer *settle = new QTimer(&editor);
+      settle->setInterval(50);
+      QObject::connect(settle, &QTimer::timeout, &editor, [settle, attempts,
+                                                           naturalSize] {
+        ++*attempts;
+        const qint64 pid = QCoreApplication::applicationPid();
+        QProcess probe;
+        probe.start(QStringLiteral("hyprctl"),
+                    {QStringLiteral("-j"), QStringLiteral("clients")});
+        const bool hyprland = probe.waitForFinished(500);
+        const QByteArray clients = probe.readAllStandardOutput();
+        bool listed = false;
+        bool alreadyFloating = false;
+        if (hyprland) {
+          const QJsonArray parsed = QJsonDocument::fromJson(clients).array();
+          for (const QJsonValue &value : parsed) {
+            const QJsonObject client = value.toObject();
+            if (client.value(QStringLiteral("pid")).toInteger() == pid) {
+              listed = true;
+              alreadyFloating =
+                  client.value(QStringLiteral("floating")).toBool();
+              break;
+            }
+          }
+        }
+        if (listed) {
+          settle->stop();
+          // The map rule normally floats and centers the window already;
+          // these dispatches are the fallback for a compositor that
+          // ignored it. hl.dsp.window.float toggles, so a window the rule
+          // floated must not be dispatched back into the tiling.
+          if (alreadyFloating)
+            return;
+          const QString selector =
+              QStringLiteral("window = \"pid:%1\"").arg(pid);
+          QProcess::execute(
+              QStringLiteral("hyprctl"),
+              {QStringLiteral("dispatch"),
+               QStringLiteral("hl.dsp.window.float({ %1 })").arg(selector)});
+          QProcess::execute(
+              QStringLiteral("hyprctl"),
+              {QStringLiteral("dispatch"),
+               QStringLiteral(
+                   "hl.dsp.window.resize({ x = %1, y = %2, relative = "
+                   "false, %3 })")
+                   .arg(naturalSize.width())
+                   .arg(naturalSize.height())
+                   .arg(selector)});
+          // Centered in the workspace area, clear of bars, or a tall
+          // window's toolbar ends up under the top bar.
+          QProcess::execute(
+              QStringLiteral("hyprctl"),
+              {QStringLiteral("dispatch"),
+               QStringLiteral("hl.dsp.window.center({ %1 })").arg(selector)});
+          return;
+        }
+        if (!hyprland && qEnvironmentVariableIsSet("SWAYSOCK")) {
+          settle->stop();
+          QProcess::execute(
+              QStringLiteral("swaymsg"),
+              {QStringLiteral("[pid=%1] floating enable, resize set %2 %3, "
+                              "move position center")
+                   .arg(pid)
+                   .arg(naturalSize.width())
+                   .arg(naturalSize.height())});
+          return;
+        }
+        if (*attempts >= 10)
+          settle->stop();
+      });
+      settle->start();
+    }
+    return application.exec();
+  }
   editor.setGeometry(targetScreen->geometry());
   editor.winId();
   QWindow *window = editor.windowHandle();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -602,6 +602,9 @@ int main(int argc, char **argv) {
     }
     return application.exec();
   }
+  if (editorWindowMode && !editingImage)
+    editor.setWindowedHandoffOnEdit(captureMode !=
+                                    CaptureEditor::CaptureMode::Scroll);
   editor.setGeometry(targetScreen->geometry());
   editor.winId();
   QWindow *window = editor.windowHandle();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -398,7 +398,7 @@ int main(int argc, char **argv) {
 
   const QSize editingPreview = capture.previewSize;
   CaptureEditor editor(std::move(capture), captureMode, quickOutputMode,
-                       restoredLog);
+                       restoredLog, nullptr, editorWindowMode && !editingImage);
   startupTimingMark("CaptureEditor constructed");
   editor.setScreen(targetScreen);
   if (windowedEditorProcess && editingImage) {
@@ -491,9 +491,6 @@ int main(int argc, char **argv) {
     }));
     return application.exec();
   }
-  if (editorWindowMode && !editingImage)
-    editor.setWindowedHandoffOnEdit(captureMode !=
-                                    CaptureEditor::CaptureMode::Scroll);
   editor.setGeometry(targetScreen->geometry());
   editor.winId();
   QWindow *window = editor.windowHandle();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#include <QFutureWatcher>
+#include <QtConcurrent/QtConcurrentRun>
 #include "capture.hpp"
 #include "cli-path.hpp"
 #include "editor.hpp"
@@ -103,6 +105,19 @@ private:
   bool sigtermInstalled_ = false;
   QSocketNotifier *notifier_ = nullptr;
 };
+// All compositor IPC runs on a worker, including the pre-map rules. A
+// missing or wedged hyprctl is bounded and never stalls a visible editor.
+QByteArray hyprctlOutput(const QStringList &arguments) {
+  QProcess process;
+  process.start(QStringLiteral("hyprctl"), arguments);
+  if (!process.waitForFinished(500)) {
+    process.kill();
+    process.waitForFinished(500);
+    return {};
+  }
+  return process.readAllStandardOutput();
+}
+
 } // namespace
 
 int main(int argc, char **argv) {
@@ -116,34 +131,14 @@ int main(int argc, char **argv) {
   // the arguments and the config by hand. Only a file edit can be
   // windowed: a fresh capture always selects on the fullscreen overlay and
   // hands off afterward.
-  bool editorWindowArg = false;
-  bool editorOverlayArg = false;
-  bool fileEditArg = false;
-  for (int index = 1; index < argc; ++index) {
-    const char *arg = argv[index];
-    if (qstrcmp(arg, "--editor") == 0 && index + 1 < argc) {
-      editorWindowArg = editorWindowArg || qstrcmp(argv[index + 1], "window") == 0;
-      editorOverlayArg =
-          editorOverlayArg || qstrcmp(argv[index + 1], "overlay") == 0;
-      ++index;
-    } else if (qstrcmp(arg, "--pin") == 0) {
-      ++index;
-    } else if (qstrcmp(arg, "--file") == 0) {
-      fileEditArg = true;
-      ++index;
-    } else if (qstrcmp(arg, "--clipboard") == 0) {
-      fileEditArg = true;
-    } else if (arg[0] != '-') {
-      fileEditArg =
-          fileEditArg || (qstrcmp(arg, "smart") != 0 &&
-                          qstrcmp(arg, "region") != 0 &&
-                          qstrcmp(arg, "windows") != 0 &&
-                          qstrcmp(arg, "fullscreen") != 0);
-    }
-  }
-  const bool windowedEditorProcess =
-      !editorOverlayArg && fileEditArg &&
-      (editorWindowArg || loadEditorWindowMode(defaultConfigPath()));
+  QStringList rawArguments;
+  for (int index = 0; index < argc; ++index)
+    rawArguments.push_back(QString::fromLocal8Bit(argv[index]));
+  QCommandLineParser startupParser;
+  configureCaptureCommandLine(startupParser);
+  const bool startupParsed = startupParser.parse(rawArguments);
+  const bool windowedEditorProcess = startupParsed &&
+      windowedEditorRequested(startupParser, loadEditorWindowMode(defaultConfigPath()));
   if (windowedEditorProcess) {
     // Unset rather than merely not set: a windowed editor spawned from the
     // overlay inherits the overlay's environment, layer-shell included.
@@ -176,83 +171,14 @@ int main(int argc, char **argv) {
   PosixSignalNotifier signalNotifier(&application);
 
   QCommandLineParser parser;
-  parser.setApplicationDescription(QStringLiteral(
-      "Native Wayland screenshot and annotation overlay for Hyprland and "
-      "Omarchy.\n"
-      "\n"
-      "Only one capture overlay runs at a time. Starting omasnap again while "
-      "an\noverlay is open dismisses it: the running instance is asked to "
-      "quit and the\nnew process exits without capturing, so the same hotkey "
-      "opens and closes the\noverlay. Quick output (--copy, --save) dismisses "
-      "it the same way instead of\nscreenshotting the overlay. With --file (or "
-      "an image path) or --clipboard, the running\ninstance is stopped and "
-      "the editor opens on that image instead.\n"
-      "\n"
-      "Exit codes: 0 success, including dismissing a running overlay; 1 "
-      "capture,\nimage, or single-instance lock failure; 2 usage error."));
-  parser.addHelpOption();
-  parser.addVersionOption();
-  const QCommandLineOption fullscreenOption(
-      QStringLiteral("capture-fullscreen"),
-      QStringLiteral("Start with the entire focused monitor selected."));
-  const QCommandLineOption windowOption(
-      {QStringLiteral("capture-window"), QStringLiteral("capture-windows")},
-      QStringLiteral("Start in window selection mode."));
-  const QCommandLineOption regionOption(
-      QStringLiteral("capture-region"),
-      QStringLiteral("Start in freeform region selection mode (default)."));
-  parser.addOption(fullscreenOption);
-  parser.addOption(windowOption);
-  parser.addOption(regionOption);
-  const QCommandLineOption copyOption(
-      QStringLiteral("copy"),
-      QStringLiteral("Copy the capture directly without opening the editor."));
-  const QCommandLineOption saveOption(
-      QStringLiteral("save"),
-      QStringLiteral("Save the capture directly without opening the editor."));
-  parser.addOption(copyOption);
-  parser.addOption(saveOption);
-  const QCommandLineOption fileOption(
-      QStringLiteral("file"),
-      QStringLiteral("Open an existing image file in the annotation editor "
-                     "instead of capturing the screen."),
-      QStringLiteral("path"));
-  parser.addOption(fileOption);
-  const QCommandLineOption clipboardOption(
-      QStringLiteral("clipboard"),
-      QStringLiteral("Open the current clipboard image in the annotation "
-                     "editor instead of capturing the screen."));
-  parser.addOption(clipboardOption);
-  const QCommandLineOption pinOption(
-      QStringLiteral("pin"),
-      QStringLiteral("Show an image as a pinned always-visible layer."),
-      QStringLiteral("path"));
-  parser.addOption(pinOption);
-  const QCommandLineOption editorOption(
-      QStringLiteral("editor"),
-      QStringLiteral("Editor presentation: overlay (fullscreen, default) or "
-                     "window (a normal compositor window). Also configurable "
-                     "as [editor] mode in omasnap.conf; W switches a live "
-                     "editor between the two."),
-      QStringLiteral("mode"));
-  parser.addOption(editorOption);
-  const QCommandLineOption scrollOption(
-      QStringLiteral("scroll"),
-      QStringLiteral("Capture a scrolling region and stitch it into one tall "
-                     "image, then open it in the editor."));
-  parser.addOption(scrollOption);
-  parser.addPositionalArgument(
-      QStringLiteral("target"),
-      QStringLiteral("Capture mode (smart, region, windows, fullscreen) or the "
-                     "path of an image file to edit."),
-      QStringLiteral("[target]"));
+  configureCaptureCommandLine(parser);
   parser.process(application);
   startupTimingMark("command line parsed");
 
-  QString filePath = parser.value(fileOption);
-  const bool clipboardInput = parser.isSet(clipboardOption);
+  QString filePath = parser.value(QStringLiteral("file"));
+  const bool clipboardInput = parser.isSet(QStringLiteral("clipboard"));
 
-  const QString editorModeArg = parser.value(editorOption).trimmed().toLower();
+  const QString editorModeArg = parser.value(QStringLiteral("editor")).trimmed().toLower();
   if (!editorModeArg.isEmpty() &&
       editorModeArg != QStringLiteral("window") &&
       editorModeArg != QStringLiteral("overlay")) {
@@ -264,35 +190,35 @@ int main(int argc, char **argv) {
       (editorModeArg.isEmpty() && loadEditorWindowMode(defaultConfigPath()));
 
   QuickOutputMode quickOutputMode = QuickOutputMode::None;
-  if (parser.isSet(copyOption) && parser.isSet(saveOption))
+  if (parser.isSet(QStringLiteral("copy")) && parser.isSet(QStringLiteral("save")))
     quickOutputMode = QuickOutputMode::Both;
-  else if (parser.isSet(copyOption))
+  else if (parser.isSet(QStringLiteral("copy")))
     quickOutputMode = QuickOutputMode::Copy;
-  else if (parser.isSet(saveOption))
+  else if (parser.isSet(QStringLiteral("save")))
     quickOutputMode = QuickOutputMode::Save;
 
   CaptureEditor::CaptureMode captureMode = CaptureEditor::CaptureMode::Region;
-  int requestedModes = parser.isSet(fullscreenOption) +
-                       parser.isSet(windowOption) + parser.isSet(regionOption) +
-                       parser.isSet(scrollOption);
-  if (parser.isSet(fullscreenOption))
+  int requestedModes = parser.isSet(QStringLiteral("capture-fullscreen")) +
+                       parser.isSet(QStringLiteral("capture-window")) + parser.isSet(QStringLiteral("capture-region")) +
+                       parser.isSet(QStringLiteral("scroll"));
+  if (parser.isSet(QStringLiteral("capture-fullscreen")))
     captureMode = CaptureEditor::CaptureMode::Fullscreen;
-  else if (parser.isSet(windowOption))
+  else if (parser.isSet(QStringLiteral("capture-window")))
     captureMode = CaptureEditor::CaptureMode::Window;
-  else if (parser.isSet(scrollOption))
+  else if (parser.isSet(QStringLiteral("scroll")))
     captureMode = CaptureEditor::CaptureMode::Scroll;
 
   const QStringList positional = parser.positionalArguments();
-  if (parser.isSet(pinOption)) {
+  if (parser.isSet(QStringLiteral("pin"))) {
     if (!filePath.isEmpty() || clipboardInput || requestedModes > 0 ||
         !positional.isEmpty() || quickOutputMode != QuickOutputMode::None) {
       qCritical()
           << "Pinned mode cannot be combined with capture or edit targets";
       return 2;
     }
-    QString pinPath = QUrl(parser.value(pinOption)).toLocalFile();
+    QString pinPath = QUrl(parser.value(QStringLiteral("pin"))).toLocalFile();
     if (pinPath.isEmpty())
-      pinPath = parser.value(pinOption);
+      pinPath = parser.value(QStringLiteral("pin"));
     return runPinnedCapture(pinPath);
   }
   if (positional.size() > 1) {
@@ -510,96 +436,59 @@ int main(int argc, char **argv) {
     // floats, centers, and keeps it opaque from the first frame instead of
     // tiling briefly and popping out.
     const bool floatingWindow = loadEditorWindowFloating(defaultConfigPath());
-    QProcess::execute(QStringLiteral("hyprctl"),
-                      {QStringLiteral("eval"),
-                       editorFloatRuleScript(floatingWindow)});
-    // Exempt from the desktop's window-opacity rules: an editor whose mat
-    // and capture ghost translucent when unfocused reads as broken.
-    QProcess::execute(
-        QStringLiteral("hyprctl"),
-        {QStringLiteral("eval"),
-         QStringLiteral("hl.window_rule({ name = \"omasnap-editor-opaque\", "
-                        "match = { title = \"^omasnap( .+)?$\" }, "
-                        "opacity = 1 })")});
-    editor.show();
-    editor.setFocus(Qt::ActiveWindowFocusReason);
-    if (floatingWindow) {
-      // Floating at the capture's natural size unless the config says
-      // tiled. Dispatched once the compositor lists the window: asked too
-      // early, a dispatch reports success and does nothing.
-      auto attempts = std::make_shared<int>(0);
-      QTimer *settle = new QTimer(&editor);
+    auto *rules = new QFutureWatcher<void>(&editor);
+    QObject::connect(rules, &QFutureWatcher<void>::finished, &editor,
+                     [&editor, rules, floatingWindow, naturalSize] {
+      rules->deleteLater();
+      editor.show();
+      editor.setFocus(Qt::ActiveWindowFocusReason);
+      if (!floatingWindow)
+        return;
+      auto *settle = new QTimer(&editor);
       settle->setInterval(50);
-      QObject::connect(settle, &QTimer::timeout, &editor, [settle, attempts,
-                                                           naturalSize] {
-        ++*attempts;
+      settle->setSingleShot(true);
+      auto *probe = new QFutureWatcher<bool>(&editor);
+      QObject::connect(probe, &QFutureWatcher<bool>::finished, &editor,
+                       [probe, settle, attempts = 0]() mutable {
+        if (!probe->result() && ++attempts < 10)
+          settle->start();
+        else {
+          settle->deleteLater();
+          probe->deleteLater();
+        }
+      });
+      QObject::connect(settle, &QTimer::timeout, &editor, [probe, naturalSize] {
         const qint64 pid = QCoreApplication::applicationPid();
-        QProcess probe;
-        probe.start(QStringLiteral("hyprctl"),
-                    {QStringLiteral("-j"), QStringLiteral("clients")});
-        const bool hyprland = probe.waitForFinished(500);
-        const QByteArray clients = probe.readAllStandardOutput();
-        bool listed = false;
-        bool alreadyFloating = false;
-        if (hyprland) {
-          const QJsonArray parsed = QJsonDocument::fromJson(clients).array();
-          for (const QJsonValue &value : parsed) {
+        probe->setFuture(QtConcurrent::run([pid, naturalSize] {
+          const QJsonArray clients = QJsonDocument::fromJson(
+              hyprctlOutput({QStringLiteral("-j"), QStringLiteral("clients")})).array();
+          for (const QJsonValue &value : clients) {
             const QJsonObject client = value.toObject();
-            if (client.value(QStringLiteral("pid")).toInteger() == pid) {
-              listed = true;
-              alreadyFloating =
-                  client.value(QStringLiteral("floating")).toBool();
-              break;
-            }
+            if (client.value(QStringLiteral("pid")).toInteger() != pid)
+              continue;
+            if (client.value(QStringLiteral("floating")).toBool())
+              return true;
+            const QString selector = QStringLiteral("window = \"pid:%1\"").arg(pid);
+            hyprctlOutput({QStringLiteral("dispatch"),
+                           QStringLiteral("hl.dsp.window.float({ %1 })").arg(selector)});
+            hyprctlOutput({QStringLiteral("dispatch"),
+                           QStringLiteral("hl.dsp.window.resize({ x = %1, y = %2, relative = false, %3 })")
+                               .arg(naturalSize.width()).arg(naturalSize.height()).arg(selector)});
+            hyprctlOutput({QStringLiteral("dispatch"),
+                           QStringLiteral("hl.dsp.window.center({ %1 })").arg(selector)});
+            return true;
           }
-        }
-        if (listed) {
-          settle->stop();
-          // The map rule normally floats and centers the window already;
-          // these dispatches are the fallback for a compositor that
-          // ignored it. hl.dsp.window.float toggles, so a window the rule
-          // floated must not be dispatched back into the tiling.
-          if (alreadyFloating)
-            return;
-          const QString selector =
-              QStringLiteral("window = \"pid:%1\"").arg(pid);
-          QProcess::execute(
-              QStringLiteral("hyprctl"),
-              {QStringLiteral("dispatch"),
-               QStringLiteral("hl.dsp.window.float({ %1 })").arg(selector)});
-          QProcess::execute(
-              QStringLiteral("hyprctl"),
-              {QStringLiteral("dispatch"),
-               QStringLiteral(
-                   "hl.dsp.window.resize({ x = %1, y = %2, relative = "
-                   "false, %3 })")
-                   .arg(naturalSize.width())
-                   .arg(naturalSize.height())
-                   .arg(selector)});
-          // Centered in the workspace area, clear of bars, or a tall
-          // window's toolbar ends up under the top bar.
-          QProcess::execute(
-              QStringLiteral("hyprctl"),
-              {QStringLiteral("dispatch"),
-               QStringLiteral("hl.dsp.window.center({ %1 })").arg(selector)});
-          return;
-        }
-        if (!hyprland && qEnvironmentVariableIsSet("SWAYSOCK")) {
-          settle->stop();
-          QProcess::execute(
-              QStringLiteral("swaymsg"),
-              {QStringLiteral("[pid=%1] floating enable, resize set %2 %3, "
-                              "move position center")
-                   .arg(pid)
-                   .arg(naturalSize.width())
-                   .arg(naturalSize.height())});
-          return;
-        }
-        if (*attempts >= 10)
-          settle->stop();
+          return false;
+        }));
       });
       settle->start();
-    }
+    });
+    rules->setFuture(QtConcurrent::run([floatingWindow] {
+      hyprctlOutput({QStringLiteral("eval"), editorFloatRuleScript(floatingWindow)});
+      hyprctlOutput({QStringLiteral("eval"),
+                     QStringLiteral("hl.window_rule({ name = \"omasnap-editor-opaque\", "
+                                    "match = { title = \"^omasnap( .+)?$\" }, opacity = 1 })")});
+    }));
     return application.exec();
   }
   if (editorWindowMode && !editingImage)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
   for (int index = 0; index < argc; ++index)
     rawArguments.push_back(QString::fromLocal8Bit(argv[index]));
   QCommandLineParser startupParser;
-  configureCaptureCommandLine(startupParser);
+  configureCaptureCommandLine(startupParser, true);
   const bool startupParsed = startupParser.parse(rawArguments);
   const bool windowedEditorProcess = startupParsed &&
       windowedEditorRequested(startupParser, loadEditorWindowMode(defaultConfigPath()));
@@ -331,6 +331,9 @@ int main(int argc, char **argv) {
             << QStringLiteral("Could not restore operation log: %1").arg(error);
         return 1;
       }
+      // Ownership of private handoff files ends once both source and log
+      // are in memory. Ordinary user files are excluded by the helper.
+      removeEditorHandoff(localFile);
     }
     describeFileCapture(capture, image, restoredLog);
     captureMode = CaptureEditor::CaptureMode::File;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,6 +336,7 @@ int main(int argc, char **argv) {
       removeEditorHandoff(localFile);
     }
     describeFileCapture(capture, image, restoredLog);
+    capture.monitor.name = parser.value(QStringLiteral("handoff-monitor"));
     captureMode = CaptureEditor::CaptureMode::File;
     qInfo().noquote() << QStringLiteral("Opened %1 for annotation (%2x%3)")
                              .arg(inputName)

--- a/src/output-config.cpp
+++ b/src/output-config.cpp
@@ -55,6 +55,46 @@ QString formatScreenshotFilename(const QString &pattern, const QDateTime &when,
   return name + QStringLiteral(".png");
 }
 
+bool loadEditorWindowMode(const QString &filePath) {
+  QSettings settings(filePath, QSettings::IniFormat);
+  return settings.value(QStringLiteral("editor/mode"))
+             .toString()
+             .trimmed()
+             .toLower() == QStringLiteral("window");
+}
+
+QString editorFloatRuleScript(bool floating) {
+  // Registered before the editor window maps: floated after the fact, the
+  // window tiles for a frame and visibly pops out. The named rule
+  // coalesces across editors, and a tiled config re-registers it disabled
+  // so a floating session's rule cannot leak into tiled use. The title
+  // pattern skips the pins, whose titles have no space after the name.
+  return floating ? QStringLiteral(
+                        "hl.window_rule({ name = \"omasnap-editor-float\", "
+                        "match = { title = \"^omasnap( .+)?$\" }, "
+                        "float = true, center = true })")
+                  : QStringLiteral(
+                        "hl.window_rule({ name = \"omasnap-editor-float\", "
+                        "match = { title = \"^omasnap( .+)?$\" }, "
+                        "enabled = false })");
+}
+
+bool loadEditorWindowFloating(const QString &filePath) {
+  QSettings settings(filePath, QSettings::IniFormat);
+  return settings.value(QStringLiteral("editor/window"))
+             .toString()
+             .trimmed()
+             .toLower() != QStringLiteral("tiled");
+}
+
+bool loadEditorWindowBackdropOpaque(const QString &filePath) {
+  QSettings settings(filePath, QSettings::IniFormat);
+  return settings.value(QStringLiteral("editor/backdrop"))
+             .toString()
+             .trimmed()
+             .toLower() != QStringLiteral("translucent");
+}
+
 QString defaultConfigPath() {
   return QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) +
          QStringLiteral("/omasnap/omasnap.conf");

--- a/src/output-config.hpp
+++ b/src/output-config.hpp
@@ -25,5 +25,22 @@ struct OutputConfig {
                                                const QDateTime &when,
                                                const QString &appSlug);
 
+/** True when [editor] mode = window: the annotation editor opens as a
+ *  normal compositor window instead of the fullscreen overlay. Overlay is
+ *  the default and any other value. */
+[[nodiscard]] bool loadEditorWindowMode(const QString &filePath);
+
+/** True unless [editor] window = tiled: a windowed editor asks the
+ *  compositor to float it at its natural size; tiled leaves it to the
+ *  layout. */
+[[nodiscard]] bool loadEditorWindowFloating(const QString &filePath);
+/** Lua chunk registering (or, tiled, disabling) the compositor rule that
+ *  floats and centers the editor window as it maps. */
+[[nodiscard]] QString editorFloatRuleScript(bool floating);
+
+/** True unless [editor] backdrop = translucent: a windowed editor paints a
+ *  solid backdrop instead of the overlay's see-through dim. */
+[[nodiscard]] bool loadEditorWindowBackdropOpaque(const QString &filePath);
+
 /** ~/.config/omasnap/omasnap.conf (XDG config location). */
 [[nodiscard]] QString defaultConfigPath();

--- a/src/overlay-chrome.cpp
+++ b/src/overlay-chrome.cpp
@@ -202,6 +202,120 @@ void drawHotkeyLegend(QPainter &painter, const QRect &bounds,
   }
 }
 
+namespace {
+constexpr qreal kLegendKeyGapAnchored = 8;
+constexpr qreal kLegendColumnGapAnchored = 14;
+constexpr qreal kLegendPaddingAnchored = 12;
+
+struct AnchoredLegendLayout {
+  int columns = 2;
+  int rows = 0;
+  QVector<qreal> keyWidth;
+  QVector<qreal> textWidth;
+  QVector<qreal> columnWidth;
+  qreal width = 0;
+};
+
+QFont anchoredLegendFont() {
+  QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
+  font.setPixelSize(11);
+  return font;
+}
+
+AnchoredLegendLayout measureAnchoredLegend(
+    const QVector<QPair<QString, QString>> &entries, int columns) {
+  const QFontMetricsF metrics{anchoredLegendFont()};
+  AnchoredLegendLayout layout;
+  layout.columns = columns;
+  layout.rows = (entries.size() + columns - 1) / columns;
+  layout.keyWidth = QVector<qreal>(columns, 0.0);
+  layout.textWidth = QVector<qreal>(columns, 0.0);
+  for (int index = 0; index < entries.size(); ++index) {
+    const int column = std::min(index / layout.rows, columns - 1);
+    layout.keyWidth[column] =
+        std::max(layout.keyWidth[column],
+                 metrics.horizontalAdvance(entries.at(index).first));
+    layout.textWidth[column] =
+        std::max(layout.textWidth[column],
+                 metrics.horizontalAdvance(entries.at(index).second));
+  }
+  layout.columnWidth = QVector<qreal>(columns, 0.0);
+  layout.width = 2 * kLegendPaddingAnchored;
+  for (int column = 0; column < columns; ++column) {
+    if (layout.keyWidth[column] <= 0 && layout.textWidth[column] <= 0)
+      continue;
+    layout.columnWidth[column] = layout.keyWidth[column] +
+                                 kLegendKeyGapAnchored +
+                                 layout.textWidth[column];
+    layout.width += layout.columnWidth[column];
+    if (column > 0)
+      layout.width += kLegendColumnGapAnchored;
+  }
+  return layout;
+}
+
+AnchoredLegendLayout fitAnchoredLegend(
+    const QVector<QPair<QString, QString>> &entries, qreal maxWidth) {
+  AnchoredLegendLayout layout;
+  for (int tryRows = 4;; ++tryRows) {
+    layout = measureAnchoredLegend(
+        entries, std::max(1, static_cast<int>((entries.size() + tryRows - 1) /
+                                              tryRows)));
+    if (layout.width <= maxWidth || layout.columns == 1)
+      return layout;
+  }
+}
+} // namespace
+
+QSize hotkeyLegendAnchoredSize(const QVector<QPair<QString, QString>> &entries,
+                               qreal maxWidth) {
+  if (entries.isEmpty())
+    return {};
+  const AnchoredLegendLayout layout = fitAnchoredLegend(entries, maxWidth);
+  return {qRound(std::min(layout.width, maxWidth)), layout.rows * 19 + 24};
+}
+
+void drawAnchoredHotkeyLegend(QPainter &painter, const QRect &bounds,
+                              const QVector<QPair<QString, QString>> &entries,
+                              const QRectF &anchorAbove) {
+  if (entries.isEmpty())
+    return;
+  const QFont font = anchoredLegendFont();
+  const AnchoredLegendLayout layout =
+      fitAnchoredLegend(entries, bounds.width() - 28.0);
+  const qreal width = std::min(layout.width, bounds.width() - 28.0);
+  const qreal height = layout.rows * 19 + 24;
+  // Pinned to the window's top, centered over the anchor: the windowed
+  // layout reserves the room, so the guide never covers the toolbar or the
+  // canvas.
+  const qreal x =
+      std::clamp(anchorAbove.center().x() - width / 2.0, 14.0,
+                 std::max(14.0, bounds.width() - width - 14.0));
+  const QRectF panel(x, 14.0, width, height);
+  painter.setPen(QPen(QColor(255, 255, 255, 34), 1));
+  painter.setBrush(QColor(13, 15, 20, 224));
+  painter.drawRoundedRect(panel, 11, 11);
+  painter.setFont(font);
+  for (int index = 0; index < entries.size(); ++index) {
+    const int column = std::min(index / layout.rows, layout.columns - 1);
+    const int row = index % layout.rows;
+    qreal cell = panel.left() + kLegendPaddingAnchored;
+    for (int before = 0; before < column; ++before)
+      cell += layout.columnWidth[before] + kLegendColumnGapAnchored;
+    const qreal top = panel.top() + 12 + row * 19;
+    painter.setPen(QColor(QStringLiteral("#a9b6cb")));
+    painter.drawText(QRectF(cell, top, layout.keyWidth[column], 18),
+                     Qt::AlignLeft | Qt::AlignVCenter,
+                     entries.at(index).first);
+    painter.setPen(QColor(QStringLiteral("#f5f5f7")));
+    painter.drawText(QRectF(cell + layout.keyWidth[column] +
+                                kLegendKeyGapAnchored,
+                            top, layout.textWidth[column], 18),
+                     Qt::AlignLeft | Qt::AlignVCenter,
+                     entries.at(index).second);
+  }
+}
+
 void drawStatusPill(QPainter &painter, const QRect &bounds,
                     const QString &text) {
   QFont font(QStringLiteral("Noto Sans"));

--- a/src/overlay-chrome.cpp
+++ b/src/overlay-chrome.cpp
@@ -217,8 +217,7 @@ struct AnchoredLegendLayout {
 };
 
 QFont anchoredLegendFont() {
-  QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
-  font.setPixelSize(11);
+  QFont font = chromeFont(11);
   return font;
 }
 

--- a/src/overlay-chrome.hpp
+++ b/src/overlay-chrome.hpp
@@ -72,6 +72,19 @@ QRectF drawModeBadge(QPainter &painter, const QRect &bounds,
 void drawHotkeyLegend(QPainter &painter, const QRect &bounds,
                       const QVector<QPair<QString, QString>> &entries);
 
+/// The size the key guide takes in its wide anchored form (a windowed
+/// editor's toolbar band) when it may be at most `maxWidth` wide: rows are
+/// added until the card fits.
+[[nodiscard]] QSize hotkeyLegendAnchoredSize(
+    const QVector<QPair<QString, QString>> &entries, qreal maxWidth);
+
+/// A wide key card a few rows tall, centered over `anchorAbove`: a compact
+/// window has no clear margin for the overlay's backgroundless column, so
+/// the windowed layout reserves this card room instead.
+void drawAnchoredHotkeyLegend(QPainter &painter, const QRect &bounds,
+                              const QVector<QPair<QString, QString>> &entries,
+                              const QRectF &anchorAbove);
+
 /// The instruction line along the bottom.
 void drawStatusPill(QPainter &painter, const QRect &bounds,
                     const QString &text);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1874,6 +1874,9 @@ bool runEditorWindowConfigCheck(QString &error) {
     error = QStringLiteral("The windowed editor sized itself wrong");
     return false;
   }
+  return true;
+}
+
 /** The draft's native caret is hidden; QPlainTextEdit actually reads cursorWidth. */
 bool runNativeCaretHiddenCheck(QApplication &application, QString &error) {
   CaptureData capture;
@@ -1980,6 +1983,86 @@ bool runDraftViewLockCheck(QApplication &application, QString &error) {
     return false;
   }
   editor.close();
+  return true;
+}
+
+/** Handing a live edit to the other presentation keeps everything: the
+ *  selection, the layers, and the undo history survive the round trip
+ *  through the handoff document and file mode. */
+bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {1600, 1200};
+  capture.monitor.scale = 2.0;
+  capture.source = QImage(1600, 1200, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(Qt::white);
+  capture.previewSize = QSize(800, 600);
+
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 100));
+  QTest::mouseMove(&editor, QPoint(650, 470), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(650, 470));
+  application.processEvents();
+  QTest::keyClick(&editor, Qt::Key_R);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(200, 200));
+  QTest::mouseMove(&editor, QPoint(300, 260), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(300, 260));
+  application.processEvents();
+  if (editor.annotationCountForTest() != 1) {
+    error = QStringLiteral("Handoff fixture did not draw its rectangle");
+    return false;
+  }
+
+  QString path;
+  if (!editor.prepareHandoff(path, error))
+    return false;
+  const QString logPath = operationLogPath(path);
+  const auto cleanup = [&] {
+    QFile::remove(path);
+    QFile::remove(logPath);
+  };
+  if (!path.contains(QStringLiteral("edit-"))) {
+    cleanup();
+    error = QStringLiteral("Handoff document has no private edit- name");
+    return false;
+  }
+
+  QImage image(path);
+  OperationLog log;
+  if (image.isNull() || !loadOperationLog(logPath, log, error)) {
+    cleanup();
+    return false;
+  }
+  CaptureData reopened;
+  describeFileCapture(reopened, std::move(image), log);
+  CaptureEditor window(reopened, CaptureEditor::CaptureMode::File,
+                       QuickOutputMode::None, log);
+  window.setSuppressSnapshots(true);
+  window.resize(800, 600);
+  window.show();
+  application.processEvents();
+  if (window.currentSelection() != QRectF(100, 100, 550, 370)) {
+    cleanup();
+    error = QStringLiteral("The selection did not survive the handoff");
+    return false;
+  }
+  if (window.annotationCountForTest() != 1) {
+    cleanup();
+    error = QStringLiteral("The annotation did not survive the handoff");
+    return false;
+  }
+  QTest::keyClick(&window, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (window.annotationCountForTest() != 0) {
+    cleanup();
+    error = QStringLiteral("The undo history did not survive the handoff");
+    return false;
+  }
+  cleanup();
   return true;
 }
 
@@ -7961,9 +8044,14 @@ int main(int argc, char **argv) {
     qWarning().noquote() << snapshotError;
     return 4;
   }
+  if (!runEditorHandoffRoundTrip(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 6;
+  }
   if (!runWindowedPaletteAnchorCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 125;
+  }
   if (!runNativeCaretHiddenCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 121;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2,6 +2,7 @@
  */
 #include "capture.hpp"
 #include "output-config.hpp"
+#include "overlay-chrome.hpp"
 #include "cli-path.hpp"
 #include "clipboard-smoke.hpp"
 #include "cut-mapping-smoke.hpp"
@@ -1796,6 +1797,83 @@ bool runTextOutlineCheck(QString &error) {
   return true;
 }
 
+/** The editor window mode config key and the windowed editor's sizing. */
+bool runEditorWindowConfigCheck(QString &error) {
+  const QString path =
+      QDir(QDir::tempPath()).filePath(QStringLiteral("omasnap-editor-mode.conf"));
+  const QString floatRule = editorFloatRuleScript(true);
+  const QString tiledRule = editorFloatRuleScript(false);
+  if (!floatRule.contains(QStringLiteral("float = true")) ||
+      !floatRule.contains(QStringLiteral("center = true")) ||
+      tiledRule.contains(QStringLiteral("float = true")) ||
+      !tiledRule.contains(QStringLiteral("enabled = false")) ||
+      !floatRule.contains(QStringLiteral("omasnap-editor-float")) ||
+      !tiledRule.contains(QStringLiteral("omasnap-editor-float"))) {
+    error = QStringLiteral("Editor float rule script is wrong");
+    return false;
+  }
+  const auto writeConf = [&path](const QString &body) {
+    QFile file(path);
+    file.open(QIODevice::WriteOnly | QIODevice::Truncate);
+    file.write(body.toUtf8());
+    file.close();
+  };
+  writeConf(QStringLiteral("[editor]\nmode = window\n"));
+  const bool window = loadEditorWindowMode(path);
+  writeConf(QStringLiteral("[editor]\nmode = overlay\n"));
+  const bool overlay = loadEditorWindowMode(path);
+  writeConf(QStringLiteral("[output]\ndirectory = /tmp\n"));
+  const bool absent = loadEditorWindowMode(path);
+  QFile::remove(path);
+  const bool missing =
+      loadEditorWindowMode(QStringLiteral("/nonexistent/omasnap.conf"));
+  if (!window || overlay || absent || missing) {
+    error = QStringLiteral("[editor] mode was not read as window-or-default");
+    return false;
+  }
+
+  writeConf(QStringLiteral("[editor]\nwindow = tiled\n"));
+  const bool tiled = loadEditorWindowFloating(path);
+  writeConf(QStringLiteral("[editor]\nwindow = floating\n"));
+  const bool floating = loadEditorWindowFloating(path);
+  QFile::remove(path);
+  const bool floatDefault =
+      loadEditorWindowFloating(QStringLiteral("/nonexistent/omasnap.conf"));
+  if (tiled || !floating || !floatDefault) {
+    error = QStringLiteral("[editor] window was not read as floating-or-tiled");
+    return false;
+  }
+
+  writeConf(QStringLiteral("[editor]\nbackdrop = translucent\n"));
+  const bool translucent = loadEditorWindowBackdropOpaque(path);
+  QFile::remove(path);
+  const bool opaqueDefault =
+      loadEditorWindowBackdropOpaque(QStringLiteral("/nonexistent/omasnap.conf"));
+  if (translucent || !opaqueDefault) {
+    error = QStringLiteral("[editor] backdrop was not read as opaque-or-not");
+    return false;
+  }
+
+  // The window hugs the capture at 100% plus the measured chrome; only a
+  // capture too large for the screen scales down, and the guide band is
+  // whatever the entries need at the window's width.
+  if (editorWindowSize(QSize(800, 600), QSize(2560, 1600), 100) !=
+          QSize(928, 910) ||
+      editorWindowSize(QSize(4000, 2000), QSize(2000, 1000), 100) !=
+          QSize(1608, 900) ||
+      editorWindowSize(QSize(100, 50), QSize(2000, 1000), 214) !=
+          QSize(640, 474) ||
+      editorWindowSize(QSize(5000, 5000), QSize(), 100) != QSize(1042, 1080)) {
+    error = QStringLiteral("The windowed editor sized itself wrong");
+    return false;
+  }
+  const QSize wide = hotkeyLegendAnchoredSize(editorHotkeyEntries(), 1300);
+  const QSize narrow = hotkeyLegendAnchoredSize(editorHotkeyEntries(), 500);
+  if (wide.height() != 100 || wide.width() > 1300 ||
+      narrow.height() <= wide.height() || narrow.width() > 500) {
+    error = QStringLiteral("The windowed editor sized itself wrong");
+    return false;
+  }
 /** The draft's native caret is hidden; QPlainTextEdit actually reads cursorWidth. */
 bool runNativeCaretHiddenCheck(QApplication &application, QString &error) {
   CaptureData capture;
@@ -2587,8 +2665,11 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
   application.processEvents();
   const QImage activeMarquee = editor.grab().toImage();
   bool foundBlueMarqueeEdge = false;
+  // Sampled on the left half of the marquee's top edge: the key guide sizes
+  // itself to its rows and reaches this far down on the right since it
+  // gained a row.
   for (int y = 117; y <= 123 && !foundBlueMarqueeEdge; ++y) {
-    for (int x = 336; x <= 344; ++x) {
+    for (int x = 150; x <= 170; ++x) {
       const QColor pixel = activeMarquee.pixelColor(x, y);
       if (pixel.blue() > 180 && pixel.green() > 80 && pixel.red() < 80) {
         foundBlueMarqueeEdge = true;
@@ -2597,8 +2678,8 @@ bool runContinuousAnnotationToolsSmoke(QApplication &application,
     }
   }
   if (!foundBlueMarqueeEdge ||
-      activeMarquee.pixelColor(340, 130) ==
-          beforeMarquee.pixelColor(340, 130)) {
+      activeMarquee.pixelColor(160, 130) ==
+          beforeMarquee.pixelColor(160, 130)) {
     error = QStringLiteral("Select drag did not paint a visible marquee box");
     return false;
   }
@@ -4639,6 +4720,87 @@ bool runEyedropperSmoke(QApplication &application, QString &error) {
   }
   editor.close();
   QFile::remove(snapshotPath);
+  return true;
+}
+
+/** Windowed, the color palette hangs off the pinned toolbar, not the canvas. */
+bool runWindowedPaletteAnchorCheck(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 1000, 800};
+  capture.monitor.pixelSize = {1000, 800};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(1000, 800, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+
+  CaptureEditor editor(capture);
+  editor.setWindowedPresentation(true);
+  editor.resize(1000, 800);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 250));
+  QTest::mouseMove(&editor, QPoint(900, 780), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(900, 780));
+  application.processEvents();
+
+  const qreal toolbarY =
+      14 +
+      hotkeyLegendAnchoredSize(editorHotkeyEntries(), editor.width() - 28.0)
+          .height() +
+      42;
+  const QRectF palette = editor.colorPaletteRectForTest();
+  if (!qFuzzyCompare(palette.top(), toolbarY + 36 + 4)) {
+    error = QStringLiteral("Windowed palette sits at %1, not under the "
+                           "toolbar at %2")
+                .arg(palette.top())
+                .arg(toolbarY + 36 + 4);
+    return false;
+  }
+
+  const QRectF paletteButton =
+      editor.toolbarButtonRectForTest(QStringLiteral("palette"));
+  if (paletteButton.isEmpty()) {
+    error = QStringLiteral("Windowed palette button is missing");
+    return false;
+  }
+  QTest::mouseMove(&editor, paletteButton.center().toPoint(), 10);
+  application.processEvents();
+  if (!editor.colorPaletteOpenForTest()) {
+    error = QStringLiteral("Hovering the windowed color button did not open "
+                           "the palette");
+    return false;
+  }
+  const QImage frame = editor.grab().toImage();
+  // The band-filling capture's crop outline must stay clear below the open
+  // palette; without the reserved row the dropdown covers it.
+  const int imageTop = qRound(toolbarY) + 36 + 54;
+  int outlinePixels = 0;
+  for (int x = 140; x < 860; ++x) {
+    for (int y = imageTop - 2; y <= imageTop; ++y) {
+      const QColor color = frame.pixelColor(x, y);
+      if (color.blue() > 110 && color.blue() > color.red() + color.green())
+        ++outlinePixels;
+    }
+  }
+  if (outlinePixels < 5) {
+    error = QStringLiteral("Open palette covers the crop outline (%1 dash "
+                           "pixels)")
+                .arg(outlinePixels);
+    return false;
+  }
+  const QColor swatch =
+      frame.pixelColor(qRound(palette.left()) + 16, qRound(palette.top()) + 18);
+  const int chroma =
+      std::max({swatch.red(), swatch.green(), swatch.blue()}) -
+      std::min({swatch.red(), swatch.green(), swatch.blue()});
+  if (chroma < 60) {
+    error = QStringLiteral("No colored swatch rendered under the windowed "
+                           "toolbar (probe %1)")
+                .arg(swatch.name());
+    return false;
+  }
+  editor.close();
   return true;
 }
 
@@ -7716,6 +7878,13 @@ int main(int argc, char **argv) {
     qWarning().noquote() << snapshotError;
     return 34;
   }
+  if (!runEditorWindowConfigCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 4;
+  }
+  if (!runWindowedPaletteAnchorCheck(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 125;
   if (!runNativeCaretHiddenCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 121;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4804,6 +4804,85 @@ bool runWindowedPaletteAnchorCheck(QApplication &application, QString &error) {
   return true;
 }
 
+/** Zoomed past fit in a window, the content stays inside the band and the
+ *  crop outline and shadow frame what is visible, not the off-screen rect. */
+bool runWindowedZoomFramingCheck(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 1000, 800};
+  capture.monitor.pixelSize = {1000, 800};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(1000, 800, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(30, 200, 60));
+  capture.previewSize = capture.source.size();
+
+  CaptureEditor editor(capture);
+  editor.setWindowedPresentation(true);
+  editor.setWindowedBackdropOpaque(true);
+  editor.resize(1000, 800);
+  editor.show();
+  application.processEvents();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(100, 300));
+  QTest::mouseMove(&editor, QPoint(900, 700), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(900, 700));
+  application.processEvents();
+
+  const auto wheelAt = [&](int deltaY, int times) {
+    for (int i = 0; i < times; ++i) {
+      QWheelEvent event(QPointF(500, 450), QPointF(500, 450), {}, {0, deltaY},
+                        Qt::NoButton, Qt::ControlModifier, Qt::NoScrollPhase,
+                        false);
+      QApplication::sendEvent(&editor, &event);
+    }
+    application.processEvents();
+  };
+  wheelAt(120, 8);
+
+  const int bandTop =
+      14 +
+      hotkeyLegendAnchoredSize(editorHotkeyEntries(), editor.width() - 28.0)
+          .height() +
+      42 + 36;
+  const int bandBottom = editor.height() - 64;
+  const QImage frame = editor.grab().toImage();
+  const auto isContent = [](const QColor &color) {
+    return color.green() > 120 && color.green() > color.red() * 2;
+  };
+  if (isContent(frame.pixelColor(60, bandTop - 18)) ||
+      isContent(frame.pixelColor(60, bandBottom + 6))) {
+    error = QStringLiteral("Zoomed content escaped the viewport band");
+    return false;
+  }
+  if (!isContent(frame.pixelColor(500, (bandTop + bandBottom) / 2))) {
+    error = QStringLiteral("Zoomed content missing inside the viewport band");
+    return false;
+  }
+  int outlinePixels = 0;
+  for (int x = 0; x < 80; ++x) {
+    // The 1 px dash stroke antialiases across the two rows above the band.
+    for (int y = bandTop - 2; y < bandTop; ++y) {
+      const QColor color = frame.pixelColor(x, y);
+      if (color.blue() > 110 && color.blue() > color.red() + color.green())
+        ++outlinePixels;
+    }
+  }
+  if (outlinePixels < 5) {
+    error = QStringLiteral("Crop outline does not frame the visible image "
+                           "when zoomed (%1 dash pixels)")
+                .arg(outlinePixels);
+    return false;
+  }
+  const QColor belowShadow = frame.pixelColor(60, bandBottom + 6);
+  if (belowShadow.red() >= 33) {
+    error = QStringLiteral("Shadow left the visible image edge when zoomed "
+                           "(probe %1)")
+                .arg(belowShadow.name());
+    return false;
+  }
+  editor.close();
+  return true;
+}
+
 /** Diagonal submenu approaches must not dismiss an already-open popover. */
 bool runSubmenuSelectionTriangleSmoke(QApplication &application, QString &error) {
   CaptureData capture;
@@ -7892,6 +7971,10 @@ int main(int argc, char **argv) {
   if (!runDraftViewLockCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 11;
+  }
+  if (!runWindowedZoomFramingCheck(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 200;
   }
   if (!runTextClickAwayCommitCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2121,6 +2121,33 @@ bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
     error = QStringLiteral("The undo history did not survive the handoff");
     return false;
   }
+  for (const auto mode : {CaptureEditor::CaptureMode::Fullscreen,
+                          CaptureEditor::CaptureMode::Scroll}) {
+    CaptureEditor automatic(capture, mode, QuickOutputMode::None, {}, nullptr, true);
+    QString automaticPath;
+    automatic.setHandoffLauncherForTest([&](const QString &, const QStringList &arguments) {
+      automaticPath = arguments.at(1);
+      return true;
+    });
+    automatic.resize(800, 600);
+    automatic.show();
+    if (mode == CaptureEditor::CaptureMode::Scroll) {
+      application.processEvents();
+      if (!automaticPath.isEmpty()) {
+        error = QStringLiteral("Scroll handed off before stitching completed");
+        return false;
+      }
+      automatic.adoptStitchedForTest(capture.source);
+    }
+    for (int attempt = 0; attempt < 500 && automatic.isVisible(); ++attempt)
+      QTest::qWait(10);
+    if (automatic.isVisible() || automaticPath.isEmpty()) {
+      error = QStringLiteral("Configured window handoff missed fullscreen or stitched scroll");
+      return false;
+    }
+    QFile::remove(automaticPath);
+    QFile::remove(operationLogPath(automaticPath));
+  }
   cleanup();
   return true;
 }
@@ -5019,6 +5046,20 @@ bool runWindowedZoomFramingCheck(QApplication &application, QString &error) {
     error = QStringLiteral("Shadow left the visible image edge when zoomed "
                            "(probe %1)")
                 .arg(belowShadow.name());
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_A);
+  const QPoint chrome(60, bandBottom + 12);
+  if (!editor.editImageRectForTest().contains(chrome)) {
+    error = QStringLiteral("Window chrome fixture did not overlap the zoomed image");
+    return false;
+  }
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, chrome);
+  QTest::mouseMove(&editor, QPoint(300, bandBottom - 80), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(300, bandBottom - 80));
+  if (editor.annotationCountForTest() != 0) {
+    error = QStringLiteral("Window chrome created an invisible annotation");
     return false;
   }
   editor.close();

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -5077,6 +5077,33 @@ bool runWindowedZoomFramingCheck(QApplication &application, QString &error) {
                 .arg(belowShadow.name());
     return false;
   }
+  // Clipped viewport boundaries are not source crop edges.
+  const QImage beforeCrop = editor.renderCurrentOutput();
+  const QPoint syntheticHandle(500, bandTop - 7);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, syntheticHandle);
+  QTest::mouseMove(&editor, syntheticHandle + QPoint(0, 20), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      syntheticHandle + QPoint(0, 20));
+  if (editor.renderCurrentOutput() != beforeCrop) {
+    error = QStringLiteral("A clipped viewport boundary acted as a crop handle");
+    return false;
+  }
+  const QImage beforeOcr = editor.grab().toImage();
+  const QRect topChrome(0, 0, editor.width(), bandTop - 2);
+  const QRect bottomChrome(0, bandBottom + 2, editor.width(), editor.height() - bandBottom - 2);
+  const QRectF source = editor.sourceFrameWidgetRectForTest();
+  const qreal scale = editor.editScaleForTest();
+  const QRectF ocr((500 - source.left()) / scale, 0, 20 / scale, source.height() / scale);
+  for (const QString &result : {QString(), QStringLiteral("recognized words ").repeated(200)}) {
+    editor.setOcrOverlayForTest(ocr, result);
+    const QImage withOcr = editor.grab().toImage();
+    if (withOcr.copy(topChrome) != beforeOcr.copy(topChrome) ||
+        withOcr.copy(bottomChrome) != beforeOcr.copy(bottomChrome)) {
+      error = QStringLiteral("OCR painting escaped the window viewport");
+      return false;
+    }
+  }
+  editor.setOcrOverlayForTest({}, {});
   QTest::keyClick(&editor, Qt::Key_B, Qt::ShiftModifier);
   application.processEvents();
   if (editor.grab().toImage().pixelColor(60, bandBottom + 6).red() <= belowShadow.red()) {

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1,4 +1,5 @@
 #include <QCommandLineParser>
+#include <QPromise>
 /** @fileoverview Exercises capture editor behavior without a live compositor.
  */
 #include "capture.hpp"
@@ -2018,6 +2019,11 @@ bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
     return false;
   }
 
+  if (!editor.waitForSnapshot())
+    return false;
+  QPromise<bool> slowSnapshot;
+  slowSnapshot.start();
+  editor.setSnapshotFutureForTest(slowSnapshot.future());
   QTest::keyClick(&editor, Qt::Key_V);
   const Annotation beforeNudge = editor.currentAnnotationsForTest().constFirst();
   const QPoint hit = editor.annotationPointToWidgetForTest(beforeNudge.start).toPoint();
@@ -2036,6 +2042,15 @@ bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
     return true;
   });
   QTest::keyClick(&editor, Qt::Key_W);
+  QTest::qWait(30);
+  if (!path.isEmpty()) {
+    slowSnapshot.addResult(true);
+    slowSnapshot.finish();
+    error = QStringLiteral("Handoff launched before pending persistence completed");
+    return false;
+  }
+  slowSnapshot.addResult(true);
+  slowSnapshot.finish();
   for (int attempt = 0; attempt < 500 && editor.isVisible(); ++attempt)
     QTest::qWait(10);
   if (editor.isVisible() || path.isEmpty() ||
@@ -2048,11 +2063,13 @@ bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
   // afterward, including equals syntax, normalization, and last-value wins.
   const QList<QStringList> windowArguments{
       launchArguments,
+      launchArguments + QStringList{QStringLiteral("-platformtheme"), QStringLiteral("gtk3")},
+      launchArguments + QStringList{QStringLiteral("-platform"), QStringLiteral("offscreen")},
       {QStringLiteral("--file=") + path, QStringLiteral("--editor=WINDOW")},
       {path, QStringLiteral("--editor=overlay"), QStringLiteral("--editor"), QStringLiteral(" window ")}};
   for (const QStringList &arguments : windowArguments) {
     QCommandLineParser parser;
-    configureCaptureCommandLine(parser);
+    configureCaptureCommandLine(parser, true);
     if (!parser.parse(QStringList{QStringLiteral("omasnap")} + arguments) ||
         !windowedEditorRequested(parser, false)) {
       error = QStringLiteral("Handoff argv selected the wrong Wayland shell");
@@ -2082,6 +2099,17 @@ bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
   OperationLog log;
   if (image.isNull() || !loadOperationLog(logPath, log, error)) {
     cleanup();
+    return false;
+  }
+  if (!removeEditorHandoff(path) || QFile::exists(path) || QFile::exists(logPath)) {
+    error = QStringLiteral("Consumed handoff files were not removed");
+    return false;
+  }
+  QTemporaryDir ordinary;
+  const QString ordinaryPath = ordinary.filePath(QStringLiteral("edit-123-0123456789abcdef.png"));
+  image.save(ordinaryPath);
+  if (removeEditorHandoff(ordinaryPath) || !QFile::exists(ordinaryPath)) {
+    error = QStringLiteral("Handoff cleanup removed an ordinary image");
     return false;
   }
   CaptureData reopened;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1,3 +1,4 @@
+#include <QCommandLineParser>
 /** @fileoverview Exercises capture editor behavior without a live compositor.
  */
 #include "capture.hpp"
@@ -2017,9 +2018,55 @@ bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
     return false;
   }
 
-  QString path;
-  if (!editor.prepareHandoff(path, error))
+  QTest::keyClick(&editor, Qt::Key_V);
+  const Annotation beforeNudge = editor.currentAnnotationsForTest().constFirst();
+  const QPoint hit = editor.annotationPointToWidgetForTest(beforeNudge.start).toPoint();
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, hit);
+  QTest::keyClick(&editor, Qt::Key_Right);
+  const Annotation nudged = editor.currentAnnotationsForTest().constFirst();
+  if (nudged.start == beforeNudge.start) {
+    error = QStringLiteral("Handoff fixture did not nudge its rectangle");
     return false;
+  }
+  QString path;
+  QStringList launchArguments;
+  editor.setHandoffLauncherForTest([&](const QString &, const QStringList &arguments) {
+    launchArguments = arguments;
+    path = arguments.at(1);
+    return true;
+  });
+  QTest::keyClick(&editor, Qt::Key_W);
+  for (int attempt = 0; attempt < 500 && editor.isVisible(); ++attempt)
+    QTest::qWait(10);
+  if (editor.isVisible() || path.isEmpty() ||
+      launchArguments != QStringList{QStringLiteral("--file"), path,
+                                      QStringLiteral("--editor"), QStringLiteral("window")}) {
+    error = QStringLiteral("W did not launch the window presentation asynchronously");
+    return false;
+  }
+  // The same parser chooses the shell before QApplication and validates it
+  // afterward, including equals syntax, normalization, and last-value wins.
+  const QList<QStringList> windowArguments{
+      launchArguments,
+      {QStringLiteral("--file=") + path, QStringLiteral("--editor=WINDOW")},
+      {path, QStringLiteral("--editor=overlay"), QStringLiteral("--editor"), QStringLiteral(" window ")}};
+  for (const QStringList &arguments : windowArguments) {
+    QCommandLineParser parser;
+    configureCaptureCommandLine(parser);
+    if (!parser.parse(QStringList{QStringLiteral("omasnap")} + arguments) ||
+        !windowedEditorRequested(parser, false)) {
+      error = QStringLiteral("Handoff argv selected the wrong Wayland shell");
+      return false;
+    }
+  }
+  QCommandLineParser overlayParser;
+  configureCaptureCommandLine(overlayParser);
+  if (!overlayParser.parse({QStringLiteral("omasnap"), path,
+                            QStringLiteral("--editor=window"), QStringLiteral("--editor=OVERLAY")}) ||
+      windowedEditorRequested(overlayParser, true)) {
+    error = QStringLiteral("Repeated editor options did not use the final value");
+    return false;
+  }
   const QString logPath = operationLogPath(path);
   const auto cleanup = [&] {
     QFile::remove(path);
@@ -2041,6 +2088,7 @@ bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
   describeFileCapture(reopened, std::move(image), log);
   CaptureEditor window(reopened, CaptureEditor::CaptureMode::File,
                        QuickOutputMode::None, log);
+  window.setWindowedPresentation(true);
   window.setSuppressSnapshots(true);
   window.resize(800, 600);
   window.show();
@@ -2053,6 +2101,17 @@ bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
   if (window.annotationCountForTest() != 1) {
     cleanup();
     error = QStringLiteral("The annotation did not survive the handoff");
+    return false;
+  }
+  if (window.currentAnnotationsForTest().constFirst().start != nudged.start) {
+    cleanup();
+    error = QStringLiteral("Handoff lost the pending keyboard nudge");
+    return false;
+  }
+  QTest::keyClick(&window, Qt::Key_Z, Qt::ControlModifier);
+  if (window.currentAnnotationsForTest().constFirst().start != beforeNudge.start) {
+    cleanup();
+    error = QStringLiteral("Handoff nudge did not remain undoable");
     return false;
   }
   QTest::keyClick(&window, Qt::Key_Z, Qt::ControlModifier);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2055,7 +2055,8 @@ bool runEditorHandoffRoundTrip(QApplication &application, QString &error) {
     QTest::qWait(10);
   if (editor.isVisible() || path.isEmpty() ||
       launchArguments != QStringList{QStringLiteral("--file"), path,
-                                      QStringLiteral("--editor"), QStringLiteral("window")}) {
+                                      QStringLiteral("--editor"), QStringLiteral("window"),
+                                      QStringLiteral("--handoff-monitor"), QStringLiteral("TEST")}) {
     error = QStringLiteral("W did not launch the window presentation asynchronously");
     return false;
   }
@@ -5076,6 +5077,12 @@ bool runWindowedZoomFramingCheck(QApplication &application, QString &error) {
                 .arg(belowShadow.name());
     return false;
   }
+  QTest::keyClick(&editor, Qt::Key_B, Qt::ShiftModifier);
+  application.processEvents();
+  if (editor.grab().toImage().pixelColor(60, bandBottom + 6).red() <= belowShadow.red()) {
+    error = QStringLiteral("Shift+B did not remove the window shadow");
+    return false;
+  }
   QTest::keyClick(&editor, Qt::Key_A);
   const QPoint chrome(60, bandBottom + 12);
   if (!editor.editImageRectForTest().contains(chrome)) {
@@ -5091,6 +5098,38 @@ bool runWindowedZoomFramingCheck(QApplication &application, QString &error) {
     return false;
   }
   editor.close();
+
+  capture.source = QImage(1600, 900, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(Qt::green);
+  capture.previewSize = capture.source.size();
+  CaptureEditor scrolling(capture, CaptureEditor::CaptureMode::File);
+  scrolling.setWindowedPresentation(true);
+  scrolling.resize(1000, 800);
+  scrolling.show();
+  application.processEvents();
+  QTest::keyClick(&scrolling, Qt::Key_V);
+  for (int i = 0; i < 20; ++i) {
+    QWheelEvent zoom(QPointF(500, 450), QPointF(500, 450), {}, {0, 30},
+                     Qt::NoButton, Qt::ControlModifier, Qt::NoScrollPhase, false);
+    QApplication::sendEvent(&scrolling, &zoom);
+    if (scrolling.editImageRectForTest().width() > scrolling.width() - 60)
+      break;
+  }
+  const QRectF before = scrolling.editImageRectForTest();
+  if (before.height() <= scrolling.height() - scrolling.contentBandTop() - 64 ||
+      before.height() >= scrolling.height() - 126) {
+    error = QStringLiteral("Window scrolling fixture missed the modest-zoom overflow");
+    return false;
+  }
+  QWheelEvent scroll(QPointF(500, 450), QPointF(500, 450), {}, {0, -120},
+                     Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+  QApplication::sendEvent(&scrolling, &scroll);
+  const QRectF after = scrolling.editImageRectForTest();
+  if (qFuzzyCompare(before.y(), after.y()) || !qFuzzyCompare(before.x(), after.x())) {
+    error = QStringLiteral("Vertical wheel was remapped sideways in a window");
+    return false;
+  }
+  scrolling.close();
   return true;
 }
 


### PR DESCRIPTION
Adds a normal-window presentation so annotations can sit beside the document, chat, or app they came from, while capture selection remains fullscreen.

- `[editor] mode = window` opens file edits in a normal compositor window, `--editor window|overlay` overrides it per launch, and `W` hands a live edit between presentations. The working document and operation log preserve the selection, layers, and undo history. Fresh captures still select in the overlay, then hand off when editing begins.
- The window opens around the capture at 100%, capped at 90% of the screen, with a toolbar-safe minimum size. A pre-map Hyprland rule floats and centers the first frame; `[editor] window = tiled` opts out. The default mat and capture shadow separate image from chrome, `[editor] backdrop = translucent` keeps the overlay dim, and an opacity rule avoids desktop-wide transparency affecting the editor.
- Window mode puts the key guide above the toolbar and reserves room for hints and popovers. Shared toolbar anchoring works in both presentations. Zoomed content stays clipped below the chrome while the outline, handles, and shadow frame only the visible portion.

Smoke coverage includes window sizing, config and compositor rules, popover anchoring, pixel-level zoom framing, and a full handoff round trip covering selection, annotations, and undo. This overlaps #82 only in the early `argv` scan that chooses shell integration; whichever merges second should fold in the other flag.

<img width="3982" height="3198" alt="image" src="https://github.com/user-attachments/assets/4ae8c0e4-80e2-4679-8fc8-272b4e6f8396" />