### PR TITLE
feat(editor): snap highlights to text

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ add_library(omasnap-core STATIC
   src/surface-capture.cpp
   src/stitch.cpp
   src/stitch.hpp
+  src/text-band.cpp
+  src/text-band.hpp
   src/auto-capture.cpp
   src/auto-capture.hpp
   src/scroll-capture.cpp

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Window capture is a crop of the focused-monitor frame. Overlapping windows stay
   visible; there is no second clean-window recapture.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
-- Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
-  hollow or filled rectangles (optionally rounded) and ellipses, numbered markers,
-  editable Neucha text (on a readability pill), and secure redaction with opaque or
-  randomized non-spatial mosaic output.
+- Arrows, straight lines, smoothed freehand strokes, and translucent highlighter
+  strokes that automatically match and stay straight across screenshot text (with
+  freehand fallback), plus hollow or filled rectangles (optionally rounded) and
+  ellipses, numbered markers, editable Neucha text (on a readability pill), and
+  secure redaction with opaque or randomized non-spatial mosaic output.
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   one-click whole-image or drag-region OCR (the recognized text is shown beside
   the image and copied to the clipboard),
@@ -331,6 +332,7 @@ without reaching for the pointer.
 | `S` | Spotlight/loupe; press again to cycle ellipse, rectangle, rounded |
 | `L` | Straight line |
 | `F` | Freehand stroke |
+| `H` | Highlighter; Snap mode uses a mouse-following I-beam at the nearby text height, then locks the drag straight to that row. Press `H` again (or click the active toolbar button) for Normal freehand mode, where wheel or `Alt`+wheel changes thickness; Snap keeps detected-row height automatic and wheel sets only its off-text fallback |
 | `I` | Eyedropper in the color popover · sample the image as the custom color |
 | `C` | Numbered marker |
 | `R` | Rectangle; hover the shape button for rectangle, ellipse, and fill controls; `Alt`+wheel rounds corners |

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -11,6 +11,7 @@
 #include "recent-snaps.hpp"
 #include "scroll-capture.hpp"
 #include "startup-timing.hpp"
+#include "text-band.hpp"
 
 #include <QtConcurrent/QtConcurrentRun>
 
@@ -76,6 +77,54 @@ constexpr qreal kToolbarImageGap = 18.0;
 constexpr qreal kTabToolbarGap = 8.0;
 constexpr qreal kMinimumRedactionExtent = 5.0;
 constexpr int kBackdropDim = 143;
+
+qreal highlighterPreviewHeight(qreal annotationSize) {
+  return std::max<qreal>(6.0, annotationSize * 3.0);
+}
+
+QRectF highlighterIBeamBounds(const QPointF &center, qreal height,
+                              qreal scale) {
+  const qreal safeScale = std::max<qreal>(scale, 0.01);
+  const qreal serifHalfWidth =
+      std::clamp(height * 0.18, 5.0 / safeScale, 9.0 / safeScale);
+  return {center.x() - serifHalfWidth, center.y() - height / 2.0,
+          serifHalfWidth * 2.0, height};
+}
+
+void paintHighlighterIBeam(QPainter &painter, const QPointF &center,
+                           qreal height, qreal scale) {
+  const qreal safeScale = std::max<qreal>(scale, 0.01);
+  const QRectF bounds = highlighterIBeamBounds(center, height, safeScale);
+  const qreal spineHalfWidth = 1.5 / safeScale;
+  const qreal serifHeight = std::min(
+      height / 2.0,
+      std::clamp(height * 0.08, 2.0 / safeScale, 4.0 / safeScale));
+  const qreal innerTop = bounds.top() + serifHeight;
+  const qreal innerBottom = bounds.bottom() - serifHeight;
+
+  QPainterPath beam;
+  beam.moveTo(bounds.topLeft());
+  beam.lineTo(bounds.topRight());
+  beam.lineTo(bounds.right(), innerTop);
+  beam.lineTo(center.x() + spineHalfWidth, innerTop);
+  beam.lineTo(center.x() + spineHalfWidth, innerBottom);
+  beam.lineTo(bounds.right(), innerBottom);
+  beam.lineTo(bounds.bottomRight());
+  beam.lineTo(bounds.bottomLeft());
+  beam.lineTo(bounds.left(), innerBottom);
+  beam.lineTo(center.x() - spineHalfWidth, innerBottom);
+  beam.lineTo(center.x() - spineHalfWidth, innerTop);
+  beam.lineTo(bounds.left(), innerTop);
+  beam.closeSubpath();
+
+  painter.save();
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  painter.setBrush(QColor(255, 255, 255, 242));
+  painter.setPen(QPen(QColor(0, 0, 0, 217), 1.6 / safeScale,
+                      Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin));
+  painter.drawPath(beam);
+  painter.restore();
+}
 
 /// Beside the snapshots and the instance lock, in the private runtime dir.
 /// Session scratch, not configuration: gone at reboot, and a region only
@@ -1106,6 +1155,41 @@ void CaptureEditor::applyBoxResize(Annotation &annotation, Interaction handle,
   annotation.end = box.bottomRight();
 }
 
+QString CaptureEditor::highlighterStatus() const {
+  if (highlighterMode_ == HighlighterMode::Snap) {
+    return QStringLiteral("Highlighter · Snap · text height automatic · wheel "
+                          "sets off-text size %1 · H toggles Normal")
+        .arg(qRound(annotationSize_));
+  }
+  return QStringLiteral("Highlighter · Normal · freehand size %1 · wheel / "
+                        "Alt+wheel resizes · H toggles Snap")
+      .arg(qRound(annotationSize_));
+}
+
+QString CaptureEditor::highlighterTooltip() const {
+  if (highlighterMode_ == HighlighterMode::Snap) {
+    return QStringLiteral("Highlighter · Snap · text height automatic · wheel "
+                          "sets off-text size %1 · H / click again: Normal")
+        .arg(qRound(annotationSize_));
+  }
+  return QStringLiteral("Highlighter · Normal · freehand · size %1 · wheel / "
+                        "Alt+wheel · H / click again: Snap")
+      .arg(qRound(annotationSize_));
+}
+
+void CaptureEditor::activateHighlighter() {
+  if (tool_ == Tool::Highlighter) {
+    highlighterMode_ = highlighterMode_ == HighlighterMode::Snap
+                           ? HighlighterMode::Normal
+                           : HighlighterMode::Snap;
+  } else {
+    tool_ = Tool::Highlighter;
+  }
+  highlighterLock_.reset();
+  highlighterPreview_.reset();
+  setStatus(highlighterStatus());
+}
+
 QString CaptureEditor::toolStatus() const {
   const int size = qRound(annotationSize_);
   switch (tool_) {
@@ -1156,10 +1240,11 @@ QString CaptureEditor::toolStatus() const {
         .arg(size);
   case Tool::Cut:
     return QStringLiteral("Cut · drag a band to remove it");
+  case Tool::Highlighter:
+    return highlighterStatus();
   case Tool::Arrow:
   case Tool::Line:
   case Tool::Freehand:
-  case Tool::Highlighter:
     break;
   }
   const QString name = tool_ == Tool::Arrow      ? QStringLiteral("Arrow")
@@ -1841,6 +1926,54 @@ QPointF CaptureEditor::sourcePoint(const QPointF &logicalPoint) const {
   return sourceRect(QRectF(logicalPoint, QSizeF())).topLeft();
 }
 
+std::optional<CaptureEditor::HighlighterLock>
+CaptureEditor::highlighterLockAt(const QPointF &annotationPoint) const {
+  if (capture_.source.isNull() || capture_.previewSize.isEmpty() ||
+      !QRectF(QPointF(), selection_.size()).contains(annotationPoint))
+    return std::nullopt;
+
+  const QSizeF sourceScale(
+      capture_.source.width() /
+          static_cast<qreal>(capture_.previewSize.width()),
+      capture_.source.height() /
+          static_cast<qreal>(capture_.previewSize.height()));
+  const QPointF logicalPoint = selection_.topLeft() + annotationPoint;
+  const auto band =
+      detectTextBand(capture_.source, sourcePoint(logicalPoint), sourceScale);
+  if (!band)
+    return std::nullopt;
+
+  // Match the text-band padding used for the committed stroke. Keeping this
+  // in one helper makes the hover I-beam and mouse-down lock identical.
+  constexpr qreal padPerSide = 0.05;
+  const qreal centerY =
+      band->center() / sourceScale.height() - selection_.top();
+  const qreal highlightedHeight =
+      band->height() * (1.0 + 2.0 * padPerSide) / sourceScale.height();
+  return HighlighterLock{std::clamp(centerY, 0.0, selection_.height()),
+                         highlightedHeight / 3.0};
+}
+
+QRectF CaptureEditor::highlighterPreviewRectForTest() const {
+  if (!highlighterPreview_)
+    return {};
+  const qreal height =
+      highlighterPreviewHeight(highlighterPreview_->annotationSize);
+  const QPointF pointer = toAnnotationPoint(cursor_);
+  const QPointF center(pointer.x(), dragging_ && highlighterLock_
+                                        ? highlighterPreview_->centerY
+                                        : pointer.y());
+  return highlighterIBeamBounds(center, height, editScale());
+}
+
+QRectF CaptureEditor::highlighterToolbarRectForTest() const {
+  for (const ToolbarButton &button : toolbarButtons()) {
+    if (button.action == QStringLiteral("tool-highlighter"))
+      return button.rect;
+  }
+  return {};
+}
+
 QRectF CaptureEditor::mapWidgetToPreview(const QRectF &widgetRect) const {
   const QSize widget = size();
   const QSize preview = capture_.previewSize;
@@ -1963,9 +2096,7 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(36, QStringLiteral("tool-freehand"), {},
       QStringLiteral("Freehand · F · Size %1 · Wheel")
           .arg(qRound(annotationSize_)));
-  add(36, QStringLiteral("tool-highlighter"), {},
-      QStringLiteral("Highlighter · H · Size %1 · Wheel")
-          .arg(qRound(annotationSize_)));
+  add(36, QStringLiteral("tool-highlighter"), {}, highlighterTooltip());
   add(36, QStringLiteral("tool-marker"), {},
       QStringLiteral("Number marker · C · Size %1 · Wheel")
           .arg(qRound(annotationSize_)));
@@ -2079,6 +2210,7 @@ void CaptureEditor::applyEditState(const EditState &state) {
   editingAnnotation_ = -1;
   interaction_ = Interaction::None;
   freehandPoints_.clear();
+  highlighterLock_.reset();
   if (textEditor_) {
     textEditor_->clear();
     textEditor_->hide();
@@ -2100,6 +2232,7 @@ void CaptureEditor::cancelActiveDragForHistory() {
   dragStartStateValid_ = false;
   dragChanged_ = false;
   freehandPoints_.clear();
+  highlighterLock_.reset();
   if (cutDragActive_) {
     cutDragActive_ = false;
     refreshComposedCapture();
@@ -2591,6 +2724,7 @@ void CaptureEditor::handleEscape() {
   colorPaletteOpen_ = false;
   customColorPickerOpen_ = false;
   freehandPoints_.clear();
+  highlighterLock_.reset();
   tool_ = Tool::Select;
   setStatus(QStringLiteral("Select/move · Esc again to close"));
   setFocus(Qt::OtherFocusReason);
@@ -3046,7 +3180,7 @@ void CaptureEditor::handleToolbar(const QString &action) {
   else if (action == QStringLiteral("tool-freehand"))
     tool_ = Tool::Freehand;
   else if (action == QStringLiteral("tool-highlighter"))
-    tool_ = Tool::Highlighter;
+    activateHighlighter();
   else if (action == QStringLiteral("tool-marker"))
     tool_ = Tool::Marker;
   else if (action == QStringLiteral("tool-rectangle") ||
@@ -3392,7 +3526,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if (event->key() == Qt::Key_F) {
     tool_ = Tool::Freehand;
   } else if (event->key() == Qt::Key_H) {
-    tool_ = Tool::Highlighter;
+    activateHighlighter();
   } else if (event->key() == Qt::Key_C || event->key() == Qt::Key_M) {
     tool_ = Tool::Marker;
   } else if (event->key() == Qt::Key_R || event->key() == Qt::Key_E) {
@@ -3518,6 +3652,12 @@ void CaptureEditor::keyReleaseEvent(QKeyEvent *event) {
     return;
   }
   QWidget::keyReleaseEvent(event);
+}
+
+void CaptureEditor::leaveEvent(QEvent *event) {
+  highlighterPreview_.reset();
+  QWidget::leaveEvent(event);
+  update();
 }
 
 void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
@@ -3734,7 +3874,9 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
     }
     if ((tool_ == Tool::Freehand || tool_ == Tool::Highlighter) && dragging_ &&
         interaction_ == Interaction::None) {
-      const QPointF point = toAnnotationPoint(cursor_);
+      QPointF point = toAnnotationPoint(cursor_);
+      if (tool_ == Tool::Highlighter && highlighterLock_)
+        point.setY(highlighterLock_->centerY);
       if (freehandPoints_.isEmpty() ||
           QLineF(freehandPoints_.last(), point).length() >= 1.5)
         freehandPoints_.push_back(point);
@@ -4161,7 +4303,16 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
       freehandPoints_.clear();
       freehandPoints_.reserve(256);
-      freehandPoints_.push_back(point);
+      highlighterLock_.reset();
+      QPointF strokeStart = point;
+      if (tool_ == Tool::Highlighter &&
+          highlighterMode_ == HighlighterMode::Snap)
+        highlighterLock_ = highlighterLockAt(point);
+      if (highlighterLock_)
+        strokeStart.setY(highlighterLock_->centerY);
+      freehandPoints_.push_back(strokeStart);
+      if (tool_ == Tool::Highlighter)
+        updatePointerCursor();
     }
   }
   update();
@@ -4303,7 +4454,9 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
 
   const QLineF span = creationSpan(toAnnotationPoint(event->position()));
   const QPointF start = span.p1();
-  const QPointF end = span.p2();
+  QPointF end = span.p2();
+  if (tool_ == Tool::Highlighter && highlighterLock_)
+    end.setY(highlighterLock_->centerY);
   creationConstraintActive_ = false;
   creationCenteredActive_ = false;
   if (tool_ == Tool::Freehand || tool_ == Tool::Highlighter) {
@@ -4322,16 +4475,18 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
       annotation.start = freehandPoints_.first();
       annotation.end = freehandPoints_.last();
       annotation.color = annotationColor();
-      annotation.size = annotationSize_;
+      annotation.size = highlighter && highlighterLock_
+                            ? highlighterLock_->annotationSize
+                            : annotationSize_;
       annotation.points = std::move(freehandPoints_);
       selectedAnnotation_ = -1;
-      setStatus(
-          highlighter
-              ? QStringLiteral("Highlight added · Esc for select mode")
-              : QStringLiteral("Stroke added · Esc for select mode"));
+      setStatus(highlighter ? highlighterStatus()
+                            : QStringLiteral("Stroke added · Esc for select "
+                                             "mode"));
       commitAnnotate(std::move(annotation));
     }
     freehandPoints_.clear();
+    highlighterLock_.reset();
     dragging_ = false;
     updatePointerCursor();
     update();
@@ -4565,8 +4720,10 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
              tool_ == Tool::Marker || tool_ == Tool::Rectangle ||
              tool_ == Tool::Ellipse) {
     annotationSize_ = std::clamp(annotationSize_ + step, 2.0, 12.0);
-    setStatus(QStringLiteral("Size %1 · mouse wheel changes size")
-                  .arg(qRound(annotationSize_)));
+    setStatus(tool_ == Tool::Highlighter
+                  ? highlighterStatus()
+                  : QStringLiteral("Size %1 · mouse wheel changes size")
+                        .arg(qRound(annotationSize_)));
   } else {
     QWidget::wheelEvent(event);
     return;
@@ -4576,6 +4733,7 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
 }
 
 void CaptureEditor::updatePointerCursor() {
+  highlighterPreview_.reset();
   if (phase_ == Phase::Export) {
     setCursor(Qt::WaitCursor);
     return;
@@ -4642,6 +4800,18 @@ void CaptureEditor::updatePointerCursor() {
     setCursor(Qt::IBeamCursor);
   else if (tool_ == Tool::Cut)
     setCursor(Qt::CrossCursor);
+  else if (tool_ == Tool::Highlighter) {
+    if (highlighterMode_ == HighlighterMode::Snap) {
+      highlighterPreview_ =
+          dragging_ ? highlighterLock_
+                    : editImageRect().contains(cursor_)
+                          ? highlighterLockAt(toAnnotationPoint(cursor_))
+                          : std::nullopt;
+    }
+    // Qt's stock I-beam has a fixed text-editor height. Paint the measured
+    // one ourselves so its serifs span exactly the row the stroke will lock.
+    setCursor(highlighterPreview_ ? Qt::BlankCursor : Qt::CrossCursor);
+  }
   else
     setCursor(Qt::CrossCursor);
 }
@@ -5486,10 +5656,12 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     preview.color = tool_ == Tool::Ocr ? QColor(Qt::white) : annotationColor();
     if (tool_ == Tool::Text)
       preview.color.setAlpha(150);
-    preview.size = tool_ == Tool::Ocr          ? 2.0
+    preview.size = tool_ == Tool::Ocr         ? 2.0
                    : tool_ == Tool::Text      ? 1.0
                    : tool_ == Tool::Spotlight ? spotlightBorder_
-                                              : annotationSize_;
+                   : tool_ == Tool::Highlighter && highlighterLock_
+                       ? highlighterLock_->annotationSize
+                       : annotationSize_;
     defaultAnnotations.push_back(std::move(preview));
   } else if (tool_ == Tool::Marker && image.contains(cursor_) && !dragging_ &&
              !pointerGrabsLayer()) {
@@ -5515,6 +5687,16 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       paintAnnotation(painter, annotation);
   }
   painter.restore();
+  if (highlighterPreview_) {
+    const qreal height =
+        highlighterPreviewHeight(highlighterPreview_->annotationSize);
+    const QPointF pointer = toAnnotationPoint(cursor_);
+    paintHighlighterIBeam(
+        painter, QPointF(pointer.x(), dragging_ && highlighterLock_
+                                          ? highlighterPreview_->centerY
+                                          : pointer.y()),
+        height, editScale());
+  }
   if (tool_ == Tool::Select && marqueeSelecting_ &&
       !marqueeRect_.isEmpty()) {
     const qreal scale = std::max<qreal>(editScale(), 0.01);
@@ -5828,6 +6010,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         } else if (tool_ == Tool::Redact) {
           tooltip = QStringLiteral("Redact · %1 · D toggles style")
                         .arg(redactionStyleName(redactionStyle_));
+        } else if (tool_ == Tool::Highlighter) {
+          tooltip = highlighterTooltip();
         } else if (tool_ == Tool::Rectangle) {
           tooltip = QStringLiteral("Rectangle · %1 · Size %2 · Scroll wheel · "
                                    "Alt+Wheel %3")

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -109,6 +109,7 @@ protected:
   bool eventFilter(QObject *watched, QEvent *event) override;
   void keyPressEvent(QKeyEvent *event) override;
   void keyReleaseEvent(QKeyEvent *event) override;
+  void leaveEvent(QEvent *event) override;
   void mouseMoveEvent(QMouseEvent *event) override;
   void mouseDoubleClickEvent(QMouseEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;
@@ -137,6 +138,7 @@ public:
 private:
   enum class Phase { Select, Export, Edit };
   enum class OutputMode { Copy, Save, Both };
+  enum class HighlighterMode { Snap, Normal };
 public:
   enum class Interaction {
     None,
@@ -274,6 +276,16 @@ public:
   }
   /// Current status line. Test accessor.
   [[nodiscard]] QString statusForTest() const { return status_; }
+  /// Text-height I-beam in annotation coordinates, or an empty rect when the
+  /// Snap highlighter has no text row near the pointer. Test accessor.
+  [[nodiscard]] QRectF highlighterPreviewRectForTest() const;
+  /// Whether the highlighter is in its default text-row snapping mode.
+  [[nodiscard]] bool highlighterSnapModeForTest() const {
+    return highlighterMode_ == HighlighterMode::Snap;
+  }
+  /// Active highlighter button geometry. Test accessor for repeated-tool
+  /// behavior without duplicating the responsive toolbar layout.
+  [[nodiscard]] QRectF highlighterToolbarRectForTest() const;
   /// Whether the selection chrome is currently stepped back for an adjustment.
   /// Test accessor.
   [[nodiscard]] bool selectionFadedForTest() const {
@@ -330,6 +342,9 @@ private:
   /// What the armed tool is currently set to, for the status line: shown on
   /// arming so its options are discoverable without trying them.
   [[nodiscard]] QString toolStatus() const;
+  [[nodiscard]] QString highlighterStatus() const;
+  [[nodiscard]] QString highlighterTooltip() const;
+  void activateHighlighter();
   [[nodiscard]] int annotationAt(const QPointF &point) const;
   /// Whether the armed tool picks a layer up rather than working over it.
   /// Moves a layer to the top of the stack, remapping every index that
@@ -560,6 +575,20 @@ private:
   bool resizeConstraintActive_ = false;
   Interaction interaction_ = Interaction::None;
   QVector<QPointF> freehandPoints_;
+  struct HighlighterLock {
+    qreal centerY = 0.0;
+    qreal annotationSize = 0.0;
+  };
+  [[nodiscard]] std::optional<HighlighterLock>
+  highlighterLockAt(const QPointF &annotationPoint) const;
+  /// Set when a highlighter drag begins near a detected screenshot text row.
+  /// Coordinates and size are selection-relative logical pixels, so the lock
+  /// survives view zoom and native/fractional monitor scaling.
+  std::optional<HighlighterLock> highlighterLock_;
+  /// Detected row supplying the Snap cursor's height. Before mouse-down its
+  /// center follows the pointer; during a locked drag it follows the row.
+  std::optional<HighlighterLock> highlighterPreview_;
+  HighlighterMode highlighterMode_ = HighlighterMode::Snap;
   // Cut tool live-drag state. cutDragStart_/cutBandLo_/cutBandHi_ and
   // liveCut_.orientation are in annotation space (selection-relative logical
   // px); the source stays untouched while a shaded removal band previews the

--- a/src/text-band.cpp
+++ b/src/text-band.cpp
@@ -1,0 +1,173 @@
+#include "text-band.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+#include <QImage>
+#include <QPointF>
+#include <QSizeF>
+#include <QtCore/qnumeric.h>
+#include <QtCore/qtypes.h>
+#include <QtGui/qrgb.h>
+
+namespace {
+constexpr qreal kHorizontalRadius = 96.0;
+constexpr qreal kSnapDistance = 20.0;
+constexpr qreal kMaximumTextHeight = 64.0;
+constexpr qreal kMinimumTextHeight = 5.0;
+// Bowl-shaped glyphs can have quiet antialiased rows between edge runs. Merge
+// gaps up to six logical pixels so one text line stays one band.
+constexpr qreal kVerticalMergeGap = 6.0;
+constexpr qreal kEdgeDensity = 0.035;
+
+int scaledPixels(qreal logicalPixels, qreal scale) {
+  return std::max(1, qRound(logicalPixels * std::max<qreal>(scale, 0.01)));
+}
+
+int colorDistance(QRgb first, QRgb second) {
+  // Luminance-only edges miss colored text whose perceived brightness is
+  // close to its background. The strongest RGB channel remains cheap and
+  // catches those glyph edges without caring whether the theme is light or
+  // dark.
+  return std::max({std::abs(qRed(first) - qRed(second)),
+                   std::abs(qGreen(first) - qGreen(second)),
+                   std::abs(qBlue(first) - qBlue(second))});
+}
+} // namespace
+
+std::optional<TextBand>
+detectTextBand(const QImage &source, const QPointF &sourcePoint,
+               const QSizeF &sourcePixelsPerLogicalPixel) {
+  if (source.isNull() ||
+      !QRectF(QPointF(), QSizeF(source.size())).contains(sourcePoint))
+    return std::nullopt;
+
+  const qreal scaleX =
+      std::max<qreal>(sourcePixelsPerLogicalPixel.width(), 0.01);
+  const qreal scaleY =
+      std::max<qreal>(sourcePixelsPerLogicalPixel.height(), 0.01);
+  const int edgeReach = scaledPixels(2.0, scaleX);
+  const int columnStep = scaledPixels(2.0, scaleX);
+  const int halfWidth = scaledPixels(kHorizontalRadius, scaleX);
+  const int snapRows = scaledPixels(kSnapDistance, scaleY);
+  const int minimumBandHeight = scaledPixels(kMinimumTextHeight, scaleY);
+  const int maximumBandHeight = scaledPixels(kMaximumTextHeight, scaleY);
+  const int mergeGap = scaledPixels(kVerticalMergeGap, scaleY);
+  const int halfHeight = snapRows + maximumBandHeight;
+
+  // QRectF accepts sub-pixel points just inside the bottom/right edge, while
+  // rounding those can land exactly one pixel past the image.
+  const int centerX =
+      std::clamp(qRound(sourcePoint.x()), 0, source.width() - 1);
+  const int centerY =
+      std::clamp(qRound(sourcePoint.y()), 0, source.height() - 1);
+  const int x0 = std::max(0, centerX - halfWidth);
+  const int x1 = std::min(source.width() - 1 - edgeReach, centerX + halfWidth);
+  const int y0 = std::max(0, centerY - halfHeight);
+  const int y1 = std::min(source.height() - 1, centerY + halfHeight);
+  if (x1 < x0 || y1 < y0)
+    return std::nullopt;
+
+  std::vector<int> columns;
+  const auto columnCapacity =
+      static_cast<std::size_t>(x1 - x0) / static_cast<std::size_t>(columnStep) +
+      1;
+  columns.reserve(columnCapacity);
+  for (int x = x0; x <= x1; x += columnStep)
+    columns.push_back(x);
+  if (columns.size() < 8)
+    return std::nullopt;
+
+  std::vector<bool> textRows(static_cast<std::size_t>(y1 - y0 + 1), false);
+  std::vector<int> deltas(columns.size());
+  const int minimumEdges =
+      std::max(3, static_cast<int>(std::ceil(
+                      static_cast<qreal>(columns.size()) * kEdgeDensity)));
+  for (int y = y0; y <= y1; ++y) {
+    for (std::size_t index = 0; index < columns.size(); ++index) {
+      const int x = columns[index];
+      deltas[index] =
+          colorDistance(source.pixel(x, y), source.pixel(x + edgeReach, y));
+    }
+
+    // Screenshot pixels are normally lossless, but images opened from files
+    // can carry compression noise. Estimate that row's noise floor from the
+    // median edge magnitude, then demand a visibly stronger transition. The
+    // cap still recognizes subdued UI text; a lone panel/button boundary
+    // cannot satisfy the density requirement by itself.
+    const auto middle =
+        deltas.begin() + static_cast<std::ptrdiff_t>(deltas.size() / 2);
+    std::nth_element(deltas.begin(), middle, deltas.end());
+    const int edgeThreshold = std::clamp(*middle + 10, 12, 24);
+    const int edgeCount = static_cast<int>(std::count_if(
+        deltas.cbegin(), deltas.cend(),
+        [edgeThreshold](int delta) { return delta >= edgeThreshold; }));
+    textRows[static_cast<std::size_t>(y - y0)] = edgeCount >= minimumEdges;
+  }
+
+  const int centerIndex = centerY - y0;
+  std::optional<int> anchor;
+  if (textRows[static_cast<std::size_t>(centerIndex)]) {
+    anchor = centerIndex;
+  } else {
+    for (int distance = 1; distance <= snapRows; ++distance) {
+      const int above = centerIndex - distance;
+      const int below = centerIndex + distance;
+      if (above >= 0 && textRows[static_cast<std::size_t>(above)]) {
+        anchor = above;
+        break;
+      }
+      if (below < static_cast<int>(textRows.size()) &&
+          textRows[static_cast<std::size_t>(below)]) {
+        anchor = below;
+        break;
+      }
+    }
+  }
+  if (!anchor)
+    return std::nullopt;
+
+  int top = *anchor;
+  int gap = 0;
+  while (top > 0) {
+    const int next = top - 1;
+    if (textRows[static_cast<std::size_t>(next)]) {
+      top = next;
+      gap = 0;
+    } else if (gap < mergeGap) {
+      top = next;
+      ++gap;
+    } else {
+      break;
+    }
+  }
+  while (top < static_cast<int>(textRows.size()) &&
+         !textRows[static_cast<std::size_t>(top)])
+    ++top;
+
+  int bottom = *anchor;
+  gap = 0;
+  while (bottom + 1 < static_cast<int>(textRows.size())) {
+    const int next = bottom + 1;
+    if (textRows[static_cast<std::size_t>(next)]) {
+      bottom = next;
+      gap = 0;
+    } else if (gap < mergeGap) {
+      bottom = next;
+      ++gap;
+    } else {
+      break;
+    }
+  }
+  while (bottom >= 0 && !textRows[static_cast<std::size_t>(bottom)])
+    --bottom;
+
+  const int height = bottom - top + 1;
+  if (height < minimumBandHeight || height > maximumBandHeight)
+    return std::nullopt;
+  return TextBand{static_cast<qreal>(y0 + top),
+                  static_cast<qreal>(y0 + bottom + 1)};
+}

--- a/src/text-band.hpp
+++ b/src/text-band.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <optional>
+
+#include <QImage>
+#include <QPointF>
+#include <QSizeF>
+#include <QtCore/qtypes.h>
+
+/** A half-open horizontal text band in native source-image pixels. */
+class TextBand {
+public:
+  // Half-open edges are deliberately passed together and named at every call.
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  TextBand(qreal top, qreal bottom) : top_(top), bottom_(bottom) {}
+
+  [[nodiscard]] qreal top() const { return top_; }
+  [[nodiscard]] qreal bottom() const { return bottom_; }
+  [[nodiscard]] qreal center() const { return (top_ + bottom_) / 2.0; }
+  [[nodiscard]] qreal height() const { return bottom_ - top_; }
+
+  bool operator==(const TextBand &) const = default;
+
+private:
+  qreal top_ = 0.0;
+  qreal bottom_ = 0.0;
+};
+
+/**
+ * Detects the text row nearest `sourcePoint` in a small source-image window.
+ *
+ * `sourcePixelsPerLogicalPixel` keeps the physical scan size and accepted text
+ * heights stable for native, fractional-scale, and HiDPI captures. Returns no
+ * band for flat or non-text-like content so callers can retain freehand input.
+ */
+[[nodiscard]] std::optional<TextBand>
+detectTextBand(const QImage &source, const QPointF &sourcePoint,
+               const QSizeF &sourcePixelsPerLogicalPixel = QSizeF(1.0, 1.0));

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -14,6 +14,7 @@
 #include "stitch-smoke.hpp"
 #include "stitch.hpp"
 #include "pin-lifecycle-smoke.hpp"
+#include "text-band.hpp"
 #include "transform-smoke.hpp"
 #include "eyedropper.hpp"
 
@@ -39,6 +40,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <numbers>
 #include <csignal>
 #include <sys/resource.h>
@@ -688,6 +690,292 @@ bool runHighlighterRenderingCheck(QString &error) {
     error = QStringLiteral("Highlighter stroke was not translucent/wide");
     return false;
   }
+  return true;
+}
+
+void paintTextLikeBand(QImage &image, const QRectF &logicalBand, qreal scale,
+                       const QColor &ink) {
+  QPainter painter(&image);
+  painter.setRenderHint(QPainter::Antialiasing, false);
+  painter.setPen(Qt::NoPen);
+  painter.setBrush(ink);
+  for (int glyph = 0; glyph < 11; ++glyph) {
+    const qreal topInset = glyph % 4 == 0 ? 0.0 : 2.0;
+    const qreal bottomInset = glyph % 3 == 0 ? 0.0 : 1.0;
+    const QRectF stem(logicalBand.left() + glyph * 13.0,
+                      logicalBand.top() + topInset, 6.0,
+                      logicalBand.height() - topInset - bottomInset);
+    painter.drawRect(QRectF(stem.topLeft() * scale, stem.size() * scale));
+  }
+}
+
+/** Local edge scan finds text height across themes and native image scales. */
+bool runTextBandDetectionCheck(QString &error) {
+  for (const qreal scale : {1.0, 2.0}) {
+    const QSize logicalSize(360, 180);
+    QImage image((QSizeF(logicalSize) * scale).toSize(), QImage::Format_RGB32);
+    image.fill(QColor(QStringLiteral("#515862")));
+    {
+      // Two surfaces in the same scan row exercise the edge-density approach:
+      // there is deliberately no single row-wide background color.
+      QPainter painter(&image);
+      painter.fillRect(
+          QRectF(QPointF(180 * scale, 0), QSizeF(180, 180) * scale),
+          QColor(QStringLiteral("#606772")));
+    }
+    const QRectF expected(82, 66, 149, 16);
+    paintTextLikeBand(image, expected, scale,
+                      QColor(QStringLiteral("#737b86")));
+
+    // The pointer may sit just under the glyphs: a highlighter should still
+    // choose the nearby row, but report its native-pixel extent.
+    const auto band =
+        detectTextBand(image, QPointF(130, 89) * scale, QSizeF(scale, scale));
+    if (!band ||
+        std::abs(band->center() / scale - expected.center().y()) > 3.0 ||
+        band->height() / scale < 10.0 || band->height() / scale > 20.0) {
+      error = QStringLiteral("Text-band detector missed a %1x mixed-background "
+                             "text row")
+                  .arg(scale);
+      return false;
+    }
+
+    // Bowl-shaped glyphs can produce distinct upper/lower edge runs with a
+    // quiet five-row middle. They are one text line, not two undersized bands.
+    QImage split((QSizeF(logicalSize) * scale).toSize(), QImage::Format_RGB32);
+    split.fill(QColor(QStringLiteral("#252a31")));
+    {
+      QPainter painter(&split);
+      painter.setRenderHint(QPainter::Antialiasing, false);
+      painter.setPen(Qt::NoPen);
+      painter.setBrush(QColor(QStringLiteral("#d8dbe2")));
+      for (int glyph = 0; glyph < 11; ++glyph) {
+        const qreal x = (82.0 + glyph * 13.0) * scale;
+        painter.drawRect(QRectF(x, 60.0 * scale, 6.0 * scale, 4.0 * scale));
+        painter.drawRect(QRectF(x, 69.0 * scale, 6.0 * scale, 5.0 * scale));
+      }
+    }
+    const auto splitBand =
+        detectTextBand(split, QPointF(130, 72) * scale, QSizeF(scale, scale));
+    if (!splitBand || splitBand->height() / scale < 12.0 ||
+        std::abs(splitBand->center() / scale - 67.0) > 3.0) {
+      error = QStringLiteral(
+                  "Text-band detector fragmented split glyphs at %1x")
+                  .arg(scale);
+      return false;
+    }
+  }
+
+  QImage flat(320, 160, QImage::Format_RGB32);
+  flat.fill(QColor(QStringLiteral("#e6e4dd")));
+  if (detectTextBand(flat, QPointF(120, 80)) ||
+      detectTextBand(flat, QPointF(319.9, 159.9))) {
+    error = QStringLiteral("Text-band detector snapped on a flat background");
+    return false;
+  }
+  return true;
+}
+
+/** The editor locks a detected text highlight and preserves freehand fallback. */
+bool runTextAwareHighlighterEditorCheck(QApplication &application,
+                                        QString &error) {
+  constexpr qreal sourceScale = 2.0;
+  const QSize logicalSize(400, 240);
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = QRect(QPoint(), logicalSize);
+  capture.monitor.pixelSize = (QSizeF(logicalSize) * sourceScale).toSize();
+  capture.monitor.scale = sourceScale;
+  capture.previewSize = logicalSize;
+  capture.source = QImage(capture.monitor.pixelSize, QImage::Format_RGB32);
+  capture.source.fill(QColor(QStringLiteral("#20242c")));
+  const QRectF textBand(80, 96, 149, 16);
+  paintTextLikeBand(capture.source, textBand, sourceScale,
+                    QColor(QStringLiteral("#d8dbe2")));
+
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::Fullscreen);
+  editor.setSuppressSnapshots(true);
+  // baseImageRect is exactly 400x240 at (30,135), making test gestures map
+  // 1:1 to annotation coordinates while leaving the toolbar clear of the
+  // capture tabs. The source itself remains 2x HiDPI.
+  editor.resize(460, 500);
+  editor.show();
+  application.processEvents();
+  const auto widgetPoint = [&editor](qreal x, qreal y) {
+    return editor.toScreenPointForTest(QPointF(x, y)).toPoint();
+  };
+
+  QTest::keyClick(&editor, Qt::Key_H);
+  application.processEvents();
+  if (!editor.highlighterSnapModeForTest() ||
+      !editor.statusForTest().contains(QStringLiteral("Snap")) ||
+      !editor.statusForTest().contains(QStringLiteral("automatic"))) {
+    error = QStringLiteral("Highlighter did not start in disclosed Snap mode");
+    return false;
+  }
+  // Hovering a detected row replaces the fixed crosshair with a measured
+  // I-beam. The detected row supplies only its height: the beam itself follows
+  // the pointer fluidly until mouse-down commits to a row.
+  QTest::mouseMove(&editor, widgetPoint(105, 114), 10);
+  application.processEvents();
+  const QRectF firstBeam = editor.highlighterPreviewRectForTest();
+  QTest::mouseMove(&editor, widgetPoint(105, 120), 10);
+  application.processEvents();
+  const QRectF beam = editor.highlighterPreviewRectForTest();
+  const QImage hovered = editor.grab().toImage();
+  const QPoint beamCenter = widgetPoint(beam.center().x(), beam.center().y());
+  if (firstBeam.isEmpty() || beam.isEmpty() ||
+      editor.cursor().shape() != Qt::BlankCursor ||
+      std::abs(firstBeam.center().y() - 114.0) > 0.6 ||
+      std::abs(beam.center().y() - 120.0) > 0.6 ||
+      std::abs(beam.height() - firstBeam.height()) > 0.01 ||
+      beam.height() < 12.0 || beam.height() > 22.0 ||
+      !hovered.rect().contains(beamCenter) ||
+      hovered.pixelColor(beamCenter).lightness() < 180) {
+    error = QStringLiteral(
+        "Snap highlighter preview did not follow the mouse at detected height");
+    return false;
+  }
+  QTest::mouseMove(&editor, widgetPoint(70, 180), 10);
+  application.processEvents();
+  if (!editor.highlighterPreviewRectForTest().isEmpty() ||
+      editor.cursor().shape() != Qt::CrossCursor) {
+    error = QStringLiteral("Highlighter I-beam did not fall back off text");
+    return false;
+  }
+  QTest::mouseMove(&editor, widgetPoint(105, 118), 10);
+  application.processEvents();
+
+  // Start just below the glyph box, then deliberately wobble far above and
+  // below it. Every recorded point should remain on the detected centerline.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier,
+                    widgetPoint(105, 118));
+  QTest::mouseMove(&editor, widgetPoint(190, 145), 10);
+  QTest::mouseMove(&editor, widgetPoint(270, 75), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      widgetPoint(325, 135));
+  application.processEvents();
+  if (editor.operationLog().isEmpty() ||
+      editor.operationLog().constLast().annotations.size() != 1) {
+    error = QStringLiteral("Text-aware highlighter did not commit a layer");
+    return false;
+  }
+  const Annotation locked =
+      editor.operationLog().constLast().annotations.constFirst();
+  qreal minimumY = std::numeric_limits<qreal>::max();
+  qreal maximumY = std::numeric_limits<qreal>::lowest();
+  for (const QPointF &point : locked.points) {
+    minimumY = std::min(minimumY, point.y());
+    maximumY = std::max(maximumY, point.y());
+  }
+  const qreal lockedWidth = std::max<qreal>(6.0, locked.size * 3.0);
+  if (locked.kind != Annotation::Kind::Highlighter ||
+      locked.points.size() < 3 || maximumY - minimumY > 0.01 ||
+      std::abs(minimumY - textBand.center().y()) > 3.0 || lockedWidth < 12.0 ||
+      lockedWidth > 22.0) {
+    error = QStringLiteral("Detected highlight did not stay straight at the "
+                           "text height");
+    return false;
+  }
+
+  // The same geometry must reach the native-resolution renderer: ink covers
+  // the measured row, but not background several pixels beyond its edge.
+  const QImage rendered = editor.renderCurrentOutput();
+  const int nativeX = qRound(260 * sourceScale);
+  const int nativeCenter = qRound(minimumY * sourceScale);
+  const int nativeOutside =
+      qRound((minimumY + lockedWidth / 2.0 + 4.0) * sourceScale);
+  if (rendered.isNull() ||
+      rendered.pixelColor(nativeX, nativeCenter) ==
+          capture.source.pixelColor(nativeX, nativeCenter) ||
+      rendered.pixelColor(nativeX, nativeOutside) !=
+          capture.source.pixelColor(nativeX, nativeOutside)) {
+    error = QStringLiteral("Text-height highlight did not render at its locked "
+                           "native-pixel width");
+    return false;
+  }
+
+  // Repeating H switches the active tool to Normal: text scanning and its
+  // I-beam are both gone, and Alt+wheel changes the freehand thickness.
+  QTest::keyClick(&editor, Qt::Key_H);
+  QTest::mouseMove(&editor, widgetPoint(105, 118), 10);
+  application.processEvents();
+  if (editor.highlighterSnapModeForTest() ||
+      !editor.statusForTest().contains(QStringLiteral("Normal")) ||
+      !editor.statusForTest().contains(QStringLiteral("Alt+wheel")) ||
+      !editor.highlighterPreviewRectForTest().isEmpty() ||
+      editor.cursor().shape() != Qt::CrossCursor) {
+    error = QStringLiteral("Repeated H did not arm disclosed Normal mode");
+    return false;
+  }
+  {
+    const QPointF wheelPoint(widgetPoint(105, 118));
+    QWheelEvent wheel(wheelPoint, wheelPoint, {}, {0, 120}, Qt::NoButton,
+                      Qt::AltModifier, Qt::NoScrollPhase, false);
+    QApplication::sendEvent(&editor, &wheel);
+    application.processEvents();
+  }
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier,
+                    widgetPoint(45, 118));
+  QTest::mouseMove(&editor, widgetPoint(55, 145), 10);
+  QTest::mouseMove(&editor, widgetPoint(65, 75), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      widgetPoint(75, 135));
+  application.processEvents();
+  const Annotation normal =
+      editor.operationLog().constLast().annotations.constFirst();
+  minimumY = std::numeric_limits<qreal>::max();
+  maximumY = std::numeric_limits<qreal>::lowest();
+  for (const QPointF &point : normal.points) {
+    minimumY = std::min(minimumY, point.y());
+    maximumY = std::max(maximumY, point.y());
+  }
+  if (normal.kind != Annotation::Kind::Highlighter ||
+      maximumY - minimumY < 40.0 || !qFuzzyCompare(normal.size, 5.0) ||
+      !editor.statusForTest().contains(QStringLiteral("Normal"))) {
+    error = QStringLiteral(
+        "Normal highlighter detected a row or ignored Alt+wheel thickness");
+    return false;
+  }
+
+  // Clicking the already-active toolbar tool follows the same repeated-tool
+  // convention and returns to Snap.
+  const QRectF highlighterButton = editor.highlighterToolbarRectForTest();
+  if (highlighterButton.isEmpty()) {
+    error = QStringLiteral("Highlighter toolbar button was unavailable");
+    return false;
+  }
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier,
+                    highlighterButton.center().toPoint());
+  application.processEvents();
+  if (!editor.highlighterSnapModeForTest() ||
+      !editor.statusForTest().contains(QStringLiteral("Snap"))) {
+    error = QStringLiteral("Active toolbar click did not return H to Snap");
+    return false;
+  }
+
+  // Snap still preserves its freehand fallback away from detected text. The
+  // manual size changed in Normal is retained for such an off-text stroke.
+  QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier,
+                    widgetPoint(70, 180));
+  QTest::mouseMove(&editor, widgetPoint(140, 211), 10);
+  QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier,
+                      widgetPoint(205, 170));
+  application.processEvents();
+  const Annotation fallback =
+      editor.operationLog().constLast().annotations.constFirst();
+  minimumY = std::numeric_limits<qreal>::max();
+  maximumY = std::numeric_limits<qreal>::lowest();
+  for (const QPointF &point : fallback.points) {
+    minimumY = std::min(minimumY, point.y());
+    maximumY = std::max(maximumY, point.y());
+  }
+  if (fallback.kind != Annotation::Kind::Highlighter ||
+      maximumY - minimumY < 20.0 || !qFuzzyCompare(fallback.size, 5.0)) {
+    error = QStringLiteral("Highlighter lost its freehand no-text fallback");
+    return false;
+  }
+  editor.close();
   return true;
 }
 
@@ -5824,6 +6112,14 @@ int main(int argc, char **argv) {
   if (!runHighlighterRenderingCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 69;
+  }
+  if (!runTextBandDetectionCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 128;
+  }
+  if (!runTextAwareHighlighterEditorCheck(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 129;
   }
   if (!runSecureRedactionChecks(snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
The highlighter now defaults to Snap mode. A fluid I-beam preview follows the pointer at the nearest detected text height; once dragging starts, the stroke locks to that text row and stays straight.

Press `H` again (or click the active toolbar button) for Normal freehand mode, where `Alt+wheel` adjusts thickness. Snap mode still falls back to freehand when there is no nearby text.

![Highlighter snapping to a text row](https://github.com/user-attachments/assets/460555b0-3d1f-41e5-91c7-2466154a7704)

Tested with `make check`.
