### PR TITLE
feat(editor): add arrow styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   shadowed and flat window gray, and Off so a background can always be removed.
   Overflow with no backdrop leaves its added pixels transparent. `Shift+B`
   toggles the current shadow directly, and undo/delete can contract grown strips.
-- Arrows, straight lines, smoothed freehand strokes, and translucent highlighter
+- Standard, pointy, curved, and double-headed arrows; straight lines; smoothed
+  freehand strokes; and translucent highlighter
   strokes that automatically match and stay straight across screenshot text (with
   freehand fallback), plus hollow or filled rectangles (optionally rounded) and
   ellipses, numbered markers, editable text in Neucha, JetBrains Mono, or Inter
@@ -355,7 +356,7 @@ without reaching for the pointer.
 | Input | Action |
 |---|---|
 | `V` | Select/move/resize layers; carrying one past the source grows the canvas; drag empty canvas for a marquee; multi-select outlines each layer without treating the canvas as one layer; wheel scales the selected layer |
-| `A` | Arrow |
+| `A` | Arrow; press again to cycle Standard, Pointy, Curved, and Double styles |
 | `S` | Spotlight/loupe; press again to cycle ellipse, rectangle, rounded |
 | `L` | Straight line |
 | `F` | Freehand stroke |
@@ -377,7 +378,7 @@ without reaching for the pointer.
 | `Shift`+wheel | Scroll a zoomed capture sideways (a wide stitch); never changes the zoom |
 | `Ctrl`+wheel · middle-drag | Zoom about the cursor · pan by dragging |
 | `+` / `-` / `0` (also with `Ctrl`) | Zoom in / out / fit |
-| Hold `Shift` while dragging | Make rectangles, ellipses, and spotlights 1:1; snap lines and arrows to 45°; while dragging a selected layer's handle, keep a rectangle, redaction or spotlight's aspect ratio (lines and arrows: 45°) |
+| Hold `Shift` while dragging | Make rectangles, ellipses, and spotlights 1:1; snap line and arrow endpoints to 45°; keep curved-arrow bends centered; while dragging a selected layer's handle, keep a rectangle, redaction or spotlight's aspect ratio |
 | Hold `Alt` while dragging | Center rectangles, ellipses, and spotlights on the press point; add `Shift` for a centered square/circle |
 | `←` `↑` `→` `↓` | Nudge the selected layer 1 px; hold `Shift` for 10 px (a held key is one undo step). With nothing selected, pan a zoomed capture |
 | Double-click text · `Enter` on a selected text | Reopen text editing |
@@ -427,9 +428,11 @@ geometry stays in the operation log, so switching back to Grow restores every of
 part of a layer.
 
 Creation tools return to Select after one placement without selecting the new layer. In
-Select mode, arrows and lines show only their two endpoint handles; other layers show a
-selection boundary. The eight blue/white handles outside the image recrop its corners or
-edges. After the canvas grows, those crop handles remain on the original source frame.
+Select mode, lines and straight arrows show two endpoint handles; curved and double arrows
+add an on-curve handle for bending the arc (hold `Shift` to keep that bend centered). Other
+layers show a selection boundary. The eight blue/white handles outside the image recrop
+its corners or edges. After the canvas grows, those crop handles remain on the original
+source frame.
 
 ## Development and verification
 

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -16,8 +16,8 @@
 #include <QJsonValue>
 #include <QLinearGradient>
 #include <QPainter>
-#include <QPointF>
 #include <QPainterPath>
+#include <QPointF>
 #include <QProcess>
 #include <QRandomGenerator>
 #include <QSaveFile>
@@ -29,6 +29,7 @@
 #include <cerrno>
 #include <cmath>
 #include <fcntl.h>
+#include <numbers>
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -416,7 +417,236 @@ QVector<WindowTarget> parseWindows(const QByteArray &json,
   return result;
 }
 
-void drawAnnotation(QPainter &painter, const Annotation &annotation) {
+namespace {
+constexpr std::array<qreal, 6> kArrowLineWidths{1.5, 3.0, 5.0, 7.0, 11.0, 16.0};
+constexpr std::array<qreal, 6> kStandardBodyWidths{5.5,  7.0,  11.5,
+                                                   14.5, 19.5, 29.5};
+constexpr std::array<qreal, 6> kStandardBackWidths{1.5, 2.5, 3.5,
+                                                   4.5, 6.0, 8.5};
+constexpr std::array<qreal, 6> kStandardHeadLengths{15.0, 20.0, 31.5,
+                                                    38.0, 52.0, 78.5};
+constexpr std::array<qreal, 6> kStandardHeadHeights{14.0, 18.5, 29.0,
+                                                    36.0, 49.0, 75.0};
+constexpr std::array<qreal, 6> kPointyBodyWidths{8.0,  10.0, 16.0,
+                                                 20.0, 27.0, 41.0};
+constexpr std::array<qreal, 6> kPointyBackWidths{1.5, 1.5, 1.75, 2.0, 2.5, 3.5};
+constexpr std::array<qreal, 6> kPointyHeadLengths{15.5, 22.0, 34.5,
+                                                  43.0, 59.0, 89.5};
+constexpr std::array<qreal, 6> kPointyHeadHeights{15.5, 22.0, 33.0,
+                                                  41.5, 56.5, 85.5};
+constexpr std::array<qreal, 6> kCurvedHeadSides{9.0,  9.0,  15.0,
+                                                19.0, 26.0, 40.0};
+constexpr std::array<qreal, 6> kCurvedShaftWidths{3.0, 3.0,  6.0,
+                                                  7.5, 11.5, 18.5};
+constexpr qreal kStandardShoulderRatio = 0.05;
+constexpr qreal kPointyWingBackRatio = 0.22;
+constexpr qreal kPointyWingHeightRatio = 0.22;
+constexpr qreal kCurveAmount = 0.25;
+constexpr qreal kOpenHeadHalfAngle = std::numbers::pi_v<qreal> / 4.0;
+
+qreal arrowMetric(qreal lineWidth, const std::array<qreal, 6> &values) {
+  const qreal width = std::max<qreal>(0.01, lineWidth);
+  if (width <= kArrowLineWidths.front())
+    return values.front() * width / kArrowLineWidths.front();
+  if (width >= kArrowLineWidths.back())
+    return values.back() * width / kArrowLineWidths.back();
+  const auto upper =
+      std::upper_bound(kArrowLineWidths.begin(), kArrowLineWidths.end(), width);
+  const auto high =
+      static_cast<std::size_t>(std::distance(kArrowLineWidths.begin(), upper));
+  const auto low = high - 1;
+  const qreal amount = (width - kArrowLineWidths.at(low)) /
+                       (kArrowLineWidths.at(high) - kArrowLineWidths.at(low));
+  return std::lerp(values.at(low), values.at(high), amount);
+}
+
+struct ArrowGeometry {
+  QPainterPath fill;
+  QPainterPath stroke;
+  qreal strokeWidth = 0.0;
+};
+
+QPointF arrowPoint(const QPointF &origin, const QPointF &along,
+                   const QPointF &across, qreal x, qreal y) {
+  return origin + along * x + across * y;
+}
+
+QPointF defaultCurveControl(const Annotation &annotation) {
+  const QPointF chord = annotation.end - annotation.start;
+  return (annotation.start + annotation.end) / 2.0 +
+         QPointF(chord.y(), -chord.x()) * kCurveAmount;
+}
+
+QPointF curveControl(const Annotation &annotation) {
+  return annotation.curveControl.value_or(defaultCurveControl(annotation));
+}
+
+QPointF quadraticPoint(const QPointF &start, const QPointF &control,
+                       const QPointF &end, qreal amount) {
+  const qreal remaining = 1.0 - amount;
+  return start * (remaining * remaining) +
+         control * (2.0 * remaining * amount) + end * (amount * amount);
+}
+
+qreal pointToSegmentDistance(const QPointF &point, const QPointF &start,
+                             const QPointF &end) {
+  const QPointF segment = end - start;
+  const qreal lengthSquared = QPointF::dotProduct(segment, segment);
+  if (lengthSquared <= 0.000001)
+    return QLineF(point, start).length();
+  const qreal amount = std::clamp(
+      QPointF::dotProduct(point - start, segment) / lengthSquared, 0.0, 1.0);
+  return QLineF(point, start + segment * amount).length();
+}
+
+void addOpenArrowHead(QPainterPath &path, const QPointF &tip,
+                      const QPointF &direction, qreal sideLength) {
+  const qreal length = QLineF(QPointF(), direction).length();
+  if (length < 0.001)
+    return;
+  const QPointF along = direction / length;
+  const QPointF across(-along.y(), along.x());
+  const qreal back = sideLength * std::cos(kOpenHeadHalfAngle);
+  const qreal side = sideLength * std::sin(kOpenHeadHalfAngle);
+  const QPointF root = tip - along * back;
+  path.moveTo(root + across * side);
+  path.lineTo(tip);
+  path.lineTo(root - across * side);
+}
+
+ArrowGeometry makeArrowGeometry(const Annotation &annotation,
+                                qreal displayScale = 1.0) {
+  ArrowGeometry geometry;
+  const QPointF chord = annotation.end - annotation.start;
+  const qreal length = QLineF(QPointF(), chord).length();
+  if (length < 1.0)
+    return geometry;
+  const QPointF along = chord / length;
+  const QPointF across(-along.y(), along.x());
+
+  if (annotation.arrowStyle == ArrowStyle::Curved ||
+      annotation.arrowStyle == ArrowStyle::Double) {
+    const QPointF control = curveControl(annotation);
+    geometry.stroke.moveTo(annotation.start);
+    geometry.stroke.quadTo(control, annotation.end);
+    const qreal headSide = arrowMetric(annotation.size, kCurvedHeadSides);
+    addOpenArrowHead(geometry.stroke, annotation.end, annotation.end - control,
+                     headSide);
+    if (annotation.arrowStyle == ArrowStyle::Double)
+      addOpenArrowHead(geometry.stroke, annotation.start,
+                       annotation.start - control, headSide);
+    geometry.strokeWidth = arrowMetric(annotation.size, kCurvedShaftWidths);
+    return geometry;
+  }
+
+  const bool pointy = annotation.arrowStyle == ArrowStyle::Pointy;
+  const qreal bodyWidth = arrowMetric(
+      annotation.size, pointy ? kPointyBodyWidths : kStandardBodyWidths);
+  const qreal naturalBackWidth = arrowMetric(
+      annotation.size, pointy ? kPointyBackWidths : kStandardBackWidths);
+  // Keep the tail at its 1:1 screen width while zoomed out.
+  // The cap keeps an extreme fit from widening it past the body; at and above
+  // 1:1 this is exactly the calibrated natural geometry.
+  const qreal backWidth =
+      std::min(naturalBackWidth /
+                   std::clamp(displayScale, qreal(0.0001), qreal(1.0)),
+               bodyWidth);
+  qreal headLength = arrowMetric(
+      annotation.size, pointy ? kPointyHeadLengths : kStandardHeadLengths);
+  const qreal headHalfHeight =
+      arrowMetric(annotation.size,
+                  pointy ? kPointyHeadHeights : kStandardHeadHeights) /
+      2.0;
+  headLength = std::min(headLength, length * 0.95);
+  const qreal outerX = length - headLength;
+  const qreal innerX =
+      outerX + (pointy ? 0.0 : headLength * kStandardShoulderRatio);
+  const qreal wingX =
+      pointy ? outerX - headLength * kPointyWingBackRatio : outerX;
+  const qreal wingHalfHeight =
+      pointy ? headHalfHeight * (1.0 + kPointyWingHeightRatio) : headHalfHeight;
+  // Standard gets a same-color rounded outline. Inset its body path so the
+  // visible width after that outline matches the calibrated body width.
+  const qreal bodyHalf =
+      std::max<qreal>(0.0, bodyWidth - (pointy ? 0.0 : backWidth)) / 2.0;
+  const qreal backHalf = pointy ? backWidth / 2.0 : 0.0;
+
+  geometry.fill.moveTo(
+      arrowPoint(annotation.start, along, across, 0.0, backHalf));
+  geometry.fill.lineTo(
+      arrowPoint(annotation.start, along, across, innerX, bodyHalf));
+  geometry.fill.lineTo(
+      arrowPoint(annotation.start, along, across, wingX, wingHalfHeight));
+  geometry.fill.lineTo(annotation.end);
+  geometry.fill.lineTo(
+      arrowPoint(annotation.start, along, across, wingX, -wingHalfHeight));
+  geometry.fill.lineTo(
+      arrowPoint(annotation.start, along, across, innerX, -bodyHalf));
+  geometry.fill.lineTo(
+      arrowPoint(annotation.start, along, across, 0.0, -backHalf));
+  geometry.fill.closeSubpath();
+  if (!pointy) {
+    geometry.stroke = geometry.fill;
+    geometry.strokeWidth = backWidth;
+  }
+  return geometry;
+}
+
+QRectF strokedBounds(const QPainterPath &path, qreal width) {
+  if (path.isEmpty())
+    return {};
+  const qreal radius = width / 2.0;
+  return path.boundingRect().adjusted(-radius, -radius, radius, radius);
+}
+} // namespace
+
+QRectF arrowVisualBoundsInternal(const Annotation &annotation,
+                                 qreal displayScale) {
+  const ArrowGeometry geometry = makeArrowGeometry(annotation, displayScale);
+  QRectF bounds = geometry.fill.boundingRect();
+  const QRectF stroke = strokedBounds(geometry.stroke, geometry.strokeWidth);
+  if (bounds.isEmpty())
+    bounds = stroke;
+  else if (!stroke.isEmpty())
+    bounds = bounds.united(stroke);
+  return bounds;
+}
+
+bool arrowContainsPointInternal(const Annotation &annotation,
+                                const QPointF &point, qreal tolerance) {
+  const QPointF chord = annotation.end - annotation.start;
+  if (QPointF::dotProduct(chord, chord) < 1.0)
+    return false;
+
+  const bool pointy = annotation.arrowStyle == ArrowStyle::Pointy;
+  const qreal headLength = arrowMetric(
+      annotation.size, pointy ? kPointyHeadLengths : kStandardHeadLengths);
+  if (annotation.arrowStyle == ArrowStyle::Standard || pointy) {
+    const qreal bodyWidth = arrowMetric(
+        annotation.size, pointy ? kPointyBodyWidths : kStandardBodyWidths);
+    const qreal pick = std::max(bodyWidth, headLength) / 2.0 + tolerance;
+    return pointToSegmentDistance(point, annotation.start, annotation.end) <=
+           pick;
+  }
+
+  const qreal shaftWidth = arrowMetric(annotation.size, kCurvedShaftWidths);
+  const qreal pick = std::max(shaftWidth, headLength) / 2.0 + tolerance;
+  const QPointF control = curveControl(annotation);
+  constexpr int segments = 24;
+  QPointF previous = annotation.start;
+  for (int index = 1; index <= segments; ++index) {
+    const QPointF next = quadraticPoint(annotation.start, control,
+                                        annotation.end,
+                                        qreal(index) / qreal(segments));
+    if (pointToSegmentDistance(point, previous, next) <= pick)
+      return true;
+    previous = next;
+  }
+  return false;
+}
+
+void drawAnnotation(QPainter &painter, const Annotation &annotation,
+                    qreal arrowDisplayScale) {
   // Redactions replace source pixels in renderCapture before ordinary vector
   // annotations are painted. They must never be approximated by a translucent
   // overlay here because that could leave recoverable source data in exports.
@@ -481,22 +711,21 @@ void drawAnnotation(QPainter &painter, const Annotation &annotation) {
   }
 
   if (annotation.kind == Annotation::Kind::Arrow) {
-    const QLineF line(annotation.start, annotation.end);
-    if (line.length() < 1.0)
-      return;
-    const qreal angle = std::atan2(line.dy(), line.dx());
-    const qreal headLength = std::max<qreal>(14.0, annotation.size * 4.2);
-    const qreal halfWidth = headLength * 0.46;
-    const QPointF direction(std::cos(angle), std::sin(angle));
-    const QPointF perpendicular(-direction.y(), direction.x());
-    const QPointF base = annotation.end - direction * headLength;
-    const QPointF stemEnd = annotation.end - direction * (headLength * 0.5);
-    painter.drawLine(annotation.start, stemEnd);
-    QPolygonF head;
-    head << annotation.end << base + perpendicular * halfWidth
-         << base - perpendicular * halfWidth;
-    painter.setPen(Qt::NoPen);
-    painter.drawPolygon(head);
+    const ArrowGeometry geometry =
+        makeArrowGeometry(annotation, arrowDisplayScale);
+    painter.save();
+    if (!geometry.fill.isEmpty()) {
+      painter.setPen(Qt::NoPen);
+      painter.setBrush(annotation.color);
+      painter.drawPath(geometry.fill);
+    }
+    if (!geometry.stroke.isEmpty()) {
+      painter.setPen(QPen(annotation.color, geometry.strokeWidth,
+                          Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+      painter.setBrush(Qt::NoBrush);
+      painter.drawPath(geometry.stroke);
+    }
+    painter.restore();
     return;
   }
 
@@ -711,8 +940,23 @@ QRect pixelSelection(const CaptureData &capture, const QRectF &selection) {
 
 } // namespace
 
-void paintAnnotation(QPainter &painter, const Annotation &annotation) {
-  drawAnnotation(painter, annotation);
+QRectF arrowVisualBounds(const Annotation &annotation, qreal displayScale) {
+  return arrowVisualBoundsInternal(annotation, displayScale);
+}
+
+QPointF arrowCurveHandlePoint(const Annotation &annotation) {
+  return quadraticPoint(annotation.start, curveControl(annotation),
+                        annotation.end, 0.5);
+}
+
+bool arrowContainsPoint(const Annotation &annotation, const QPointF &point,
+                        qreal tolerance) {
+  return arrowContainsPointInternal(annotation, point, tolerance);
+}
+
+void paintAnnotation(QPainter &painter, const Annotation &annotation,
+                     qreal arrowDisplayScale) {
+  drawAnnotation(painter, annotation, arrowDisplayScale);
 }
 
 QPainterPath spotlightPath(const Annotation &annotation) {
@@ -806,7 +1050,8 @@ void paintSpotlights(QPainter &painter, const QImage &source,
 
 void paintDefaultLayer(QPainter &painter, const QImage &redacted,
                        const QRectF &logicalBounds,
-                       const QVector<Annotation> &annotations) {
+                       const QVector<Annotation> &annotations,
+                       qreal arrowDisplayScale) {
   paintSpotlights(painter, redacted, logicalBounds, QRectF(redacted.rect()),
                   annotations);
   // What a capture is annotated *with* goes over what it is annotated *on*:
@@ -817,7 +1062,7 @@ void paintDefaultLayer(QPainter &painter, const QImage &redacted,
   const auto passOver = [&](bool (*belongs)(Annotation::Kind)) {
     for (const Annotation &annotation : annotations) {
       if (belongs(annotation.kind))
-        paintAnnotation(painter, annotation);
+        paintAnnotation(painter, annotation, arrowDisplayScale);
     }
   };
   passOver([](Annotation::Kind kind) {
@@ -1578,6 +1823,30 @@ bool annotationKindFromName(const QString &name, Annotation::Kind &kind) {
   return true;
 }
 
+QString arrowStyleName(ArrowStyle style) {
+  switch (style) {
+  case ArrowStyle::Standard:
+    return QStringLiteral("standard");
+  case ArrowStyle::Pointy:
+    return QStringLiteral("pointy");
+  case ArrowStyle::Curved:
+    return QStringLiteral("curved");
+  case ArrowStyle::Double:
+    return QStringLiteral("double");
+  }
+  return QStringLiteral("standard");
+}
+
+ArrowStyle arrowStyleFromName(const QString &name) {
+  if (name == QStringLiteral("pointy"))
+    return ArrowStyle::Pointy;
+  if (name == QStringLiteral("curved"))
+    return ArrowStyle::Curved;
+  if (name == QStringLiteral("double"))
+    return ArrowStyle::Double;
+  return ArrowStyle::Standard;
+}
+
 } // namespace
 
 QString backgroundStyleName(BackgroundStyle style) {
@@ -1680,6 +1949,13 @@ QJsonObject annotationToJson(const Annotation &annotation) {
   object.insert(QStringLiteral("color"),
                 annotation.color.name(QColor::HexArgb));
   object.insert(QStringLiteral("size"), annotation.size);
+  if (annotation.kind == Annotation::Kind::Arrow) {
+    object.insert(QStringLiteral("arrowStyle"),
+                  arrowStyleName(annotation.arrowStyle));
+    if (annotation.curveControl)
+      object.insert(QStringLiteral("curveControl"),
+                    pointArray(*annotation.curveControl));
+  }
   if (!annotation.text.isEmpty())
     object.insert(QStringLiteral("text"), annotation.text);
   if (annotation.kind == Annotation::Kind::Text)
@@ -1735,6 +2011,13 @@ bool annotationFromJson(const QJsonObject &object, Annotation &annotation,
   annotation.end = pointFromArray(object.value(QStringLiteral("end")));
   annotation.color = QColor(object.value(QStringLiteral("color")).toString());
   annotation.size = object.value(QStringLiteral("size")).toDouble(4.0);
+  annotation.arrowStyle =
+      arrowStyleFromName(object.value(QStringLiteral("arrowStyle")).toString());
+  annotation.curveControl.reset();
+  if (annotation.kind == Annotation::Kind::Arrow &&
+      object.value(QStringLiteral("curveControl")).isArray())
+    annotation.curveControl =
+        pointFromArray(object.value(QStringLiteral("curveControl")));
   annotation.text = object.value(QStringLiteral("text")).toString();
   annotation.textFont = textFontFromStyleName(
       object.value(QStringLiteral("textFont")).toString());

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -146,20 +146,8 @@ QRectF captureCanvasRect(const QSizeF &sourceFrameSize,
 
     QRectF bounds(annotation.start, annotation.end);
     bounds = bounds.normalized();
-    if (annotation.kind == Annotation::Kind::Arrow) {
-      const QLineF line(annotation.start, annotation.end);
-      if (line.length() >= 1.0) {
-        const qreal angle = std::atan2(line.dy(), line.dx());
-        const qreal headLength = std::max<qreal>(14.0, annotation.size * 4.2);
-        const qreal halfWidth = headLength * 0.46;
-        const QPointF direction(std::cos(angle), std::sin(angle));
-        const QPointF perpendicular(-direction.y(), direction.x());
-        const QPointF base = annotation.end - direction * headLength;
-        bounds = pointBounds({annotation.start, annotation.end,
-                              base + perpendicular * halfWidth,
-                              base - perpendicular * halfWidth});
-      }
-    }
+    if (annotation.kind == Annotation::Kind::Arrow)
+      return arrowVisualBounds(annotation).adjusted(-1, -1, 1, 1);
     qreal extent = 1.0;
     if (annotation.kind == Annotation::Kind::Line ||
         annotation.kind == Annotation::Kind::Arrow ||
@@ -530,11 +518,15 @@ ArrowGeometry makeArrowGeometry(const Annotation &annotation,
     geometry.stroke.moveTo(annotation.start);
     geometry.stroke.quadTo(control, annotation.end);
     const qreal headSide = arrowMetric(annotation.size, kCurvedHeadSides);
-    addOpenArrowHead(geometry.stroke, annotation.end, annotation.end - control,
-                     headSide);
+    const auto tangentOrChord = [&](const QPointF &tangent,
+                                    const QPointF &fallback) {
+      return QLineF(QPointF(), tangent).length() < 0.001 ? fallback : tangent;
+    };
+    addOpenArrowHead(geometry.stroke, annotation.end,
+                     tangentOrChord(annotation.end - control, chord), headSide);
     if (annotation.arrowStyle == ArrowStyle::Double)
       addOpenArrowHead(geometry.stroke, annotation.start,
-                       annotation.start - control, headSide);
+                       tangentOrChord(annotation.start - control, -chord), headSide);
     geometry.strokeWidth = arrowMetric(annotation.size, kCurvedShaftWidths);
     return geometry;
   }

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -146,8 +146,10 @@ QRectF captureCanvasRect(const QSizeF &sourceFrameSize,
 
     QRectF bounds(annotation.start, annotation.end);
     bounds = bounds.normalized();
-    if (annotation.kind == Annotation::Kind::Arrow)
-      return arrowVisualBounds(annotation).adjusted(-1, -1, 1, 1);
+    if (annotation.kind == Annotation::Kind::Arrow) {
+      const QRectF visual = arrowVisualBounds(annotation);
+      return visual.isEmpty() ? QRectF() : visual.adjusted(-1, -1, 1, 1);
+    }
     qreal extent = 1.0;
     if (annotation.kind == Annotation::Kind::Line ||
         annotation.kind == Annotation::Kind::Arrow ||

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 #include <QPainterPath>
 #include <QColor>
@@ -60,6 +61,7 @@ enum class SpotlightShape { Ellipse, Rectangle, RoundedRectangle };
 enum class RedactionStyle { Solid, Pixelate };
 enum class TextBackground { Plain, Pill, Outline };
 enum class TextFont { Neucha, JetBrainsMono, InterDisplay };
+enum class ArrowStyle { Standard, Pointy, Curved, Double };
 
 struct Annotation {
   enum class Kind {
@@ -92,7 +94,11 @@ struct Annotation {
   TextBackground textBackground = TextBackground::Pill;
   /// Typeface is a layer property so reopened and duplicated labels keep it.
   TextFont textFont = TextFont::Neucha;
+  ArrowStyle arrowStyle = ArrowStyle::Standard;
   quint64 id = 0;
+  /** Explicit quadratic Bezier control for Curved/Double arrows. Empty uses
+   *  the calibrated perpendicular-offset curve. */
+  std::optional<QPointF> curveControl = std::nullopt;
 
   bool operator==(const Annotation &) const = default;
 };
@@ -252,7 +258,21 @@ void describeFileCapture(CaptureData &capture, QImage image,
 [[nodiscard]] bool quickOutput(const QImage &image, QuickOutputMode mode,
                                QString &error);
 [[nodiscard]] bool copyTextToClipboard(const QString &text, QString &error);
-void paintAnnotation(QPainter &painter, const Annotation &annotation);
+/** Paints one annotation. `arrowDisplayScale` affects only the on-screen tail
+ *  legibility floor for Standard/Pointy arrows; exports use the default 1.0. */
+void paintAnnotation(QPainter &painter, const Annotation &annotation,
+                     qreal arrowDisplayScale = 1.0);
+/** Visual extent of an arrow, including its head and stroke. The optional
+ *  display scale matches the preview-only Standard/Pointy tail floor; canvas
+ *  growth and exports use the natural 1.0 default. */
+[[nodiscard]] QRectF arrowVisualBounds(const Annotation &annotation,
+                                       qreal displayScale = 1.0);
+/** The on-curve midpoint handle used to reshape Curved/Double arrows. */
+[[nodiscard]] QPointF arrowCurveHandlePoint(const Annotation &annotation);
+/** Shape-aware arrow hit test in annotation-space pixels. */
+[[nodiscard]] bool arrowContainsPoint(const Annotation &annotation,
+                                      const QPointF &point,
+                                      qreal tolerance = 0.0);
 [[nodiscard]] QPainterPath spotlightPath(const Annotation &annotation);
 void paintSpotlights(QPainter &painter, const QImage &source,
                      const QRectF &targetBounds, const QRectF &sourceRect,
@@ -264,7 +284,8 @@ void paintSpotlights(QPainter &painter, const QImage &source,
  */
 void paintDefaultLayer(QPainter &painter, const QImage &redacted,
                        const QRectF &logicalBounds,
-                       const QVector<Annotation> &annotations);
+                       const QVector<Annotation> &annotations,
+                       qreal arrowDisplayScale = 1.0);
 /** `customBackdrop` is the image drawn (cover-fit) for
  *  `BackgroundStyle::Custom`; a null image there paints nothing, same as
  *  `BackgroundStyle::None`. */

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -291,6 +291,8 @@ void translateAnnotation(Annotation &annotation, const QPointF &delta) {
   annotation.start += delta;
   if (hasEndpointHandles(annotation.kind))
     annotation.end += delta;
+  if (annotation.curveControl)
+    *annotation.curveControl += delta;
   if (isStrokeKind(annotation.kind)) {
     for (QPointF &point : annotation.points)
       point += delta;
@@ -468,6 +470,48 @@ TextFont nextTextFont(TextFont textFont) {
 QString redactionStyleName(RedactionStyle style) {
   return style == RedactionStyle::Solid ? QStringLiteral("Solid")
                                         : QStringLiteral("Pixelate");
+}
+
+QString arrowStyleName(ArrowStyle style) {
+  switch (style) {
+  case ArrowStyle::Standard:
+    return QStringLiteral("Standard");
+  case ArrowStyle::Pointy:
+    return QStringLiteral("Pointy");
+  case ArrowStyle::Curved:
+    return QStringLiteral("Curved");
+  case ArrowStyle::Double:
+    return QStringLiteral("Double");
+  }
+  return QStringLiteral("Standard");
+}
+
+QString arrowToolAction(ArrowStyle style) {
+  switch (style) {
+  case ArrowStyle::Standard:
+    return QStringLiteral("tool-arrow-standard");
+  case ArrowStyle::Pointy:
+    return QStringLiteral("tool-arrow-pointy");
+  case ArrowStyle::Curved:
+    return QStringLiteral("tool-arrow-curved");
+  case ArrowStyle::Double:
+    return QStringLiteral("tool-arrow-double");
+  }
+  return QStringLiteral("tool-arrow-standard");
+}
+
+ArrowStyle nextArrowStyle(ArrowStyle style) {
+  switch (style) {
+  case ArrowStyle::Standard:
+    return ArrowStyle::Pointy;
+  case ArrowStyle::Pointy:
+    return ArrowStyle::Curved;
+  case ArrowStyle::Curved:
+    return ArrowStyle::Double;
+  case ArrowStyle::Double:
+    return ArrowStyle::Standard;
+  }
+  return ArrowStyle::Standard;
 }
 
 qreal constrainedRedactionCoordinate(qreal candidate, qreal fixed,
@@ -988,6 +1032,8 @@ QRectF CaptureEditor::annotationBounds(const Annotation &annotation) const {
   }
   if (annotation.kind == Annotation::Kind::Text)
     return annotationTextBounds(annotation);
+  if (annotation.kind == Annotation::Kind::Arrow)
+    return arrowVisualBounds(annotation);
   if (isStrokeKind(annotation.kind)) {
     if (annotation.points.isEmpty())
       return {};
@@ -1025,9 +1071,18 @@ bool CaptureEditor::annotationSelected(int index) const {
 
 QVector<QPair<QPointF, CaptureEditor::Interaction>>
 CaptureEditor::annotationHandles(const Annotation &annotation) const {
-  // A line or an arrow is two points, so it has two handles and no box.
-  if (annotation.kind == Annotation::Kind::Arrow ||
-      annotation.kind == Annotation::Kind::Line) {
+  if (annotation.kind == Annotation::Kind::Arrow) {
+    QVector<QPair<QPointF, Interaction>> handles{
+        {annotation.start, Interaction::ResizeStart},
+        {annotation.end, Interaction::ResizeEnd}};
+    if (annotation.arrowStyle == ArrowStyle::Curved ||
+        annotation.arrowStyle == ArrowStyle::Double) {
+      handles.push_back(
+          {arrowCurveHandlePoint(annotation), Interaction::ResizeControl});
+    }
+    return handles;
+  }
+  if (annotation.kind == Annotation::Kind::Line) {
     return {{annotation.start, Interaction::ResizeStart},
             {annotation.end, Interaction::ResizeEnd}};
   }
@@ -1075,7 +1130,13 @@ CaptureEditor::selectedHandleAt(const QPointF &point) const {
   // miss it and start a marquee or a new drawing instead.
   if (selectedAnnotation_ < 0 || selectedAnnotation_ >= annotations_.size())
     return Interaction::None;
-  const qreal tolerance = 9.0 / std::max<qreal>(editScale(), 0.01);
+  const Annotation &selected = annotations_.at(selectedAnnotation_);
+  const bool curvedArrow =
+      selected.kind == Annotation::Kind::Arrow &&
+      (selected.arrowStyle == ArrowStyle::Curved ||
+       selected.arrowStyle == ArrowStyle::Double);
+  const qreal tolerance = (curvedArrow ? 18.0 : 9.0) /
+                          std::max<qreal>(editScale(), 0.01);
   Interaction nearest = Interaction::None;
   qreal nearestDistance = tolerance;
   for (const auto &[position, handle] :
@@ -1104,6 +1165,8 @@ Qt::CursorShape CaptureEditor::handleCursorShape(Interaction handle) const {
     if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
         annotations_.at(selectedAnnotation_).kind == Annotation::Kind::Text)
       return Qt::SizeHorCursor;
+    return Qt::PointingHandCursor;
+  case Interaction::ResizeControl:
     return Qt::PointingHandCursor;
   case Interaction::ResizeTopLeft:
   case Interaction::ResizeBottomRight:
@@ -1311,12 +1374,15 @@ QString CaptureEditor::toolStatus() const {
   case Tool::Highlighter:
     return highlighterStatus();
   case Tool::Arrow:
+    return QStringLiteral("Arrow · %1 · A cycles style · size %2 · wheel "
+                          "resizes · Shift snaps 45° / centers bend")
+        .arg(arrowStyleName(arrowStyle_))
+        .arg(size);
   case Tool::Line:
   case Tool::Freehand:
     break;
   }
-  const QString name = tool_ == Tool::Arrow      ? QStringLiteral("Arrow")
-                       : tool_ == Tool::Line     ? QStringLiteral("Line")
+  const QString name = tool_ == Tool::Line     ? QStringLiteral("Line")
                        : tool_ == Tool::Freehand ? QStringLiteral("Pen")
                                                  : QStringLiteral("Highlighter");
   return QStringLiteral("%1 · size %2 · wheel resizes · Shift constrains")
@@ -1327,8 +1393,12 @@ QString CaptureEditor::toolStatus() const {
 bool CaptureEditor::annotationContains(const Annotation &annotation,
                                        const QPointF &point,
                                        bool edgeOnly) const {
-    if (annotation.kind == Annotation::Kind::Arrow ||
-        annotation.kind == Annotation::Kind::Line) {
+    if (annotation.kind == Annotation::Kind::Arrow) {
+      return arrowContainsPoint(
+          annotation, point,
+          std::max<qreal>(8.0, annotation.size + 4.0));
+    }
+    if (annotation.kind == Annotation::Kind::Line) {
       const QPointF delta = annotation.end - annotation.start;
       const qreal lengthSquared = delta.x() * delta.x() + delta.y() * delta.y();
       if (lengthSquared <= 0)
@@ -1679,6 +1749,43 @@ void CaptureEditor::cycleTextFont() {
   tool_ = Tool::Text;
   setStatus(QStringLiteral("Text: %1 · Shift+T cycles font")
                 .arg(annotationTextFontName(textFont_)));
+}
+
+void CaptureEditor::cycleArrowStyle() {
+  ArrowStyle seed = arrowStyle_;
+  QVector<int> selectedLayers;
+  for (const int index : selectedAnnotations_) {
+    if (index >= 0 && index < annotations_.size() &&
+        !selectedLayers.contains(index))
+      selectedLayers.push_back(index);
+  }
+  if (selectedLayers.isEmpty() && selectedAnnotation_ >= 0 &&
+      selectedAnnotation_ < annotations_.size())
+    selectedLayers.push_back(selectedAnnotation_);
+
+  QVector<int> arrows;
+  for (const int index : selectedLayers) {
+    if (annotations_.at(index).kind == Annotation::Kind::Arrow)
+      arrows.push_back(index);
+  }
+  // A single selected arrow continues from its own style. A mixed/group
+  // selection uses the current tool style as the common seed.
+  if (selectedLayers.size() == 1 && arrows.size() == 1)
+    seed = annotations_.at(arrows.constFirst()).arrowStyle;
+  arrowStyle_ = nextArrowStyle(seed);
+  if (!arrows.isEmpty()) {
+    for (const int index : arrows)
+      annotations_[index].arrowStyle = arrowStyle_;
+    setStatus(arrows.size() == 1
+                  ? QStringLiteral("Selected arrow: %1 · A cycles style")
+                        .arg(arrowStyleName(arrowStyle_))
+                  : QStringLiteral("%1 selected arrows: %2 · A cycles style")
+                        .arg(arrows.size())
+                        .arg(arrowStyleName(arrowStyle_)));
+    commitPatch(arrows);
+    return;
+  }
+  setStatus(toolStatus());
 }
 
 QPointF CaptureEditor::constrainedResizeEndpoint(
@@ -2233,8 +2340,10 @@ CaptureEditor::toolbarButtons(QVector<qreal> *groupDividers,
   // Tools: everything that acts on the image via the cursor.
   add(36, QStringLiteral("tool-select"), {},
       QStringLiteral("Select/move · V · Ctrl+wheel zoom · outer handles crop"));
-  add(36, QStringLiteral("tool-arrow"), {},
-      QStringLiteral("Arrow · A · Shift snaps 45° · Size %1 · Wheel")
+  add(36, arrowToolAction(arrowStyle_), {},
+      QStringLiteral("Arrow · %1 · A cycles · Shift snaps 45° / centers "
+                     "bend · Size %2 · Wheel")
+          .arg(arrowStyleName(arrowStyle_))
           .arg(qRound(annotationSize_)));
   add(36, QStringLiteral("tool-line"), {},
       QStringLiteral("Line · L · Shift snaps 45° · Size %1 · Wheel")
@@ -2721,6 +2830,8 @@ void CaptureEditor::replayLog() {
         };
         shift(annotation.start);
         shift(annotation.end);
+        if (annotation.curveControl)
+          shift(*annotation.curveControl);
         for (QPointF &point : annotation.points)
           shift(point);
       }
@@ -3507,8 +3618,12 @@ void CaptureEditor::handleToolbar(const QString &action) {
   const QString statusBefore = status_;
   if (action == QStringLiteral("tool-select"))
     tool_ = Tool::Select;
-  else if (action == QStringLiteral("tool-arrow"))
-    tool_ = Tool::Arrow;
+  else if (action.startsWith(QStringLiteral("tool-arrow-"))) {
+    if (tool_ == Tool::Arrow)
+      cycleArrowStyle();
+    else
+      tool_ = Tool::Arrow;
+  }
   else if (action == QStringLiteral("tool-line"))
     tool_ = Tool::Line;
   else if (action == QStringLiteral("tool-freehand"))
@@ -3641,7 +3756,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   }
   if (event->key() == Qt::Key_Shift && phase_ == Phase::Edit && dragging_) {
     // Shift pressed mid-drag constrains the drag: creation for drawing
-    // tools, handle resizing for the Select tool.
+    // tools, or handle resizing whether Select or a drawing tool is armed.
     const bool resizing =
         isLayerResize(interaction_);
     if (resizing)
@@ -3850,7 +3965,10 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if (event->matches(QKeySequence::SelectAll)) {
     selectAllAnnotations();
   } else if (event->key() == Qt::Key_A) {
-    tool_ = Tool::Arrow;
+    if (tool_ == Tool::Arrow)
+      cycleArrowStyle();
+    else
+      tool_ = Tool::Arrow;
   } else if (event->key() == Qt::Key_L) {
     tool_ = Tool::Line;
   } else if (event->key() == Qt::Key_F) {
@@ -4261,6 +4379,8 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
           annotation.start += annotationDelta;
           if (hasEndpointHandles(annotation.kind))
             annotation.end += annotationDelta;
+          if (annotation.curveControl)
+            *annotation.curveControl += annotationDelta;
           if (isStrokeKind(annotation.kind)) {
             for (QPointF &point : annotation.points)
               point += annotationDelta;
@@ -4296,6 +4416,8 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
           annotation.start += delta;
           if (hasEndpointHandles(annotation.kind))
             annotation.end += delta;
+          if (annotation.curveControl)
+            *annotation.curveControl += delta;
           if (isStrokeKind(annotation.kind)) {
             for (QPointF &strokePoint : annotation.points)
               strokePoint += delta;
@@ -4356,6 +4478,29 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
                   annotationTextFont(annotation.size, annotation.textFont))
                   .ascent());
         }
+      } else if (interaction_ == Interaction::ResizeControl &&
+                 annotation.kind == Annotation::Kind::Arrow &&
+                 (annotation.arrowStyle == ArrowStyle::Curved ||
+                  annotation.arrowStyle == ArrowStyle::Double)) {
+        QPointF handlePoint = point;
+        if (resizeConstraintActive_) {
+          // Keep the visible t=.5 handle centered along the chord while its
+          // perpendicular distance remains under the pointer. This preserves
+          // an adjustable, symmetric bend instead of flattening the arrow.
+          const QPointF chord = annotation.end - annotation.start;
+          const qreal chordLengthSquared = QPointF::dotProduct(chord, chord);
+          if (!qFuzzyIsNull(chordLengthSquared)) {
+            const QPointF midpoint =
+                (annotation.start + annotation.end) * 0.5;
+            handlePoint -=
+                chord * (QPointF::dotProduct(handlePoint - midpoint, chord) /
+                         chordLengthSquared);
+          }
+        }
+        // The pointer owns the visible t=.5 point on the quadratic. Solve
+        // M=.25*S+.5*C+.25*E for C so the handle tracks it exactly.
+        annotation.curveControl =
+            handlePoint * 2.0 - (annotation.start + annotation.end) * 0.5;
       }
       }
       dragChanged_ = true;
@@ -4749,7 +4894,8 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       dragStart_ = point;
       dragging_ = true;
       resizeConstraintActive_ = isLayerResize(interaction_) &&
-                                event->modifiers().testFlag(Qt::ShiftModifier);
+                                heldModifiers(event->modifiers())
+                                    .testFlag(Qt::ShiftModifier);
       setStatus(selectedAnnotations_.size() > 1
                     ? QStringLiteral("%1 layers selected · drag to move")
                           .arg(selectedAnnotations_.size())
@@ -4794,6 +4940,9 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       originalSelectedAnnotations_.clear();
       originalSelectedAnnotations_.push_back(annotations_.at(grabbed));
       interaction_ = grabInteraction;
+      resizeConstraintActive_ =
+          isLayerResize(interaction_) &&
+          heldModifiers(event->modifiers()).testFlag(Qt::ShiftModifier);
       dragStartState_ = before;
       dragStartStateValid_ = true;
       dragChanged_ = raised;
@@ -4913,6 +5062,7 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     // an edit like any other, so it takes its own undo step. Ctrl+Z after
     // nudging a layer must put that layer back, not remove the one before it.
     dragging_ = false;
+    resizeConstraintActive_ = false;
     interaction_ = Interaction::None;
     if (dragStartStateValid_ && dragChanged_)
       commitPatch(selectedAnnotations_);
@@ -5096,6 +5246,8 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       annotation.spotlightShape = spotlightShape_;
     } else {
       annotation.kind = dragShapeKind(tool_);
+      if (tool_ == Tool::Arrow)
+        annotation.arrowStyle = arrowStyle_;
       if (tool_ == Tool::Rectangle || tool_ == Tool::Ellipse)
         annotation.filled = fillShapes_;
       if (tool_ == Tool::Rectangle)
@@ -6259,6 +6411,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         preview.cornerRadius = 2.0;
       } else {
         preview.kind = dragShapeKind(tool_);
+        if (tool_ == Tool::Arrow)
+          preview.arrowStyle = arrowStyle_;
         if (tool_ == Tool::Rectangle || tool_ == Tool::Ellipse)
           preview.filled = fillShapes_;
         if (tool_ == Tool::Rectangle)
@@ -6372,10 +6526,10 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   // so a spotlight carried past the old frame has valid pixels to sample.
   if (!defaultLayerSource.isNull()) {
     paintDefaultLayer(painter, defaultLayerSource, defaultLayerBounds,
-                      defaultAnnotations);
+                      defaultAnnotations, editScale());
   } else {
     for (const Annotation &annotation : defaultAnnotations)
-      paintAnnotation(painter, annotation);
+      paintAnnotation(painter, annotation, editScale());
   }
   painter.restore();
   if (highlighterPreview_) {
@@ -6612,6 +6766,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   for (const ToolbarButton &button : buttons) {
     const bool selected =
         button.action == currentTool ||
+        (button.action.startsWith(QStringLiteral("tool-arrow-")) &&
+         tool_ == Tool::Arrow) ||
         (button.action == QStringLiteral("shape-rectangle") &&
          tool_ == Tool::Rectangle) ||
         (button.action == QStringLiteral("shape-ellipse") &&
@@ -6697,7 +6853,9 @@ void CaptureEditor::paintEdit(QPainter &painter) {
              tool_ == Tool::Text) {
     const QString selectedAction = toolAction(tool_);
     for (const ToolbarButton &button : buttons) {
-      if (button.action == selectedAction) {
+      if (button.action == selectedAction ||
+          (tool_ == Tool::Arrow &&
+           button.action.startsWith(QStringLiteral("tool-arrow-")))) {
         QString tooltip;
         if (tool_ == Tool::Text) {
           tooltip = QStringLiteral(

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -4177,6 +4177,12 @@ QRegion CaptureEditor::pointerMotionRegion(const QPointF &point) const {
   };
   const auto annotationRegion = [&](const Annotation &annotation) {
     QRegion region;
+    if (annotation.kind == Annotation::Kind::Arrow) {
+      const QRectF bounds = arrowVisualBounds(annotation, scale);
+      return QRegion(QRectF(widgetPoint(bounds.topLeft()), bounds.size() * scale)
+                         .adjusted(-4, -4, 4, 4).toAlignedRect()) &
+             QRegion(widgetBounds);
+    }
     const bool stroke = annotation.kind == Annotation::Kind::Arrow ||
                         annotation.kind == Annotation::Kind::Line ||
                         annotation.kind == Annotation::Kind::Freehand ||
@@ -4283,6 +4289,7 @@ QRegion CaptureEditor::pointerMotionRegion(const QPointF &point) const {
     preview.end = toUnclampedAnnotationPoint(point);
   } else {
     preview.kind = dragShapeKind(tool_);
+    preview.arrowStyle = arrowStyle_;
     const QLineF span = creationSpan(toUnclampedAnnotationPoint(point));
     preview.start = span.p1();
     preview.end = span.p2();

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -165,6 +165,8 @@ public:
     /// that have only one (a text's wrap width).
     ResizeStart,
     ResizeEnd,
+    /// The on-curve midpoint handle that bends a Curved/Double arrow.
+    ResizeControl,
     /// A box's eight handles, in the same clockwise order as the crop ones.
     ResizeTopLeft,
     ResizeTop,
@@ -345,7 +347,7 @@ public:
   }
   [[nodiscard]] QRectF toolbarButtonRectForTest(const QString &action) const {
     for (const ToolbarButton &button : toolbarButtons())
-      if (button.action == action)
+      if (button.action == action || button.action.startsWith(action + '-'))
         return button.rect;
     return {};
   }
@@ -566,6 +568,7 @@ private:
   void toggleShapeFill();
   void toggleTextBackground();
   void cycleTextFont();
+  void cycleArrowStyle();
   void nudgeSelectedAnnotation(const QPointF &delta);
   void endNudgeRun();
   /// Wheel over a selected layer: weight, not size. Thickness for anything
@@ -701,6 +704,7 @@ private:
   qreal customHue_ = 0.98;
   int nextMarker_ = 1;
   qreal annotationSize_ = 4.0;
+  ArrowStyle arrowStyle_ = ArrowStyle::Standard;
   bool fillShapes_ = false;
   qreal cornerRadius_ = 0.0;
   /// True while a wheel adjustment is in flight; the selection chrome draws

--- a/src/icons.cpp
+++ b/src/icons.cpp
@@ -1,10 +1,54 @@
 #include "icons.hpp"
 
 #include "overlay-chrome.hpp"
+#include "capture.hpp"
 
 #include <QConicalGradient>
 #include <QPainter>
 #include <QPainterPath>
+
+namespace {
+constexpr qreal kArrowIconWidth = 28.0;
+constexpr qreal kArrowIconLength = 100.0;
+constexpr qreal kArrowIconSize = 5.0;
+
+bool arrowStyleForAction(const QString &action, ArrowStyle &style) {
+  if (action == QStringLiteral("tool-arrow-standard"))
+    style = ArrowStyle::Standard;
+  else if (action == QStringLiteral("tool-arrow-pointy"))
+    style = ArrowStyle::Pointy;
+  else if (action == QStringLiteral("tool-arrow-curved"))
+    style = ArrowStyle::Curved;
+  else if (action == QStringLiteral("tool-arrow-double"))
+    style = ArrowStyle::Double;
+  else
+    return false;
+  return true;
+}
+
+void drawArrowStyleIcon(QPainter &painter, const QRectF &bounds,
+                        ArrowStyle style, const QColor &color) {
+  Annotation arrow;
+  arrow.kind = Annotation::Kind::Arrow;
+  arrow.start = QPointF(0.0, 0.0);
+  arrow.end = QPointF(kArrowIconLength, 0.0);
+  arrow.color = color;
+  arrow.size = kArrowIconSize;
+  arrow.arrowStyle = style;
+
+  const QRectF natural = arrowVisualBounds(arrow);
+  if (natural.isEmpty())
+    return;
+  // Width is the invariant across styles. A single uniform transform keeps
+  // every calibrated polygon, curve, tangent and head angle identical to the
+  // annotation renderer instead of stretching a separate toolbar sketch.
+  const qreal scale = kArrowIconWidth / natural.width();
+  painter.translate(bounds.center());
+  painter.scale(scale, scale);
+  painter.translate(-natural.center());
+  paintAnnotation(painter, arrow);
+}
+} // namespace
 
 void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
                      const QString &action, const QString &label,
@@ -16,10 +60,20 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
   }
 
   painter.save();
+  ArrowStyle arrowStyle = ArrowStyle::Standard;
+  if (arrowStyleForAction(action, arrowStyle)) {
+    drawArrowStyleIcon(painter, bounds, arrowStyle, color);
+    painter.restore();
+    return;
+  }
+
   constexpr qreal iconSize = 19.0;
-  painter.translate(bounds.center().x() - iconSize / 2.0,
-                    bounds.center().y() - iconSize / 2.0);
-  painter.scale(iconSize / 24.0, iconSize / 24.0);
+  const qreal iconWidth = iconSize;
+  const qreal iconHeight = iconSize;
+  constexpr qreal logicalWidth = 24.0;
+  painter.translate(bounds.center().x() - iconWidth / 2.0,
+                    bounds.center().y() - iconHeight / 2.0);
+  painter.scale(iconWidth / logicalWidth, iconHeight / 24.0);
   painter.setPen(QPen(color, 2.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
   painter.setBrush(Qt::NoBrush);
 
@@ -31,10 +85,6 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     pointer.lineTo(9, 21);
     pointer.closeSubpath();
     painter.drawPath(pointer);
-  } else if (action == QStringLiteral("tool-arrow")) {
-    painter.drawLine(QPointF(7, 17), QPointF(17, 7));
-    painter.drawLine(QPointF(7, 7), QPointF(17, 7));
-    painter.drawLine(QPointF(17, 7), QPointF(17, 17));
   } else if (action == QStringLiteral("tool-line")) {
     painter.drawLine(QPointF(5, 19), QPointF(19, 5));
   } else if (action == QStringLiteral("tool-freehand")) {

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -18,6 +18,7 @@
 #include "text-band.hpp"
 #include "transform-smoke.hpp"
 #include "eyedropper.hpp"
+#include "icons.hpp"
 
 #include <QApplication>
 #include <QBuffer>
@@ -7470,6 +7471,651 @@ bool runAreaLastRegionSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+bool runArrowStyleSmoke(QApplication &application, QString &error) {
+  const std::array<QString, 4> iconActions{
+      QStringLiteral("tool-arrow-standard"),
+      QStringLiteral("tool-arrow-pointy"),
+      QStringLiteral("tool-arrow-curved"),
+      QStringLiteral("tool-arrow-double")};
+  const std::array<ArrowStyle, 4> styles{ArrowStyle::Standard,
+                                         ArrowStyle::Pointy, ArrowStyle::Curved,
+                                         ArrowStyle::Double};
+  const auto exactArrowIcon = [](ArrowStyle style) {
+    QImage image(36, 36, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    Annotation arrow;
+    arrow.kind = Annotation::Kind::Arrow;
+    arrow.start = {0, 0};
+    arrow.end = {100, 0};
+    arrow.color = Qt::white;
+    arrow.size = 5;
+    arrow.arrowStyle = style;
+    const QRectF natural = arrowVisualBounds(arrow);
+    QPainter painter(&image);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.translate(QRectF(0, 0, 36, 36).center());
+    const qreal scale = 28.0 / natural.width();
+    painter.scale(scale, scale);
+    painter.translate(-natural.center());
+    paintAnnotation(painter, arrow);
+    return image;
+  };
+  std::array<QImage, 4> arrowIcons;
+  for (std::size_t index = 0; index < iconActions.size(); ++index) {
+    arrowIcons.at(index) =
+        QImage(36, 36, QImage::Format_ARGB32_Premultiplied);
+    arrowIcons.at(index).fill(Qt::transparent);
+    QPainter painter(&arrowIcons.at(index));
+    painter.setRenderHint(QPainter::Antialiasing);
+    drawToolbarIcon(painter, QRectF(0, 0, 36, 36), iconActions.at(index), {},
+                    Qt::white);
+    painter.end();
+    if (arrowIcons.at(index) != exactArrowIcon(styles.at(index))) {
+      error = QStringLiteral(
+          "Arrow toolbar icon did not use exact annotation geometry");
+      return false;
+    }
+  }
+  const auto visibleIconBounds = [](const QImage &image) {
+    QRect bounds;
+    for (int y = 0; y < image.height(); ++y) {
+      for (int x = 0; x < image.width(); ++x) {
+        if (image.pixelColor(x, y).alpha() > 32)
+          bounds |= QRect(x, y, 1, 1);
+      }
+    }
+    return bounds;
+  };
+  const QRect firstIconBounds = visibleIconBounds(arrowIcons.front());
+  for (const QImage &icon : arrowIcons) {
+    const QRect bounds = visibleIconBounds(icon);
+    if (bounds.width() < 27 || bounds.width() != firstIconBounds.width() ||
+        bounds.center().x() != firstIconBounds.center().x()) {
+      error = QStringLiteral(
+          "Arrow toolbar icons did not share one centered visible width");
+      return false;
+    }
+  }
+  for (std::size_t first = 0; first < arrowIcons.size(); ++first) {
+    for (std::size_t second = first + 1; second < arrowIcons.size(); ++second) {
+      if (arrowIcons.at(first) == arrowIcons.at(second)) {
+        error = QStringLiteral("Two arrow toolbar icons rendered identically");
+        return false;
+      }
+    }
+  }
+
+  Annotation arrow;
+  arrow.kind = Annotation::Kind::Arrow;
+  arrow.start = {30, 80};
+  arrow.end = {170, 80};
+  arrow.color = QColor(QStringLiteral("#ff375f"));
+  arrow.size = 5;
+
+  std::array<QImage, 4> rendered;
+  for (std::size_t index = 0; index < styles.size(); ++index) {
+    arrow.arrowStyle = styles.at(index);
+    rendered.at(index) = QImage(200, 120, QImage::Format_ARGB32_Premultiplied);
+    rendered.at(index).fill(Qt::transparent);
+    QPainter painter(&rendered.at(index));
+    painter.setRenderHint(QPainter::Antialiasing);
+    paintAnnotation(painter, arrow);
+  }
+  for (std::size_t first = 0; first < rendered.size(); ++first) {
+    for (std::size_t second = first + 1; second < rendered.size(); ++second) {
+      if (rendered.at(first) == rendered.at(second)) {
+        error = QStringLiteral("Two arrow styles rendered identically");
+        return false;
+      }
+    }
+  }
+
+  const auto rectNear = [](const QRectF &actual, const QRectF &expected,
+                           qreal tolerance = 0.01) {
+    return std::abs(actual.x() - expected.x()) <= tolerance &&
+           std::abs(actual.y() - expected.y()) <= tolerance &&
+           std::abs(actual.width() - expected.width()) <= tolerance &&
+           std::abs(actual.height() - expected.height()) <= tolerance;
+  };
+
+  arrow.arrowStyle = ArrowStyle::Standard;
+  const QRectF standardBounds = arrowVisualBounds(arrow);
+  if (!rectNear(standardBounds, QRectF(28.25, 63.75, 143.5, 32.5))) {
+    error = QStringLiteral("Standard arrow geometry drifted (%1,%2 %3x%4)")
+                .arg(standardBounds.x())
+                .arg(standardBounds.y())
+                .arg(standardBounds.width())
+                .arg(standardBounds.height());
+    return false;
+  }
+  arrow.arrowStyle = ArrowStyle::Pointy;
+  const QRectF pointyBounds = arrowVisualBounds(arrow);
+  if (!rectNear(pointyBounds, QRectF(30.0, 59.87, 140.0, 40.26)) ||
+      pointyBounds.height() <= standardBounds.height() ||
+      !arrowContainsPoint(arrow, QPointF(100, 80))) {
+    error = QStringLiteral("Pointy arrow did not use the swept-back geometry");
+    return false;
+  }
+
+  // The calibrated polygon rotates with the chord and keeps its full head on
+  // short arrows rather than shrinking into an unrecognizable triangle.
+  arrow.arrowStyle = ArrowStyle::Standard;
+  arrow.start = {80, 30};
+  arrow.end = {80, 170};
+  if (!rectNear(arrowVisualBounds(arrow),
+                QRectF(63.75, 28.25, 32.5, 143.5))) {
+    error = QStringLiteral("Standard arrow did not rotate its exact geometry");
+    return false;
+  }
+  arrow.start = {30, 80};
+  arrow.end = {40, 80};
+  if (!rectNear(arrowVisualBounds(arrow),
+                QRectF(28.25, 63.75, 13.5, 32.5))) {
+    error = QStringLiteral("Short arrow changed the calibrated head geometry");
+    return false;
+  }
+  arrow.end = {170, 80};
+
+  // Use generous body-aligned pick bands, not the narrow visible
+  // polygon/stroke alone.
+  if (!arrowContainsPoint(arrow, QPointF(100, 95.7)) ||
+      arrowContainsPoint(arrow, QPointF(100, 95.8))) {
+    error = QStringLiteral("Standard arrow pick band was not head-width based");
+    return false;
+  }
+  arrow.arrowStyle = ArrowStyle::Pointy;
+  if (!arrowContainsPoint(arrow, QPointF(100, 97.2)) ||
+      arrowContainsPoint(arrow, QPointF(100, 97.3))) {
+    error = QStringLiteral("Pointy arrow pick band was not head-width based");
+    return false;
+  }
+
+  arrow.arrowStyle = ArrowStyle::Curved;
+  const QPointF curveMidpoint(100, 62.5);
+  if (!arrowContainsPoint(arrow, curveMidpoint) ||
+      arrowContainsPoint(arrow, QPointF(100, 80)) ||
+      !arrowContainsPoint(arrow, QPointF(100, 80), 2.0)) {
+    error = QStringLiteral("Curved arrow did not follow the expected arc");
+    return false;
+  }
+  // One outer corner of the Double style's start V. It is deliberately far
+  // from the Curved style's shaft, so this checks the second head itself.
+  const QPoint doubleStartHeadCorner(35, 66);
+  if (rendered.at(2).pixelColor(doubleStartHeadCorner).alpha() > 8) {
+    error = QStringLiteral("Curved arrow unexpectedly had a start head");
+    return false;
+  }
+  arrow.arrowStyle = ArrowStyle::Double;
+  if (rendered.at(3).pixelColor(doubleStartHeadCorner).alpha() < 64) {
+    error = QStringLiteral("Double arrow did not draw its start head");
+    return false;
+  }
+
+  // The third handle is the visible t=.5 point, while the persisted point is
+  // the off-curve quadratic control. Both geometry and hit testing must use
+  // the override.
+  arrow.arrowStyle = ArrowStyle::Curved;
+  arrow.curveControl = QPointF(100, 20);
+  if (QLineF(arrowCurveHandlePoint(arrow), QPointF(100, 50)).length() > 0.001 ||
+      !rectNear(arrowVisualBounds(arrow),
+                QRectF(27.0, 47.0, 146.0, 37.150447), 0.02) ||
+      !arrowContainsPoint(arrow, QPointF(100, 65.7)) ||
+      arrowContainsPoint(arrow, QPointF(100, 65.8))) {
+    error = QStringLiteral("Custom arrow curve was not used consistently");
+    return false;
+  }
+  arrow.curveControl.reset();
+
+  const auto renderAtDisplayScale = [&](ArrowStyle style, qreal displayScale) {
+    arrow.arrowStyle = style;
+    QImage image(200, 120, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    painter.setRenderHint(QPainter::Antialiasing);
+    paintAnnotation(painter, arrow, displayScale);
+    return image;
+  };
+  const auto tailSpan = [](const QImage &image, int x) {
+    int first = image.height();
+    int last = -1;
+    for (int y = 0; y < image.height(); ++y) {
+      if (image.pixelColor(x, y).alpha() <= 8)
+        continue;
+      first = std::min(first, y);
+      last = std::max(last, y);
+    }
+    return last >= first ? last - first + 1 : 0;
+  };
+  const QImage standardNatural = renderAtDisplayScale(ArrowStyle::Standard, 1);
+  const QImage standardFit = renderAtDisplayScale(ArrowStyle::Standard, 0.5);
+  const QImage standardCapped = renderAtDisplayScale(ArrowStyle::Standard, 0.1);
+  arrow.arrowStyle = ArrowStyle::Standard;
+  const QRectF standardFitBounds = arrowVisualBounds(arrow, 0.5);
+  if (standardNatural != rendered.at(0) ||
+      tailSpan(standardFit, 30) <= tailSpan(standardNatural, 30) ||
+      standardCapped != renderAtDisplayScale(ArrowStyle::Standard, 0.01) ||
+      !rectNear(standardFitBounds, QRectF(26.5, 62.0, 147.0, 36.0)) ||
+      standardFitBounds.left() >= standardBounds.left() ||
+      standardFitBounds.right() <= standardBounds.right() ||
+      arrowVisualBounds(arrow) != standardBounds ||
+      arrowVisualBounds(arrow, 1.0) != standardBounds) {
+    error = QStringLiteral(
+        "Standard preview bounds did not include the zoom-aware tail");
+    return false;
+  }
+  const QImage pointyNatural = renderAtDisplayScale(ArrowStyle::Pointy, 1);
+  const QImage pointyFit = renderAtDisplayScale(ArrowStyle::Pointy, 0.5);
+  const QImage pointyCapped = renderAtDisplayScale(ArrowStyle::Pointy, 0.1);
+  if (pointyNatural != rendered.at(1) ||
+      tailSpan(pointyFit, 30) <= tailSpan(pointyNatural, 30) ||
+      pointyCapped != renderAtDisplayScale(ArrowStyle::Pointy, 0.01) ||
+      arrowVisualBounds(arrow) != pointyBounds) {
+    error = QStringLiteral("Pointy preview tail changed export geometry");
+    return false;
+  }
+
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 800, 600};
+  capture.monitor.pixelSize = {800, 600};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::Fullscreen);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+
+  const auto draw = [&](int y) {
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(240, y));
+    QTest::mouseMove(&editor, QPoint(560, y), 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                        QPoint(560, y));
+    application.processEvents();
+  };
+  QTest::keyClick(&editor, Qt::Key_A);
+  if (!editor.statusForTest().contains(QStringLiteral("Standard"))) {
+    error = QStringLiteral("Arming Arrow did not report Standard");
+    return false;
+  }
+  draw(210);
+  QTest::keyClick(&editor, Qt::Key_A);
+  draw(270);
+  QTest::keyClick(&editor, Qt::Key_A);
+  draw(330);
+  QTest::keyClick(&editor, Qt::Key_A);
+  draw(390);
+
+  QVector<ArrowStyle> committed;
+  for (const Operation &operation : editor.operationLog()) {
+    if (operation.type == Operation::Type::Annotate &&
+        operation.annotations.size() == 1 &&
+        operation.annotations.constFirst().kind == Annotation::Kind::Arrow)
+      committed.push_back(operation.annotations.constFirst().arrowStyle);
+  }
+  if (committed != QVector<ArrowStyle>{ArrowStyle::Standard, ArrowStyle::Pointy,
+                                       ArrowStyle::Curved,
+                                       ArrowStyle::Double}) {
+    error = QStringLiteral("Repeated A did not cycle all four arrow styles");
+    return false;
+  }
+
+  // The same cycle restyles the one selected arrow, seeding from that
+  // arrow's own style instead of the style most recently used for drawing.
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(400, 210));
+  QTest::keyClick(&editor, Qt::Key_A);
+  QTest::keyClick(&editor, Qt::Key_A);
+  const Operation &restyled = editor.operationLog().constLast();
+  if (restyled.type != Operation::Type::Patch ||
+      restyled.annotations.size() != 1 ||
+      restyled.annotations.constFirst().arrowStyle != ArrowStyle::Pointy) {
+    error = QStringLiteral("Repeated A did not restyle the selected arrow");
+    return false;
+  }
+
+  // Select the Curved arrow at its default on-curve midpoint, then drag that
+  // third handle. The committed value is the back-solved Bezier control, not
+  // the visible midpoint itself.
+  QTest::keyClick(&editor, Qt::Key_V);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(400, 290));
+  application.processEvents();
+  const int beforeBend = editor.operationIndex();
+  // Begin 15 screen px off the handle: Curved/Double intentionally double
+  // the normal 9 px target radius for all three handles.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(400, 305));
+  QTest::mouseMove(&editor, QPoint(420, 250), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(420, 250));
+  application.processEvents();
+  if (editor.operationIndex() != beforeBend + 1 ||
+      editor.operationLog().constLast().type != Operation::Type::Patch ||
+      editor.operationLog().constLast().annotations.size() != 1) {
+    error = QStringLiteral("Dragging the curve handle did not commit one patch");
+    return false;
+  }
+  const Annotation bent =
+      editor.operationLog().constLast().annotations.constFirst();
+  const qreal annotationPerScreen = (bent.end.x() - bent.start.x()) / 320.0;
+  const QPointF expectedHandle =
+      bent.start + QPointF(180, -80) * annotationPerScreen;
+  const QPointF expectedControl =
+      expectedHandle * 2.0 - (bent.start + bent.end) * 0.5;
+  if (bent.kind != Annotation::Kind::Arrow ||
+      bent.arrowStyle != ArrowStyle::Curved || !bent.curveControl ||
+      QLineF(*bent.curveControl, expectedControl).length() > 1.0 ||
+      QLineF(arrowCurveHandlePoint(bent), expectedHandle).length() > 1.0) {
+    error = QStringLiteral("Curve handle did not back-solve its control point");
+    return false;
+  }
+  const QPointF bentCurveControl =
+      bent.curveControl.value_or(QPointF());
+
+  // Moving the bent arrow translates all three defining points together.
+  const int beforeMove = editor.operationIndex();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(335, 270));
+  QTest::mouseMove(&editor, QPoint(345, 280), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(345, 280));
+  application.processEvents();
+  if (editor.operationIndex() != beforeMove + 1 ||
+      editor.operationLog().constLast().annotations.size() != 1) {
+    error = QStringLiteral("Moving a bent arrow did not commit one patch");
+    return false;
+  }
+  const Annotation moved =
+      editor.operationLog().constLast().annotations.constFirst();
+  if (!moved.curveControl) {
+    error = QStringLiteral("Moving an arrow dropped its curve control");
+    return false;
+  }
+  const QPointF movedCurveControl =
+      moved.curveControl.value_or(QPointF());
+  const QPointF movedStart = moved.start - bent.start;
+  const QPointF movedEnd = moved.end - bent.end;
+  const QPointF movedControl = movedCurveControl - bentCurveControl;
+  if (QLineF(movedStart, movedEnd).length() > 0.001 ||
+      QLineF(movedStart, movedControl).length() > 0.001) {
+    error = QStringLiteral("Moving an arrow left its curve control behind");
+    return false;
+  }
+
+  // Keep an explicit control fixed in canvas space when one endpoint is
+  // resized, so the same arc can be refined without its bend drifting.
+  const int beforeResize = editor.operationIndex();
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(250, 355));
+  QTest::mouseMove(&editor, QPoint(270, 340), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(270, 340));
+  application.processEvents();
+  if (editor.operationIndex() != beforeResize + 1 ||
+      editor.operationLog().constLast().annotations.size() != 1) {
+    error = QStringLiteral("Resizing a bent arrow did not commit one patch");
+    return false;
+  }
+  const Annotation resized =
+      editor.operationLog().constLast().annotations.constFirst();
+  if (!resized.curveControl || resized.start == moved.start ||
+      resized.end != moved.end ||
+      QLineF(resized.curveControl.value_or(QPointF()), movedCurveControl)
+              .length() >
+          0.001) {
+    error = QStringLiteral("Endpoint resize changed the explicit arrow curve");
+    return false;
+  }
+
+  // Keep Arrow armed while editing its selected handle: this is the implicit
+  // layer-grab path that used to ignore Shift if it was already held before
+  // mouse-down. Constraining the middle handle removes its along-chord drift
+  // while preserving the perpendicular bend selected by the pointer.
+  QTest::keyClick(&editor, Qt::Key_A);
+  const QPointF arrowStartScreen(270, 340);
+  const QPointF arrowEndScreen(570, 340);
+  const qreal arrowScreenScale =
+      QLineF(resized.start, resized.end).length() /
+      QLineF(arrowStartScreen, arrowEndScreen).length();
+  const auto arrowPointFromScreen = [&](const QPointF &screenPoint) {
+    return resized.start +
+           (screenPoint - arrowStartScreen) * arrowScreenScale;
+  };
+  const auto arrowPointToScreen = [&](const QPointF &annotationPoint) {
+    return arrowStartScreen +
+           (annotationPoint - resized.start) / arrowScreenScale;
+  };
+  const QPoint curveHandleScreen =
+      arrowPointToScreen(arrowCurveHandlePoint(resized)).toPoint();
+  const QPointF rawCurveScreen(500, 230);
+  const QPointF rawCurvePoint = arrowPointFromScreen(rawCurveScreen);
+  const QPointF chord = resized.end - resized.start;
+  const QPointF chordMidpoint = (resized.start + resized.end) * 0.5;
+  const QPointF expectedCenteredHandle =
+      rawCurvePoint -
+      chord * (QPointF::dotProduct(rawCurvePoint - chordMidpoint, chord) /
+               QPointF::dotProduct(chord, chord));
+  const int beforeCenteredBend = editor.operationIndex();
+  QTest::keyPress(&editor, Qt::Key_Shift);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::ShiftModifier,
+                    curveHandleScreen);
+  QTest::mouseMove(&editor, rawCurveScreen.toPoint(), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::ShiftModifier,
+                      rawCurveScreen.toPoint());
+  QTest::keyRelease(&editor, Qt::Key_Shift);
+  application.processEvents();
+  if (editor.operationIndex() != beforeCenteredBend + 1 ||
+      editor.operationLog().constLast().type != Operation::Type::Patch ||
+      editor.operationLog().constLast().annotations.size() != 1) {
+    error =
+        QStringLiteral("Pre-held Shift did not resize the arrow curve handle");
+    return false;
+  }
+  const Annotation centered =
+      editor.operationLog().constLast().annotations.constFirst();
+  const QPointF centeredHandle = arrowCurveHandlePoint(centered);
+  if (QLineF(centeredHandle, expectedCenteredHandle).length() > 1.5 ||
+      std::abs(QPointF::dotProduct(centeredHandle - chordMidpoint, chord)) >
+          chord.manhattanLength() ||
+      QLineF(centeredHandle, chordMidpoint).length() < 20.0) {
+    error = QStringLiteral(
+        "Shift did not center the curved-arrow bend without flattening it");
+    return false;
+  }
+
+  // The same pre-held gesture on an endpoint snaps to the nearest 45-degree
+  // ray immediately; it must not require releasing and pressing Shift again.
+  const QPointF rawArrowEndScreen(620, 400);
+  const QPointF rawArrowEnd = arrowPointFromScreen(rawArrowEndScreen);
+  const QPointF expectedArrowEnd = constrainedCreationEndpoint(
+      CaptureEditor::Tool::Line, centered.start, rawArrowEnd);
+  const int beforeShiftArrowResize = editor.operationIndex();
+  QTest::keyPress(&editor, Qt::Key_Shift);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::ShiftModifier,
+                    arrowEndScreen.toPoint());
+  QTest::mouseMove(&editor, rawArrowEndScreen.toPoint(), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::ShiftModifier,
+                      rawArrowEndScreen.toPoint());
+  QTest::keyRelease(&editor, Qt::Key_Shift);
+  application.processEvents();
+  if (editor.operationIndex() != beforeShiftArrowResize + 1 ||
+      editor.operationLog().constLast().annotations.size() != 1) {
+    error = QStringLiteral("Pre-held Shift did not resize the arrow endpoint");
+    return false;
+  }
+  const Annotation snappedArrow =
+      editor.operationLog().constLast().annotations.constFirst();
+  if (snappedArrow.start != centered.start ||
+      QLineF(snappedArrow.end, expectedArrowEnd).length() > 1.5) {
+    error = QStringLiteral("Pre-held Shift did not snap the arrow endpoint");
+    return false;
+  }
+
+  // Exercise the identical implicit-grab path for a Line. Drawing it leaves
+  // Line armed; clicking the shaft selects it, then Shift is held before the
+  // endpoint press.
+  QTest::keyClick(&editor, Qt::Key_L);
+  const QPointF lineStartScreen(220, 430);
+  const QPointF lineEndScreen(480, 455);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier,
+                    lineStartScreen.toPoint());
+  QTest::mouseMove(&editor, lineEndScreen.toPoint(), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      lineEndScreen.toPoint());
+  application.processEvents();
+  const Annotation lineBefore =
+      editor.operationLog().constLast().annotations.constFirst();
+  if (lineBefore.kind != Annotation::Kind::Line) {
+    error = QStringLiteral("Could not set up the line endpoint Shift check");
+    return false;
+  }
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier,
+                    ((lineStartScreen + lineEndScreen) * 0.5).toPoint());
+  application.processEvents();
+  const qreal lineScreenScale =
+      QLineF(lineBefore.start, lineBefore.end).length() /
+      QLineF(lineStartScreen, lineEndScreen).length();
+  const QPointF rawLineEndScreen(620, 500);
+  const QPointF rawLineEnd =
+      lineBefore.start +
+      (rawLineEndScreen - lineStartScreen) * lineScreenScale;
+  const QPointF expectedLineEnd = constrainedCreationEndpoint(
+      CaptureEditor::Tool::Line, lineBefore.start, rawLineEnd);
+  const int beforeShiftLineResize = editor.operationIndex();
+  QTest::keyPress(&editor, Qt::Key_Shift);
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::ShiftModifier,
+                    lineEndScreen.toPoint());
+  QTest::mouseMove(&editor, rawLineEndScreen.toPoint(), 20);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::ShiftModifier,
+                      rawLineEndScreen.toPoint());
+  QTest::keyRelease(&editor, Qt::Key_Shift);
+  application.processEvents();
+  if (editor.operationIndex() != beforeShiftLineResize + 1 ||
+      editor.operationLog().constLast().annotations.size() != 1) {
+    error = QStringLiteral("Pre-held Shift did not resize the line endpoint");
+    return false;
+  }
+  const Annotation snappedLine =
+      editor.operationLog().constLast().annotations.constFirst();
+  if (snappedLine.start != lineBefore.start ||
+      QLineF(snappedLine.end, expectedLineEnd).length() > 1.5) {
+    error = QStringLiteral("Pre-held Shift did not snap the line endpoint");
+    return false;
+  }
+
+  QTemporaryDir directory;
+  if (!directory.isValid()) {
+    error = QStringLiteral("Could not create arrow log directory");
+    return false;
+  }
+  OperationLog saved;
+  saved.ops = editor.operationLog();
+  saved.index = editor.operationIndex();
+  saved.previewSize = capture.previewSize;
+  const QString path =
+      QDir(directory.path()).filePath(QStringLiteral("arrows.json"));
+  if (!saveOperationLog(path, saved, error))
+    return false;
+  OperationLog loaded;
+  if (!loadOperationLog(path, loaded, error) || loaded.ops != saved.ops) {
+    error = QStringLiteral("Arrow state did not survive operation-log reload");
+    return false;
+  }
+  const bool loadedCurve = std::ranges::any_of(
+      loaded.ops, [](const Operation &operation) {
+        return std::ranges::any_of(
+            operation.annotations, [](const Annotation &annotation) {
+              return annotation.kind == Annotation::Kind::Arrow &&
+                     annotation.curveControl.has_value();
+            });
+      });
+  if (!loadedCurve) {
+    error = QStringLiteral("Custom arrow curve was missing after log reload");
+    return false;
+  }
+  editor.close();
+  application.processEvents();
+
+  // A mixed multi-selection applies one common next style to every arrow,
+  // leaves non-arrows alone, and records the whole restyle as one undo step.
+  Annotation firstArrow;
+  firstArrow.kind = Annotation::Kind::Arrow;
+  firstArrow.start = {100, 180};
+  firstArrow.end = {300, 180};
+  firstArrow.color = QColor(QStringLiteral("#ff375f"));
+  firstArrow.size = 5;
+  firstArrow.id = 1;
+  Annotation secondArrow = firstArrow;
+  secondArrow.start = {380, 300};
+  secondArrow.end = {650, 300};
+  secondArrow.color = QColor(QStringLiteral("#64d2ff"));
+  secondArrow.id = 2;
+  Annotation rectangle;
+  rectangle.kind = Annotation::Kind::Rectangle;
+  rectangle.start = {330, 90};
+  rectangle.end = {460, 150};
+  rectangle.color = QColor(QStringLiteral("#30d158"));
+  rectangle.size = 4;
+  rectangle.id = 3;
+
+  OperationLog groupLog;
+  for (const Annotation &annotation :
+       {firstArrow, secondArrow, rectangle}) {
+    Operation annotate;
+    annotate.type = Operation::Type::Annotate;
+    annotate.annotations = {annotation};
+    groupLog.ops.push_back(std::move(annotate));
+  }
+  groupLog.index = static_cast<int>(groupLog.ops.size());
+  groupLog.nextId = 4;
+  groupLog.previewSize = capture.previewSize;
+  CaptureEditor groupEditor(capture, CaptureEditor::CaptureMode::Fullscreen,
+                            QuickOutputMode::None, groupLog);
+  groupEditor.setSuppressSnapshots(true);
+  groupEditor.resize(800, 600);
+  groupEditor.show();
+  application.processEvents();
+  const QImage beforeGroupRestyle = groupEditor.renderCurrentOutput();
+  QTest::keyClick(&groupEditor, Qt::Key_A, Qt::ControlModifier);
+  QTest::keyClick(&groupEditor, Qt::Key_A); // arm Arrow
+  const int beforeGroupPatch = groupEditor.operationIndex();
+  QTest::keyClick(&groupEditor, Qt::Key_A); // cycle the selection
+  application.processEvents();
+  if (groupEditor.operationIndex() != beforeGroupPatch + 1 ||
+      groupEditor.operationLog().constLast().type != Operation::Type::Patch ||
+      groupEditor.operationLog().constLast().annotations.size() != 2 ||
+      !std::ranges::all_of(
+          groupEditor.operationLog().constLast().annotations,
+          [](const Annotation &annotation) {
+            return annotation.kind == Annotation::Kind::Arrow &&
+                   annotation.arrowStyle == ArrowStyle::Pointy;
+          })) {
+    error =
+        QStringLiteral("Repeated A did not restyle selected arrows in one patch");
+    return false;
+  }
+  const QImage afterGroupRestyle = groupEditor.renderCurrentOutput();
+  if (afterGroupRestyle == beforeGroupRestyle) {
+    error = QStringLiteral("Multi-arrow restyle did not change the output");
+    return false;
+  }
+  QTest::keyClick(&groupEditor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (groupEditor.operationIndex() != beforeGroupPatch ||
+      groupEditor.renderCurrentOutput() != beforeGroupRestyle) {
+    error = QStringLiteral("One undo did not restore a multi-arrow restyle");
+    return false;
+  }
+  QTest::keyClick(&groupEditor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  if (groupEditor.operationIndex() != beforeGroupPatch + 1 ||
+      groupEditor.renderCurrentOutput() != afterGroupRestyle) {
+    error = QStringLiteral("Redo did not restore a multi-arrow restyle");
+    return false;
+  }
+  groupEditor.close();
+  return true;
+}
+
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -7558,6 +8204,10 @@ int main(int argc, char **argv) {
   if (!runTextAwareHighlighterEditorCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 129;
+  }
+  if (!runArrowStyleSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 203;
   }
   if (!runSecureRedactionChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7510,6 +7510,21 @@ bool runArrowStyleSmoke(QApplication &application, QString &error) {
       }
     }
   }
+  for (const ArrowStyle style : styles) {
+    Annotation collapsed;
+    collapsed.kind = Annotation::Kind::Arrow;
+    collapsed.arrowStyle = style;
+    collapsed.start = {80, 50};
+    collapsed.end = {80.5, 50};
+    for (const CanvasBoundaryMode boundary :
+         {CanvasBoundaryMode::Framed, CanvasBoundaryMode::Overflow}) {
+      if (captureCanvasRect(QSizeF(200, 100), {collapsed}, boundary) !=
+          QRectF(0, 0, 200, 100)) {
+        error = QStringLiteral("An invisible collapsed arrow grew the canvas");
+        return false;
+      }
+    }
+  }
   const auto exactArrowIcon = [](ArrowStyle style) {
     QImage image(36, 36, QImage::Format_ARGB32_Premultiplied);
     image.fill(Qt::transparent);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7480,6 +7480,36 @@ bool runArrowStyleSmoke(QApplication &application, QString &error) {
   const std::array<ArrowStyle, 4> styles{ArrowStyle::Standard,
                                          ArrowStyle::Pointy, ArrowStyle::Curved,
                                          ArrowStyle::Double};
+  // Canvas growth must include the real arc and heads, including controls
+  // far outside the source and endpoint-degenerate tangents.
+  for (const ArrowStyle style : styles) {
+    Annotation edge;
+    edge.kind = Annotation::Kind::Arrow;
+    edge.start = {10, 20};
+    edge.end = {190, 20};
+    edge.size = 12;
+    edge.arrowStyle = style;
+    edge.curveControl = QPointF(100, -180);
+    const QRectF visual = arrowVisualBounds(edge);
+    if (!captureCanvasRect(QSizeF(200, 100), {edge}).contains(visual)) {
+      error = QStringLiteral("Canvas clipped styled arrow geometry");
+      return false;
+    }
+    if (style == ArrowStyle::Curved || style == ArrowStyle::Double) {
+      edge.curveControl = edge.end;
+      if (arrowVisualBounds(edge).height() < 10) {
+        error = QStringLiteral("Endpoint control removed the arrow head");
+        return false;
+      }
+      if (style == ArrowStyle::Double) {
+        edge.curveControl = edge.start;
+        if (arrowVisualBounds(edge).height() < 10) {
+          error = QStringLiteral("Endpoint control removed the double head");
+          return false;
+        }
+      }
+    }
+  }
   const auto exactArrowIcon = [](ArrowStyle style) {
     QImage image(36, 36, QImage::Format_ARGB32_Premultiplied);
     image.fill(Qt::transparent);


### PR DESCRIPTION
The arrow tool now includes Standard, Pointy, Curved, and Double styles. Repeatedly pressing `A` cycles them, and the toolbar icon mirrors the active arrow geometry.

Selected arrows can be restyled the same way. Endpoint edits honor a pre-held `Shift` for 45° snapping, while `Shift` keeps curved-arrow bends centered.

![The four arrow styles](https://github.com/user-attachments/assets/f2c48ff6-e5bd-4435-97bb-62c53f255593)

Tested with `make check`.
