### PR TITLE
feat(editor): grow canvas around annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Window capture is a crop of the focused-monitor frame. Overlapping windows stay
   visible; there is no second clean-window recapture.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
+- Draw, type, resize, or carry a layer past the screenshot edge to grow the canvas.
+  New strips start in the window gray with the original screenshot's card shadow.
+  `B` then cycles through the colorful backdrops with shadows. Fullscreen finishes
+  with shadowed and then flat window gray, including after the canvas grows.
+  `Shift+B` toggles the current shadow directly, and undo/delete can contract grown
+  strips again.
 - Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
   hollow or filled rectangles (optionally rounded) and ellipses, numbered markers,
   editable Neucha text (on a readability pill), and secure redaction with opaque or
@@ -23,7 +29,7 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Per-layer preset or custom colors (including highlighter ink), undo/redo history,
   one-click whole-image or drag-region OCR (the recognized text is shown beside
   the image and copied to the clipboard),
-  mesh-gradient backdrops, and rendered drop shadows.
+  mesh-gradient backdrops, and rendered drop shadows on standard backdrop cards.
 - Cut tool: drag across a band of the image to remove it and collapse the gap, with a
   live preview and dashed seam marker while dragging; annotations shift to follow.
 - Pin a finished capture as a bottom-right always-on-top layer surface, launched
@@ -326,7 +332,7 @@ without reaching for the pointer.
 
 | Input | Action |
 |---|---|
-| `V` | Select/move/resize layers; drag empty canvas for a marquee; wheel scales the selected layer |
+| `V` | Select/move/resize layers; carrying one past the source grows the canvas; drag empty canvas for a marquee; multi-select outlines each layer without treating the canvas as one layer; wheel scales the selected layer |
 | `A` | Arrow |
 | `S` | Spotlight/loupe; press again to cycle ellipse, rectangle, rounded |
 | `L` | Straight line |
@@ -339,7 +345,8 @@ without reaching for the pointer.
 | `X` | Cut out a band; drag to preview the crossed-out strip, then release to remove and collapse it |
 | `T` | Neucha text on a cream readability pill. Click for a one-line label, or drag a box to give it room for several lines: Enter moves to the next line while there is room and commits on the last one; `Shift+Enter` always adds a line; `Esc` commits too but keeps the label selected, so `Backspace` removes it; clicking away keeps the text; press T again to toggle the pill |
 | `O` | Recognize and copy all text in the current image |
-| `B` | Cycle backdrop |
+| `B` | Cycle shadowed colors, then shadowed and flat window gray before returning to blue |
+| `Shift+B` | Toggle the screenshot card's drop shadow; on by default |
 | `1`–`8` | Set annotation color; `7` is black and `8` is white |
 | Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size (`Alt`+wheel: rectangle corner radius or spotlight border); while just viewing a zoomed capture, scroll it like a document |
 | `Shift`+wheel | Scroll a zoomed capture sideways (a wide stitch); never changes the zoom |
@@ -393,7 +400,7 @@ rule is required; the controls use the same vector icon renderer as the annotati
 Creation tools return to Select after one placement without selecting the new layer. In
 Select mode, arrows and lines show only their two endpoint handles; other layers show a
 selection boundary. The eight blue/white handles outside the image recrop its corners or
-edges.
+edges. After the canvas grows, those crop handles remain on the original source frame.
 
 ## Development and verification
 
@@ -404,7 +411,8 @@ make check
 The smoke executable exercises region/window/fullscreen startup modes, capture selection,
 working-document persistence (source plus op-log JSON), annotation tools, undo/redo
 replay, vector movement and scaling, text editing, OCR, native-DPI output,
-endpoint-only line selection, external crop handles, and the native-pixel
+endpoint-only line selection, annotation-driven canvas growth, external crop handles,
+and the native-pixel
 measurement readout on a scaled monitor.
 
 For live launch profiling, the binary has an opt-in millisecond trace from `main()`

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   visible; there is no second clean-window recapture.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
 - Draw, type, resize, or carry a layer past the screenshot edge to grow the canvas.
-  Growth is the default; `G` cycles to clipping at the normal frame or at the
-  original image, and `Shift+G` cycles backward without changing layer geometry.
-  New strips start in the window gray with the original screenshot's card shadow.
-  `B` then cycles through the colorful backdrops with shadows. Fullscreen finishes
-  with shadowed and then flat window gray, including after the canvas grows.
-  `Shift+B` toggles the current shadow directly, and undo/delete can contract grown
-  strips again.
+  Framed growth is the default; `G` cycles to tight Overflow growth (only the
+  sides needed by annotations, with no frame), then Image (the original canvas
+  size, clipping every outside annotation). `Shift+G` cycles backward without
+  changing layer geometry. New framed strips start in window gray with the
+  original screenshot's card shadow. `B` cycles through the colorful backdrops,
+  shadowed and flat window gray, and Off so a background can always be removed.
+  Overflow with no backdrop leaves its added pixels transparent. `Shift+B`
+  toggles the current shadow directly, and undo/delete can contract grown strips.
 - Arrows, straight lines, smoothed freehand strokes, translucent highlighter strokes,
   hollow or filled rectangles (optionally rounded) and ellipses, numbered markers,
   editable Neucha text (on a readability pill), and secure redaction with opaque or
@@ -347,9 +348,9 @@ without reaching for the pointer.
 | `X` | Cut out a band; drag to preview the crossed-out strip, then release to remove and collapse it |
 | `T` | Neucha text on a cream readability pill. Click for a one-line label, or drag a box to give it room for several lines: Enter moves to the next line while there is room and commits on the last one; `Shift+Enter` always adds a line; `Esc` commits too but keeps the label selected, so `Backspace` removes it; clicking away keeps the text; press T again to toggle the pill |
 | `O` | Recognize and copy all text in the current image |
-| `B` | Cycle shadowed colors, then shadowed and flat window gray before returning to blue |
+| `B` | Cycle shadowed colors, window gray (shadowed and flat), and Off |
 | `Shift+B` | Toggle the screenshot card's drop shadow; on by default |
-| `G` / `Shift+G` | Cycle canvas boundaries forward/backward: Grow, Frame, Image. Frame clips at the normal background frame; Image clips at the original screenshot edge |
+| `G` / `Shift+G` | Cycle canvas boundaries forward/backward: Framed, Overflow, Image. Framed auto-grows with the normal frame; Overflow grows only the sides needed by annotations with no frame; Image clips at the original screenshot edge |
 | `1`–`8` | Set annotation color; `7` is black and `8` is white |
 | Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size (`Alt`+wheel: rectangle corner radius or spotlight border); while just viewing a zoomed capture, scroll it like a document |
 | `Shift`+wheel | Scroll a zoomed capture sideways (a wide stitch); never changes the zoom |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   visible; there is no second clean-window recapture.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
 - Draw, type, resize, or carry a layer past the screenshot edge to grow the canvas.
+  Growth is the default; `G` cycles to clipping at the normal frame or at the
+  original image, and `Shift+G` cycles backward without changing layer geometry.
   New strips start in the window gray with the original screenshot's card shadow.
   `B` then cycles through the colorful backdrops with shadows. Fullscreen finishes
   with shadowed and then flat window gray, including after the canvas grows.
@@ -347,6 +349,7 @@ without reaching for the pointer.
 | `O` | Recognize and copy all text in the current image |
 | `B` | Cycle shadowed colors, then shadowed and flat window gray before returning to blue |
 | `Shift+B` | Toggle the screenshot card's drop shadow; on by default |
+| `G` / `Shift+G` | Cycle canvas boundaries forward/backward: Grow, Frame, Image. Frame clips at the normal background frame; Image clips at the original screenshot edge |
 | `1`–`8` | Set annotation color; `7` is black and `8` is white |
 | Wheel | Scale selected layer, magnify the spotlight under the cursor, or change active tool size (`Alt`+wheel: rectangle corner radius or spotlight border); while just viewing a zoomed capture, scroll it like a document |
 | `Shift`+wheel | Scroll a zoomed capture sideways (a wide stitch); never changes the zoom |
@@ -397,6 +400,10 @@ Image and path copying use `wl-copy` rather than `QClipboard`, so clipboard data
 available after the pin is closed. No font-based symbol set or compositor-specific window
 rule is required; the controls use the same vector icon renderer as the annotation toolbar.
 
+Canvas boundary changes affect only preview and export clipping. The complete vector
+geometry stays in the operation log, so switching back to Grow restores every off-canvas
+part of a layer.
+
 Creation tools return to Select after one placement without selecting the new layer. In
 Select mode, arrows and lines show only their two endpoint handles; other layers show a
 selection boundary. The eight blue/white handles outside the image recrop its corners or
@@ -411,7 +418,8 @@ make check
 The smoke executable exercises region/window/fullscreen startup modes, capture selection,
 working-document persistence (source plus op-log JSON), annotation tools, undo/redo
 replay, vector movement and scaling, text editing, OCR, native-DPI output,
-endpoint-only line selection, annotation-driven canvas growth, external crop handles,
+endpoint-only line selection, annotation-driven canvas growth and clipping policies,
+external crop handles,
 and the native-pixel
 measurement readout on a scaled monitor.
 

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -32,6 +32,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+constexpr qreal kBackdropMargin = 64.0;
+
 bool loadCaptureFonts() {
   static const int fontId =
       QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/Neucha.ttf"));
@@ -152,22 +154,24 @@ QRectF captureCanvasRect(const QSizeF &sourceFrameSize,
       canvas = canvas.united(bounds);
   }
 
-  // Quantize only newly exposed strips. A fractional crop is itself the
-  // stable source frame; rounding its untouched right/bottom edges would look
-  // like growth and would resample an otherwise exact native-pixel export.
   const QRectF sourceFrame(QPointF(), sourceFrameSize);
-  const qreal left = canvas.left() < sourceFrame.left()
-                         ? std::floor(canvas.left())
-                         : sourceFrame.left();
-  const qreal top = canvas.top() < sourceFrame.top()
-                        ? std::floor(canvas.top())
-                        : sourceFrame.top();
-  const qreal right = canvas.right() > sourceFrame.right()
-                          ? std::ceil(canvas.right())
-                          : sourceFrame.right();
-  const qreal bottom = canvas.bottom() > sourceFrame.bottom()
-                           ? std::ceil(canvas.bottom())
-                           : sourceFrame.bottom();
+  const bool growsLeft = canvas.left() < sourceFrame.left();
+  const bool growsTop = canvas.top() < sourceFrame.top();
+  const bool growsRight = canvas.right() > sourceFrame.right();
+  const bool growsBottom = canvas.bottom() > sourceFrame.bottom();
+  if (!growsLeft && !growsTop && !growsRight && !growsBottom)
+    return sourceFrame;
+
+  // Begin with the same frame as a regular backdrop, then extend only a side
+  // whose annotation exceeds it. Source and layer coordinates stay fixed.
+  const QRectF backdropFrame = sourceFrame.adjusted(
+      -kBackdropMargin, -kBackdropMargin, kBackdropMargin, kBackdropMargin);
+  const qreal left = std::floor(std::min(canvas.left(), backdropFrame.left()));
+  const qreal top = std::floor(std::min(canvas.top(), backdropFrame.top()));
+  const qreal right =
+      std::ceil(std::max(canvas.right(), backdropFrame.right()));
+  const qreal bottom =
+      std::ceil(std::max(canvas.bottom(), backdropFrame.bottom()));
   return {left, top, right - left, bottom - top};
 }
 
@@ -1054,9 +1058,13 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
 
   const bool hasBackground = effectiveBackground != BackgroundStyle::None;
   const int marginX =
-      hasBackground ? static_cast<int>(std::round(64.0 * scaleX)) : 0;
+      hasBackground
+          ? static_cast<int>(std::round(kBackdropMargin * scaleX))
+          : 0;
   const int marginY =
-      hasBackground ? static_cast<int>(std::round(64.0 * scaleY)) : 0;
+      hasBackground
+          ? static_cast<int>(std::round(kBackdropMargin * scaleY))
+          : 0;
   QImage output(cropped.width() + marginX * 2, cropped.height() + marginY * 2,
                 QImage::Format_ARGB32_Premultiplied);
   output.fill(Qt::transparent);

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -67,6 +67,110 @@ QRectF annotationTextBounds(const Annotation &annotation) {
   return glyphs.adjusted(-pad, -pad, pad, bottom - metrics.descent());
 }
 
+QRectF captureCanvasRect(const QSizeF &sourceFrameSize,
+                         const QVector<Annotation> &annotations) {
+  QRectF canvas(QPointF(), sourceFrameSize);
+  if (canvas.isEmpty())
+    return {};
+
+  const auto pointBounds = [](const QVector<QPointF> &points) {
+    if (points.isEmpty())
+      return QRectF();
+    qreal left = points.constFirst().x();
+    qreal right = left;
+    qreal top = points.constFirst().y();
+    qreal bottom = top;
+    for (const QPointF &point : points) {
+      left = std::min(left, point.x());
+      right = std::max(right, point.x());
+      top = std::min(top, point.y());
+      bottom = std::max(bottom, point.y());
+    }
+    return QRectF(QPointF(left, top), QPointF(right, bottom));
+  };
+  const auto paintedBounds = [&](const Annotation &annotation) {
+    // Redaction only replaces pixels inside the source frame. Its geometry
+    // can extend past that frame, but there are no painted pixels there for a
+    // larger canvas to reveal.
+    if (annotation.kind == Annotation::Kind::Redaction)
+      return QRectF();
+    if (annotation.kind == Annotation::Kind::Text)
+      return annotationTextBounds(annotation).adjusted(-1, -1, 1, 1);
+    if (annotation.kind == Annotation::Kind::Marker) {
+      const qreal diameter = std::max<qreal>(24.0, annotation.size * 6.0);
+      const qreal antialias =
+          std::max<qreal>(1.0, annotation.size * 0.35) / 2.0 + 1.0;
+      return QRectF(annotation.start.x() - diameter / 2.0,
+                    annotation.start.y() - diameter / 2.0, diameter, diameter)
+          .adjusted(-antialias, -antialias, antialias, antialias);
+    }
+    if (annotation.kind == Annotation::Kind::Freehand ||
+        annotation.kind == Annotation::Kind::Highlighter) {
+      if (annotation.points.size() < 2)
+        return QRectF();
+      const qreal width =
+          annotation.kind == Annotation::Kind::Highlighter
+              ? std::max<qreal>(6.0, annotation.size * 3.0)
+              : std::max<qreal>(2.0, annotation.size);
+      const qreal extent = width / 2.0 + 1.0;
+      return pointBounds(annotation.points)
+          .adjusted(-extent, -extent, extent, extent);
+    }
+
+    QRectF bounds(annotation.start, annotation.end);
+    bounds = bounds.normalized();
+    if (annotation.kind == Annotation::Kind::Arrow) {
+      const QLineF line(annotation.start, annotation.end);
+      if (line.length() >= 1.0) {
+        const qreal angle = std::atan2(line.dy(), line.dx());
+        const qreal headLength = std::max<qreal>(14.0, annotation.size * 4.2);
+        const qreal halfWidth = headLength * 0.46;
+        const QPointF direction(std::cos(angle), std::sin(angle));
+        const QPointF perpendicular(-direction.y(), direction.x());
+        const QPointF base = annotation.end - direction * headLength;
+        bounds = pointBounds({annotation.start, annotation.end,
+                              base + perpendicular * halfWidth,
+                              base - perpendicular * halfWidth});
+      }
+    }
+    qreal extent = 1.0;
+    if (annotation.kind == Annotation::Kind::Line ||
+        annotation.kind == Annotation::Kind::Arrow ||
+        ((annotation.kind == Annotation::Kind::Rectangle ||
+          annotation.kind == Annotation::Kind::Ellipse) &&
+         !annotation.filled)) {
+      extent += std::max<qreal>(2.0, annotation.size) / 2.0;
+    } else if (annotation.kind == Annotation::Kind::Spotlight) {
+      extent += std::max<qreal>(1.0, annotation.size / 2.0) / 2.0;
+    }
+    return bounds.adjusted(-extent, -extent, extent, extent);
+  };
+
+  for (const Annotation &annotation : annotations) {
+    const QRectF bounds = paintedBounds(annotation);
+    if (!bounds.isNull())
+      canvas = canvas.united(bounds);
+  }
+
+  // Quantize only newly exposed strips. A fractional crop is itself the
+  // stable source frame; rounding its untouched right/bottom edges would look
+  // like growth and would resample an otherwise exact native-pixel export.
+  const QRectF sourceFrame(QPointF(), sourceFrameSize);
+  const qreal left = canvas.left() < sourceFrame.left()
+                         ? std::floor(canvas.left())
+                         : sourceFrame.left();
+  const qreal top = canvas.top() < sourceFrame.top()
+                        ? std::floor(canvas.top())
+                        : sourceFrame.top();
+  const qreal right = canvas.right() > sourceFrame.right()
+                          ? std::ceil(canvas.right())
+                          : sourceFrame.right();
+  const qreal bottom = canvas.bottom() > sourceFrame.bottom()
+                           ? std::ceil(canvas.bottom())
+                           : sourceFrame.bottom();
+  return {left, top, right - left, bottom - top};
+}
+
 bool ensurePrivateDirectory(const QString &path) {
   if (path.isEmpty())
     return false;
@@ -677,6 +781,11 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
                             BackgroundStyle backgroundStyle) {
   if (backgroundStyle == BackgroundStyle::None)
     return;
+  if (backgroundStyle == BackgroundStyle::Slate) {
+    // Slate is the opaque mat; the image shadow is painted separately.
+    painter.fillRect(bounds, QColor(QStringLiteral("#242424")));
+    return;
+  }
 
   struct Blob {
     QPointF center;
@@ -741,6 +850,33 @@ void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
     gradient.setColorAt(1, edge);
     painter.fillRect(bounds, gradient);
   }
+}
+
+void paintCaptureImageShadow(QPainter &painter, const QRectF &imageRect,
+                             qreal scaleX, qreal scaleY) {
+  const qreal scale = std::max(scaleX, scaleY);
+  painter.save();
+  painter.setPen(Qt::NoPen);
+
+  // Approximate a 40 px key shadow with a 14 px offset and a 12 px ambient
+  // halo. Keep the solid contour rings faint so stacking does not darken the
+  // image edge.
+  for (int layer = 14; layer > 0; --layer) {
+    const qreal spread = layer * scale * (40.0 / 14.0);
+    painter.setBrush(QColor(0, 0, 0, 6));
+    painter.drawRoundedRect(
+        imageRect.adjusted(-spread, -spread + 14 * scaleY, spread,
+                           spread + 14 * scaleY),
+        spread, spread);
+  }
+  for (int layer = 8; layer > 0; --layer) {
+    const qreal spread = layer * scale * (12.0 / 8.0);
+    painter.setBrush(QColor(0, 0, 0, 6));
+    painter.drawRoundedRect(imageRect.adjusted(-spread, -spread, spread,
+                                               spread),
+                            spread, spread);
+  }
+  painter.restore();
 }
 
 bool probeFocusedMonitor(MonitorInfo &monitor, QString &error) {
@@ -815,7 +951,7 @@ bool captureFocusedMonitor(CaptureData &capture, bool includeWindows,
 
 QImage renderCapture(const CaptureData &capture, const QRectF &selection,
                      const QVector<Annotation> &annotations,
-                     BackgroundStyle backgroundStyle) {
+                     BackgroundStyle backgroundStyle, bool imageShadow) {
   const QRect pixels = pixelSelection(capture, selection);
   if (pixels.isEmpty())
     return {};
@@ -850,7 +986,73 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   applyRedactions(cropped, annotations, resized ? scaleX : sourceScaleX,
                   resized ? scaleY : sourceScaleY,
                   resized ? QPointF{} : sourceOriginOffset);
-  const bool hasBackground = backgroundStyle != BackgroundStyle::None;
+  const QRectF sourceFrame(QPointF(), selection.size());
+  const QRectF canvas = captureCanvasRect(selection.size(), annotations);
+  const bool canvasGrown = canvas.left() < sourceFrame.left() - 0.001 ||
+                           canvas.top() < sourceFrame.top() - 0.001 ||
+                           canvas.right() > sourceFrame.right() + 0.001 ||
+                           canvas.bottom() > sourceFrame.bottom() + 0.001;
+  const BackgroundStyle effectiveBackground =
+      canvasGrown && backgroundStyle == BackgroundStyle::None
+          ? BackgroundStyle::Slate
+          : backgroundStyle;
+
+  if (canvasGrown) {
+    // The source frame and annotation canvas are intentionally separate.
+    // New strips are rendered from the stable source on every frame instead
+    // of copying an already-expanded raster, so repeated growth cannot leave
+    // seams or drift existing pixels. Integer logical canvas edges make the
+    // settle after a drag deterministic at every display scale.
+    const int growLeft = std::max(
+        0, static_cast<int>(std::ceil(-canvas.left() * scaleX)));
+    const int growTop =
+        std::max(0, static_cast<int>(std::ceil(-canvas.top() * scaleY)));
+    const int growRight = std::max(
+        0, static_cast<int>(std::ceil(
+               (canvas.right() - sourceFrame.right()) * scaleX)));
+    const int growBottom = std::max(
+        0, static_cast<int>(std::ceil(
+               (canvas.bottom() - sourceFrame.bottom()) * scaleY)));
+    QImage output(cropped.width() + growLeft + growRight,
+                  cropped.height() + growTop + growBottom,
+                  QImage::Format_ARGB32_Premultiplied);
+    output.fill(Qt::transparent);
+
+    QPainter painter(&output);
+    painter.setRenderHints(QPainter::Antialiasing |
+                           QPainter::SmoothPixmapTransform |
+                           QPainter::TextAntialiasing);
+    paintCaptureBackground(painter, output.rect(), effectiveBackground);
+    // The extension is one continuous mat. Its shadow belongs only to the
+    // original source card; annotations paint over both in the next pass.
+    const QRectF imageRect(growLeft, growTop, cropped.width(), cropped.height());
+    if (imageShadow)
+      paintCaptureImageShadow(painter, imageRect, scaleX, scaleY);
+    painter.drawImage(imageRect.topLeft(), cropped);
+    painter.end();
+
+    const bool hasSpotlight = std::any_of(
+        annotations.cbegin(), annotations.cend(), [](const Annotation &item) {
+          return item.kind == Annotation::Kind::Spotlight;
+        });
+    // A spotlight samples the fully composed mat. Avoid detaching/copying the
+    // full grown image for the common case where annotations only paint over
+    // it, and never copy an image while a painter is active on that device.
+    const QImage layerSource = hasSpotlight ? output.copy() : cropped;
+    const QRectF layerBounds = hasSpotlight ? canvas : sourceFrame;
+    QPainter layerPainter(&output);
+    layerPainter.setRenderHints(QPainter::Antialiasing |
+                                QPainter::SmoothPixmapTransform |
+                                QPainter::TextAntialiasing);
+    layerPainter.translate(growLeft, growTop);
+    layerPainter.scale(scaleX, scaleY);
+    layerPainter.setClipRect(canvas);
+    paintDefaultLayer(layerPainter, layerSource, layerBounds, annotations);
+    layerPainter.end();
+    return output;
+  }
+
+  const bool hasBackground = effectiveBackground != BackgroundStyle::None;
   const int marginX =
       hasBackground ? static_cast<int>(std::round(64.0 * scaleX)) : 0;
   const int marginY =
@@ -864,23 +1066,10 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
                          QPainter::SmoothPixmapTransform |
                          QPainter::TextAntialiasing);
   if (hasBackground) {
-    paintCaptureBackground(painter, output.rect(), backgroundStyle);
+    paintCaptureBackground(painter, output.rect(), effectiveBackground);
     const QRectF imageRect(marginX, marginY, cropped.width(), cropped.height());
-    painter.setPen(Qt::NoPen);
-    for (int layer = 24; layer > 0; --layer) {
-      const qreal spread = layer * std::max(scaleX, scaleY) * 0.85;
-      painter.setBrush(QColor(0, 0, 0, 2 + (24 - layer) / 5));
-      painter.drawRoundedRect(imageRect.adjusted(-spread, -spread + 14 * scaleY,
-                                                 spread, spread + 14 * scaleY),
-                              16 * scaleX + spread, 16 * scaleY + spread);
-    }
-    for (int layer = 12; layer > 0; --layer) {
-      const qreal spread = layer * std::max(scaleX, scaleY) * 0.45;
-      painter.setBrush(QColor(0, 0, 0, 3 + (12 - layer)));
-      painter.drawRoundedRect(imageRect.adjusted(-spread, -spread + 8 * scaleY,
-                                                 spread, spread + 8 * scaleY),
-                              14 * scaleX + spread, 14 * scaleY + spread);
-    }
+    if (imageShadow)
+      paintCaptureImageShadow(painter, imageRect, scaleX, scaleY);
     QPainterPath clip;
     clip.addRoundedRect(imageRect, 14 * scaleX, 14 * scaleY);
     painter.save();
@@ -1308,6 +1497,8 @@ QString backgroundStyleName(BackgroundStyle style) {
   switch (style) {
   case BackgroundStyle::None:
     return QStringLiteral("none");
+  case BackgroundStyle::Slate:
+    return QStringLiteral("slate");
   case BackgroundStyle::Aurora:
     return QStringLiteral("aurora");
   case BackgroundStyle::Sunset:
@@ -1323,6 +1514,8 @@ QString backgroundStyleName(BackgroundStyle style) {
 bool backgroundStyleFromName(const QString &name, BackgroundStyle &style) {
   if (name == QStringLiteral("none"))
     style = BackgroundStyle::None;
+  else if (name == QStringLiteral("slate"))
+    style = BackgroundStyle::Slate;
   else if (name == QStringLiteral("aurora"))
     style = BackgroundStyle::Aurora;
   else if (name == QStringLiteral("sunset"))
@@ -1439,6 +1632,7 @@ QJsonObject operationToJson(const Operation &operation) {
     object.insert(QStringLiteral("type"), QStringLiteral("background"));
     object.insert(QStringLiteral("style"),
                   backgroundStyleName(operation.background));
+    object.insert(QStringLiteral("shadow"), operation.imageShadow);
     break;
   case Operation::Type::Annotate:
     object.insert(QStringLiteral("type"), QStringLiteral("annotate"));
@@ -1492,6 +1686,7 @@ bool operationFromJson(const QJsonObject &object, Operation &operation,
       error = QStringLiteral("Operation log has an unknown background style");
       return false;
     }
+    operation.imageShadow = object.value(QStringLiteral("shadow")).toBool(true);
     return true;
   }
   if (type == QStringLiteral("annotate")) {

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -70,10 +70,15 @@ QRectF annotationTextBounds(const Annotation &annotation) {
 }
 
 QRectF captureCanvasRect(const QSizeF &sourceFrameSize,
-                         const QVector<Annotation> &annotations) {
-  QRectF canvas(QPointF(), sourceFrameSize);
-  if (canvas.isEmpty())
+                         const QVector<Annotation> &annotations,
+                         CanvasBoundaryMode boundaryMode) {
+  const QRectF sourceFrame(QPointF(), sourceFrameSize);
+  if (sourceFrame.isEmpty())
     return {};
+  if (boundaryMode == CanvasBoundaryMode::Image)
+    return sourceFrame;
+
+  QRectF canvas = sourceFrame;
 
   const auto pointBounds = [](const QVector<QPointF> &points) {
     if (points.isEmpty())
@@ -154,7 +159,6 @@ QRectF captureCanvasRect(const QSizeF &sourceFrameSize,
       canvas = canvas.united(bounds);
   }
 
-  const QRectF sourceFrame(QPointF(), sourceFrameSize);
   const bool growsLeft = canvas.left() < sourceFrame.left();
   const bool growsTop = canvas.top() < sourceFrame.top();
   const bool growsRight = canvas.right() > sourceFrame.right();
@@ -166,6 +170,8 @@ QRectF captureCanvasRect(const QSizeF &sourceFrameSize,
   // whose annotation exceeds it. Source and layer coordinates stay fixed.
   const QRectF backdropFrame = sourceFrame.adjusted(
       -kBackdropMargin, -kBackdropMargin, kBackdropMargin, kBackdropMargin);
+  if (boundaryMode == CanvasBoundaryMode::Frame)
+    return backdropFrame;
   const qreal left = std::floor(std::min(canvas.left(), backdropFrame.left()));
   const qreal top = std::floor(std::min(canvas.top(), backdropFrame.top()));
   const qreal right =
@@ -955,7 +961,8 @@ bool captureFocusedMonitor(CaptureData &capture, bool includeWindows,
 
 QImage renderCapture(const CaptureData &capture, const QRectF &selection,
                      const QVector<Annotation> &annotations,
-                     BackgroundStyle backgroundStyle, bool imageShadow) {
+                     BackgroundStyle backgroundStyle, bool imageShadow,
+                     CanvasBoundaryMode boundaryMode) {
   const QRect pixels = pixelSelection(capture, selection);
   if (pixels.isEmpty())
     return {};
@@ -991,7 +998,8 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
                   resized ? scaleY : sourceScaleY,
                   resized ? QPointF{} : sourceOriginOffset);
   const QRectF sourceFrame(QPointF(), selection.size());
-  const QRectF canvas = captureCanvasRect(selection.size(), annotations);
+  const QRectF canvas =
+      captureCanvasRect(selection.size(), annotations, boundaryMode);
   const bool canvasGrown = canvas.left() < sourceFrame.left() - 0.001 ||
                            canvas.top() < sourceFrame.top() - 0.001 ||
                            canvas.right() > sourceFrame.right() + 0.001 ||
@@ -1537,6 +1545,30 @@ bool backgroundStyleFromName(const QString &name, BackgroundStyle &style) {
   return true;
 }
 
+QString canvasBoundaryModeName(CanvasBoundaryMode mode) {
+  switch (mode) {
+  case CanvasBoundaryMode::Grow:
+    return QStringLiteral("grow");
+  case CanvasBoundaryMode::Frame:
+    return QStringLiteral("frame");
+  case CanvasBoundaryMode::Image:
+    return QStringLiteral("image");
+  }
+  return QStringLiteral("grow");
+}
+
+bool canvasBoundaryModeFromName(const QString &name,
+                                CanvasBoundaryMode &mode) {
+  if (name == QStringLiteral("grow"))
+    mode = CanvasBoundaryMode::Grow;
+  else if (name == QStringLiteral("frame"))
+    mode = CanvasBoundaryMode::Frame;
+  else if (name == QStringLiteral("image"))
+    mode = CanvasBoundaryMode::Image;
+  else
+    return false;
+  return true;
+}
 QJsonObject annotationToJson(const Annotation &annotation) {
   QJsonObject object;
   object.insert(QStringLiteral("id"), QString::number(annotation.id));
@@ -1642,6 +1674,11 @@ QJsonObject operationToJson(const Operation &operation) {
                   backgroundStyleName(operation.background));
     object.insert(QStringLiteral("shadow"), operation.imageShadow);
     break;
+  case Operation::Type::CanvasBoundary:
+    object.insert(QStringLiteral("type"), QStringLiteral("canvas-boundary"));
+    object.insert(QStringLiteral("mode"),
+                  canvasBoundaryModeName(operation.canvasBoundary));
+    break;
   case Operation::Type::Annotate:
     object.insert(QStringLiteral("type"), QStringLiteral("annotate"));
     if (!operation.annotations.isEmpty())
@@ -1695,6 +1732,16 @@ bool operationFromJson(const QJsonObject &object, Operation &operation,
       return false;
     }
     operation.imageShadow = object.value(QStringLiteral("shadow")).toBool(true);
+    return true;
+  }
+  if (type == QStringLiteral("canvas-boundary")) {
+    operation.type = Operation::Type::CanvasBoundary;
+    if (!canvasBoundaryModeFromName(
+            object.value(QStringLiteral("mode")).toString(),
+            operation.canvasBoundary)) {
+      error = QStringLiteral("Operation log has an unknown canvas boundary");
+      return false;
+    }
     return true;
   }
   if (type == QStringLiteral("annotate")) {

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -166,12 +166,19 @@ QRectF captureCanvasRect(const QSizeF &sourceFrameSize,
   if (!growsLeft && !growsTop && !growsRight && !growsBottom)
     return sourceFrame;
 
-  // Begin with the same frame as a regular backdrop, then extend only a side
-  // whose annotation exceeds it. Source and layer coordinates stay fixed.
+  if (boundaryMode == CanvasBoundaryMode::Overflow) {
+    const qreal left = std::floor(canvas.left());
+    const qreal top = std::floor(canvas.top());
+    const qreal right = std::ceil(canvas.right());
+    const qreal bottom = std::ceil(canvas.bottom());
+    return {left, top, right - left, bottom - top};
+  }
+
+  // Framed mode begins with the same frame as a regular backdrop, then
+  // extends only a side whose annotation exceeds it. Source and layer
+  // coordinates stay fixed.
   const QRectF backdropFrame = sourceFrame.adjusted(
       -kBackdropMargin, -kBackdropMargin, kBackdropMargin, kBackdropMargin);
-  if (boundaryMode == CanvasBoundaryMode::Frame)
-    return backdropFrame;
   const qreal left = std::floor(std::min(canvas.left(), backdropFrame.left()));
   const qreal top = std::floor(std::min(canvas.top(), backdropFrame.top()));
   const qreal right =
@@ -789,7 +796,8 @@ void paintDefaultLayer(QPainter &painter, const QImage &redacted,
 
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
                             BackgroundStyle backgroundStyle) {
-  if (backgroundStyle == BackgroundStyle::None)
+  if (backgroundStyle == BackgroundStyle::None ||
+      backgroundStyle == BackgroundStyle::Off)
     return;
   if (backgroundStyle == BackgroundStyle::Slate) {
     // Slate is the opaque mat; the image shadow is painted separately.
@@ -1004,10 +1012,13 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
                            canvas.top() < sourceFrame.top() - 0.001 ||
                            canvas.right() > sourceFrame.right() + 0.001 ||
                            canvas.bottom() > sourceFrame.bottom() + 0.001;
+  const bool automaticFramedBackground =
+      boundaryMode == CanvasBoundaryMode::Framed && canvasGrown &&
+      backgroundStyle == BackgroundStyle::None;
   const BackgroundStyle effectiveBackground =
-      canvasGrown && backgroundStyle == BackgroundStyle::None
-          ? BackgroundStyle::Slate
-          : backgroundStyle;
+      automaticFramedBackground ? BackgroundStyle::Slate : backgroundStyle;
+  const bool hasBackground = effectiveBackground != BackgroundStyle::None &&
+                             effectiveBackground != BackgroundStyle::Off;
 
   if (canvasGrown) {
     // The source frame and annotation canvas are intentionally separate.
@@ -1038,7 +1049,7 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
     // The extension is one continuous mat. Its shadow belongs only to the
     // original source card; annotations paint over both in the next pass.
     const QRectF imageRect(growLeft, growTop, cropped.width(), cropped.height());
-    if (imageShadow)
+    if (imageShadow && hasBackground)
       paintCaptureImageShadow(painter, imageRect, scaleX, scaleY);
     painter.drawImage(imageRect.topLeft(), cropped);
     painter.end();
@@ -1064,13 +1075,14 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
     return output;
   }
 
-  const bool hasBackground = effectiveBackground != BackgroundStyle::None;
+  const bool framedBackground =
+      hasBackground && boundaryMode == CanvasBoundaryMode::Framed;
   const int marginX =
-      hasBackground
+      framedBackground
           ? static_cast<int>(std::round(kBackdropMargin * scaleX))
           : 0;
   const int marginY =
-      hasBackground
+      framedBackground
           ? static_cast<int>(std::round(kBackdropMargin * scaleY))
           : 0;
   QImage output(cropped.width() + marginX * 2, cropped.height() + marginY * 2,
@@ -1081,7 +1093,7 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   painter.setRenderHints(QPainter::Antialiasing |
                          QPainter::SmoothPixmapTransform |
                          QPainter::TextAntialiasing);
-  if (hasBackground) {
+  if (framedBackground) {
     paintCaptureBackground(painter, output.rect(), effectiveBackground);
     const QRectF imageRect(marginX, marginY, cropped.width(), cropped.height());
     if (imageShadow)
@@ -1513,6 +1525,8 @@ QString backgroundStyleName(BackgroundStyle style) {
   switch (style) {
   case BackgroundStyle::None:
     return QStringLiteral("none");
+  case BackgroundStyle::Off:
+    return QStringLiteral("off");
   case BackgroundStyle::Slate:
     return QStringLiteral("slate");
   case BackgroundStyle::Aurora:
@@ -1530,6 +1544,8 @@ QString backgroundStyleName(BackgroundStyle style) {
 bool backgroundStyleFromName(const QString &name, BackgroundStyle &style) {
   if (name == QStringLiteral("none"))
     style = BackgroundStyle::None;
+  else if (name == QStringLiteral("off"))
+    style = BackgroundStyle::Off;
   else if (name == QStringLiteral("slate"))
     style = BackgroundStyle::Slate;
   else if (name == QStringLiteral("aurora"))
@@ -1547,22 +1563,22 @@ bool backgroundStyleFromName(const QString &name, BackgroundStyle &style) {
 
 QString canvasBoundaryModeName(CanvasBoundaryMode mode) {
   switch (mode) {
-  case CanvasBoundaryMode::Grow:
-    return QStringLiteral("grow");
-  case CanvasBoundaryMode::Frame:
-    return QStringLiteral("frame");
+  case CanvasBoundaryMode::Framed:
+    return QStringLiteral("framed");
+  case CanvasBoundaryMode::Overflow:
+    return QStringLiteral("overflow");
   case CanvasBoundaryMode::Image:
     return QStringLiteral("image");
   }
-  return QStringLiteral("grow");
+  return QStringLiteral("framed");
 }
 
 bool canvasBoundaryModeFromName(const QString &name,
                                 CanvasBoundaryMode &mode) {
-  if (name == QStringLiteral("grow"))
-    mode = CanvasBoundaryMode::Grow;
-  else if (name == QStringLiteral("frame"))
-    mode = CanvasBoundaryMode::Frame;
+  if (name == QStringLiteral("framed"))
+    mode = CanvasBoundaryMode::Framed;
+  else if (name == QStringLiteral("overflow"))
+    mode = CanvasBoundaryMode::Overflow;
   else if (name == QStringLiteral("image"))
     mode = CanvasBoundaryMode::Image;
   else

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -43,8 +43,8 @@ struct CaptureData {
   QVector<WindowTarget> windows;
 };
 
-enum class BackgroundStyle { None, Slate, Aurora, Sunset, Lagoon, Violet };
-enum class CanvasBoundaryMode { Grow, Frame, Image };
+enum class BackgroundStyle { None, Off, Slate, Aurora, Sunset, Lagoon, Violet };
+enum class CanvasBoundaryMode { Framed, Overflow, Image };
 enum class QuickOutputMode { None, Copy, Save, Both };
 
 enum class SpotlightShape { Ellipse, Rectangle, RoundedRectangle };
@@ -100,7 +100,7 @@ struct Operation {
   QRectF crop;
   BackgroundStyle background = BackgroundStyle::None;
   bool imageShadow = true;
-  CanvasBoundaryMode canvasBoundary = CanvasBoundaryMode::Grow;
+  CanvasBoundaryMode canvasBoundary = CanvasBoundaryMode::Framed;
   QVector<Annotation> annotations;
   QVector<quint64> ids;
   CutOp cut;
@@ -161,7 +161,7 @@ enum class AnnotationLayer { Redaction, Default };
 [[nodiscard]] QRectF
 captureCanvasRect(const QSizeF &sourceFrameSize,
                   const QVector<Annotation> &annotations,
-                  CanvasBoundaryMode boundaryMode = CanvasBoundaryMode::Grow);
+                  CanvasBoundaryMode boundaryMode = CanvasBoundaryMode::Framed);
 /** Captures the named output through ext-image-copy-capture. */
 /** A live native capture session for one output (`MonitorInfo::name`, e.g.
  *  "DP-3") over its own Wayland connection: open once, then grab frames
@@ -216,7 +216,7 @@ void describeFileCapture(CaptureData &capture, QImage image,
                                    BackgroundStyle backgroundStyle,
                                    bool imageShadow = true,
                                    CanvasBoundaryMode boundaryMode =
-                                       CanvasBoundaryMode::Grow);
+                                       CanvasBoundaryMode::Framed);
 /** Loads the current Wayland clipboard image. */
 [[nodiscard]] bool loadClipboardImage(QImage &image, QString &error);
 [[nodiscard]] bool copyPngFileToClipboard(const QString &path, QString &error);

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -43,7 +43,7 @@ struct CaptureData {
   QVector<WindowTarget> windows;
 };
 
-enum class BackgroundStyle { None, Aurora, Sunset, Lagoon, Violet };
+enum class BackgroundStyle { None, Slate, Aurora, Sunset, Lagoon, Violet };
 enum class QuickOutputMode { None, Copy, Save, Both };
 
 enum class SpotlightShape { Ellipse, Rectangle, RoundedRectangle };
@@ -90,6 +90,7 @@ struct Operation {
   Type type = Type::Annotate;
   QRectF crop;
   BackgroundStyle background = BackgroundStyle::None;
+  bool imageShadow = true;
   QVector<Annotation> annotations;
   QVector<quint64> ids;
   CutOp cut;
@@ -140,6 +141,16 @@ enum class AnnotationLayer { Redaction, Default };
 /** Bounds of a text layer's glyph box, or of its readability pill when it
  *  has one; `start` is the baseline origin. */
 [[nodiscard]] QRectF annotationTextBounds(const Annotation &annotation);
+/**
+ * Tight, pixel-aligned annotation space containing both the source frame and
+ * every annotation's painted extent. The source frame always starts at 0,0;
+ * a negative top/left means background was added before it. Keeping this as a
+ * derived value avoids translating layers or repeatedly copying the source as
+ * the canvas grows and shrinks.
+ */
+[[nodiscard]] QRectF
+captureCanvasRect(const QSizeF &sourceFrameSize,
+                  const QVector<Annotation> &annotations);
 /** Captures the named output through ext-image-copy-capture. */
 /** A live native capture session for one output (`MonitorInfo::name`, e.g.
  *  "DP-3") over its own Wayland connection: open once, then grab frames
@@ -191,7 +202,8 @@ void describeFileCapture(CaptureData &capture, QImage image,
 [[nodiscard]] QImage renderCapture(const CaptureData &capture,
                                    const QRectF &selection,
                                    const QVector<Annotation> &annotations,
-                                   BackgroundStyle backgroundStyle);
+                                   BackgroundStyle backgroundStyle,
+                                   bool imageShadow = true);
 /** Loads the current Wayland clipboard image. */
 [[nodiscard]] bool loadClipboardImage(QImage &image, QString &error);
 [[nodiscard]] bool copyPngFileToClipboard(const QString &path, QString &error);
@@ -214,6 +226,9 @@ void paintDefaultLayer(QPainter &painter, const QImage &redacted,
                        const QVector<Annotation> &annotations);
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
                             BackgroundStyle backgroundStyle);
+/** Paints the app's soft ambient-plus-key shadow around `imageRect`. */
+void paintCaptureImageShadow(QPainter &painter, const QRectF &imageRect,
+                             qreal scaleX = 1.0, qreal scaleY = 1.0);
 /**
  * Renders the selection region at `targetSize` for the redaction layer. The
  * result carries no annotations; callers overlay redactions with

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -44,6 +44,7 @@ struct CaptureData {
 };
 
 enum class BackgroundStyle { None, Slate, Aurora, Sunset, Lagoon, Violet };
+enum class CanvasBoundaryMode { Grow, Frame, Image };
 enum class QuickOutputMode { None, Copy, Save, Both };
 
 enum class SpotlightShape { Ellipse, Rectangle, RoundedRectangle };
@@ -85,12 +86,21 @@ struct Annotation {
 };
 
 struct Operation {
-  enum class Type { Crop, Background, Annotate, Patch, Delete, Cut };
+  enum class Type {
+    Crop,
+    Background,
+    CanvasBoundary,
+    Annotate,
+    Patch,
+    Delete,
+    Cut
+  };
 
   Type type = Type::Annotate;
   QRectF crop;
   BackgroundStyle background = BackgroundStyle::None;
   bool imageShadow = true;
+  CanvasBoundaryMode canvasBoundary = CanvasBoundaryMode::Grow;
   QVector<Annotation> annotations;
   QVector<quint64> ids;
   CutOp cut;
@@ -142,15 +152,16 @@ enum class AnnotationLayer { Redaction, Default };
  *  has one; `start` is the baseline origin. */
 [[nodiscard]] QRectF annotationTextBounds(const Annotation &annotation);
 /**
- * Tight, pixel-aligned annotation space containing both the source frame and
- * every annotation's painted extent. The source frame always starts at 0,0;
- * a negative top/left means background was added before it. Keeping this as a
- * derived value avoids translating layers or repeatedly copying the source as
- * the canvas grows and shrinks.
+ * Pixel-aligned annotation space selected by `boundaryMode`. Grow contains
+ * every painted extent, Frame stops at the normal backdrop frame, and Image
+ * stops at the source frame. The source always starts at 0,0; a negative
+ * top/left means background was added before it. Keeping this as a derived
+ * value avoids translating layers or repeatedly copying the source.
  */
 [[nodiscard]] QRectF
 captureCanvasRect(const QSizeF &sourceFrameSize,
-                  const QVector<Annotation> &annotations);
+                  const QVector<Annotation> &annotations,
+                  CanvasBoundaryMode boundaryMode = CanvasBoundaryMode::Grow);
 /** Captures the named output through ext-image-copy-capture. */
 /** A live native capture session for one output (`MonitorInfo::name`, e.g.
  *  "DP-3") over its own Wayland connection: open once, then grab frames
@@ -203,7 +214,9 @@ void describeFileCapture(CaptureData &capture, QImage image,
                                    const QRectF &selection,
                                    const QVector<Annotation> &annotations,
                                    BackgroundStyle backgroundStyle,
-                                   bool imageShadow = true);
+                                   bool imageShadow = true,
+                                   CanvasBoundaryMode boundaryMode =
+                                       CanvasBoundaryMode::Grow);
 /** Loads the current Wayland clipboard image. */
 [[nodiscard]] bool loadClipboardImage(QImage &image, QString &error);
 [[nodiscard]] bool copyPngFileToClipboard(const QString &path, QString &error);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -250,13 +250,15 @@ quint32 freshRedactionSeed() {
 
 /// Offset for a duplicated layer: down-left by default, flipped per axis
 /// when that would push the copy off the canvas and the other way fits.
-QPointF duplicateOffset(const QRectF &bounds, const QSizeF &canvas) {
+QPointF duplicateOffset(const QRectF &bounds, const QRectF &canvas) {
   constexpr qreal step = 100.0;
   qreal dx = -step;
   qreal dy = step;
-  if (bounds.left() + dx < 0 && bounds.right() - dx <= canvas.width())
+  if (bounds.left() + dx < canvas.left() &&
+      bounds.right() - dx <= canvas.right())
     dx = -dx;
-  if (bounds.bottom() + dy > canvas.height() && bounds.top() - dy >= 0)
+  if (bounds.bottom() + dy > canvas.bottom() &&
+      bounds.top() - dy >= canvas.top())
     dy = -dy;
   return {dx, dy};
 }
@@ -476,6 +478,8 @@ QString backgroundName(BackgroundStyle style) {
   switch (style) {
   case BackgroundStyle::None:
     return QStringLiteral("None");
+  case BackgroundStyle::Slate:
+    return QStringLiteral("Window gray");
   case BackgroundStyle::Aurora:
     return QStringLiteral("Aurora");
   case BackgroundStyle::Sunset:
@@ -868,28 +872,6 @@ QRectF CaptureEditor::annotationBounds(const Annotation &annotation) const {
   }
   return QRectF(annotation.start, annotation.end).normalized();
 }
-QRectF CaptureEditor::selectedAnnotationsBounds() const {
-  QRectF bounds;
-  bool initialized = false;
-  for (const int index : selectedAnnotations_) {
-    if (index < 0 || index >= annotations_.size())
-      continue;
-    QRectF annotation = annotationBounds(annotations_.at(index));
-    if (annotation.isNull())
-      continue;
-    // A horizontal arrow or line has zero height, which isEmpty() reports as
-    // nothing at all; give it an extent so the group still covers it.
-    annotation = annotation.normalized();
-    if (annotation.width() <= 0.0)
-      annotation.setWidth(1.0);
-    if (annotation.height() <= 0.0)
-      annotation.setHeight(1.0);
-    bounds = initialized ? bounds.united(annotation) : annotation;
-    initialized = true;
-  }
-  return initialized ? bounds : QRectF();
-}
-
 void CaptureEditor::selectAllAnnotations() {
   if (annotations_.isEmpty()) {
     setStatus(QStringLiteral("No layers to select"));
@@ -1338,7 +1320,7 @@ void CaptureEditor::duplicateSelectedAnnotation() {
   Annotation copy = annotations_.at(selectedAnnotation_);
   copy.id = 0;
   translateAnnotation(
-      copy, duplicateOffset(annotationBounds(copy), selection_.size()));
+      copy, duplicateOffset(annotationBounds(copy), canvasRect_));
   if (copy.kind == Annotation::Kind::Marker)
     copy.number = nextMarker_;
   if (copy.kind == Annotation::Kind::Redaction) {
@@ -1541,6 +1523,10 @@ void CaptureEditor::nudgeSelectedAnnotation(const QPointF &delta) {
     endNudgeRun();
   nudgeTimer_.restart();
   translateAnnotation(annotations_[selectedAnnotation_], delta);
+  // Keyboard geometry has no pointer-to-canvas feedback loop, so refit it
+  // immediately. The coalescing timer still keeps the whole key run in one
+  // undo/snapshot operation.
+  refreshCanvasRect();
   setStatus(QStringLiteral("Nudged · arrows move 1 px · Shift 10 px"));
   nudgePersistTimer_.start();
 }
@@ -1661,15 +1647,15 @@ qreal CaptureEditor::imageTopMargin() const {
 }
 
 QRectF CaptureEditor::baseImageRect() const {
-  if (selection_.isEmpty())
+  if (selection_.isEmpty() || canvasRect_.isEmpty())
     return {};
   const qreal top = imageTopMargin();
   const QRectF available(30, top, std::max(1, width() - 60),
                          std::max<qreal>(1, height() - top - 58));
   const qreal scale =
-      std::min<qreal>({1.0, available.width() / selection_.width(),
-                       available.height() / selection_.height()});
-  const QSizeF shown = selection_.size() * scale;
+      std::min<qreal>({1.0, available.width() / canvasRect_.width(),
+                       available.height() / canvasRect_.height()});
+  const QSizeF shown = canvasRect_.size() * scale;
   // Snapped to the pixel grid: centering can land the origin on a half
   // pixel, which is needless blur at scale 1 (the common case, an
   // unscaled or lightly cropped capture) for no visual benefit.
@@ -1692,9 +1678,9 @@ QRectF CaptureEditor::editImageRect() const {
 
 qreal CaptureEditor::maxViewZoom() const {
   const QRectF base = baseImageRect();
-  if (base.isEmpty() || selection_.width() <= 0)
+  if (base.isEmpty() || canvasRect_.width() <= 0)
     return 1.0;
-  const qreal baseScale = base.width() / selection_.width();
+  const qreal baseScale = base.width() / canvasRect_.width();
   return std::max<qreal>(1.0, 4.0 / std::max<qreal>(baseScale, 0.0001));
 }
 
@@ -1724,13 +1710,15 @@ void CaptureEditor::setViewZoom(qreal zoom, const QPointF &focus) {
   if (qFuzzyCompare(clamped, viewZoom_))
     return;
   const QRectF before = editImageRect();
-  const qreal beforeScale = before.width() > 0 ? before.width() / selection_.width() : 1.0;
+  const qreal beforeScale =
+      before.width() > 0 ? before.width() / canvasRect_.width() : 1.0;
   const QPointF imagePoint((focus.x() - before.left()) / std::max(beforeScale, 1e-6),
                            (focus.y() - before.top()) / std::max(beforeScale, 1e-6));
   viewZoom_ = clamped;
   clampViewOffset();
   const QRectF after = editImageRect();
-  const qreal afterScale = after.width() > 0 ? after.width() / selection_.width() : 1.0;
+  const qreal afterScale =
+      after.width() > 0 ? after.width() / canvasRect_.width() : 1.0;
   const QPointF mappedFocus(after.left() + imagePoint.x() * afterScale,
                             after.top() + imagePoint.y() * afterScale);
   viewOffset_ += focus - mappedFocus;
@@ -1757,7 +1745,7 @@ void CaptureEditor::resetView() {
 }
 
 QVector<QRectF> CaptureEditor::cropHandleRects() const {
-  const QRectF image = editImageRect();
+  const QRectF image = sourceFrameWidgetRect();
   if (image.isEmpty())
     return {};
   constexpr qreal outside = 7;
@@ -1789,25 +1777,35 @@ int CaptureEditor::cropHandleAt(const QPointF &point) const {
 }
 
 qreal CaptureEditor::editScale() const {
-  return selection_.width() > 0 ? editImageRect().width() / selection_.width()
+  return canvasRect_.width() > 0 ? editImageRect().width() / canvasRect_.width()
                                 : 1.0;
+}
+
+QRectF CaptureEditor::sourceFrameWidgetRect() const {
+  const QRectF canvas = editImageRect();
+  if (canvas.isEmpty() || canvasRect_.isEmpty())
+    return {};
+  const qreal scale = std::max<qreal>(editScale(), 0.001);
+  return {canvas.left() - canvasRect_.left() * scale,
+          canvas.top() - canvasRect_.top() * scale,
+          selection_.width() * scale, selection_.height() * scale};
 }
 
 QPointF CaptureEditor::toAnnotationPoint(const QPointF &position) const {
   const QRectF image = editImageRect();
   const qreal scale = std::max<qreal>(editScale(), 0.001);
-  return {std::clamp((position.x() - image.left()) / scale, 0.0,
-                     selection_.width()),
-          std::clamp((position.y() - image.top()) / scale, 0.0,
-                     selection_.height())};
+  return {std::clamp((position.x() - image.left()) / scale + canvasRect_.left(),
+                     canvasRect_.left(), canvasRect_.right()),
+          std::clamp((position.y() - image.top()) / scale + canvasRect_.top(),
+                     canvasRect_.top(), canvasRect_.bottom())};
 }
 
 QPointF
 CaptureEditor::toUnclampedAnnotationPoint(const QPointF &position) const {
   const QRectF image = editImageRect();
   const qreal scale = std::max<qreal>(editScale(), 0.001);
-  return {(position.x() - image.left()) / scale,
-          (position.y() - image.top()) / scale};
+  return {(position.x() - image.left()) / scale + canvasRect_.left(),
+          (position.y() - image.top()) / scale + canvasRect_.top()};
 }
 
 bool CaptureEditor::selectedLayerAcceptsPoint(const QPointF &point) const {
@@ -1998,7 +1996,7 @@ QVector<CaptureEditor::ToolbarButton> CaptureEditor::toolbarButtons() const {
   add(36, QStringLiteral("tool-ocr"), {},
       QStringLiteral("Copy all text in the image · O"));
   add(36, QStringLiteral("background"), {},
-      QStringLiteral("Cycle backdrop · B"));
+      QStringLiteral("Backdrop · B cycles · Shift+B toggles shadow"));
   add(36, QStringLiteral("undo"), {}, QStringLiteral("Undo · Ctrl+Z"));
   add(36, QStringLiteral("redo"), {},
       QStringLiteral("Redo · Ctrl+Shift+Z / Ctrl+Y"));
@@ -2051,14 +2049,43 @@ void CaptureEditor::setStatus(QString status) {
 }
 
 CaptureEditor::EditState CaptureEditor::editState() const {
-  return {annotations_,        backgroundStyle_,     selection_,
-          selectedAnnotation_, selectedAnnotations_, nextMarker_,
-          cuts_};
+  return {annotations_,        backgroundStyle_,     imageShadow_,
+          selection_,          selectedAnnotation_,  selectedAnnotations_,
+          nextMarker_,         cuts_};
+}
+
+void CaptureEditor::refreshCanvasRect() {
+  const QRectF next = selection_.isEmpty()
+                          ? QRectF()
+                          : captureCanvasRect(selection_.size(), annotations_);
+  if (next == canvasRect_)
+    return;
+  canvasRect_ = next;
+  redactionBaseStale_ = true;
+  viewZoom_ = std::min(viewZoom_, maxViewZoom());
+  clampViewOffset();
+}
+
+bool CaptureEditor::canvasGrown() const {
+  if (selection_.isEmpty() || canvasRect_.isEmpty())
+    return false;
+  const QRectF sourceFrame(QPointF(), selection_.size());
+  return canvasRect_.left() < sourceFrame.left() - 0.001 ||
+         canvasRect_.top() < sourceFrame.top() - 0.001 ||
+         canvasRect_.right() > sourceFrame.right() + 0.001 ||
+         canvasRect_.bottom() > sourceFrame.bottom() + 0.001;
+}
+
+BackgroundStyle CaptureEditor::effectiveBackgroundStyle() const {
+  return canvasGrown() && backgroundStyle_ == BackgroundStyle::None
+             ? BackgroundStyle::Slate
+             : backgroundStyle_;
 }
 
 void CaptureEditor::applyEditState(const EditState &state) {
   annotations_ = state.annotations;
   backgroundStyle_ = state.backgroundStyle;
+  imageShadow_ = state.imageShadow;
   selection_ = state.selection;
   selectedAnnotation_ = std::clamp(state.selectedAnnotation, -1,
                                    static_cast<int>(annotations_.size()) - 1);
@@ -2076,6 +2103,7 @@ void CaptureEditor::applyEditState(const EditState &state) {
     cuts_ = state.cuts;
     refreshComposedCapture();
   }
+  refreshCanvasRect();
   editingAnnotation_ = -1;
   interaction_ = Interaction::None;
   freehandPoints_.clear();
@@ -2196,11 +2224,46 @@ void CaptureEditor::commitCut(CutOp cut) {
   commitOp(std::move(op));
 }
 
-void CaptureEditor::commitBackground(BackgroundStyle style) {
+void CaptureEditor::commitBackground(BackgroundStyle style, bool imageShadow) {
   Operation op;
   op.type = Operation::Type::Background;
   op.background = style;
+  op.imageShadow = imageShadow;
   commitOp(std::move(op));
+}
+
+void CaptureEditor::cycleBackground() {
+  BackgroundStyle next = BackgroundStyle::None;
+  bool nextShadow = true;
+  switch (backgroundStyle_) {
+  case BackgroundStyle::None:
+    // None starts the fullscreen/grown-canvas cycle at Aurora.
+    next = BackgroundStyle::Aurora;
+    break;
+  case BackgroundStyle::Slate:
+    // Slate alternates shadowed and flat before wrapping to Aurora.
+    next = imageShadow_ ? BackgroundStyle::Slate : BackgroundStyle::Aurora;
+    nextShadow = !imageShadow_;
+    break;
+  case BackgroundStyle::Aurora:
+    next = BackgroundStyle::Sunset;
+    break;
+  case BackgroundStyle::Sunset:
+    next = BackgroundStyle::Lagoon;
+    break;
+  case BackgroundStyle::Lagoon:
+    next = BackgroundStyle::Violet;
+    break;
+  case BackgroundStyle::Violet:
+    next = BackgroundStyle::Slate;
+    break;
+  }
+  setStatus(QStringLiteral("Backdrop: %1 · shadow %2 · B cycles · Shift+B "
+                           "toggles shadow")
+                .arg(backgroundName(next),
+                     nextShadow ? QStringLiteral("on")
+                                : QStringLiteral("off")));
+  commitBackground(next, nextShadow);
 }
 
 void CaptureEditor::replayLog() {
@@ -2220,6 +2283,7 @@ void CaptureEditor::replayLog() {
                                      : pristineLogicalSize_;
   QRectF selection{QPointF(), QSizeF(startSize)};
   BackgroundStyle background = BackgroundStyle::None;
+  bool imageShadow = true;
   QVector<Annotation> annotations;
   QVector<CutOp> cuts;
   int nextMarker = 1;
@@ -2227,22 +2291,21 @@ void CaptureEditor::replayLog() {
     const Operation &op = ops_.at(index);
     switch (op.type) {
     case Operation::Type::Crop: {
-      // Annotations anchor to the image content, not to the crop frame: a
-      // recrop moves the frame's origin, so every layer shifts by the same
-      // delta to stay over the pixels it was drawn on. This matches what the
-      // live crop drag shows and restores the committed behaviour the
-      // pre-op-log undo model had in 1.13.0. The leading crop replays over
-      // an empty layer list, so it is unaffected.
-      const QPointF originDelta = selection.topLeft() - op.crop.topLeft();
-      if (!originDelta.isNull()) {
+      // Annotation coordinates are relative to the source frame. Preserve
+      // their absolute capture position when a later crop moves that frame,
+      // matching the live crop-handle preview and making undo/reload stable.
+      const QPointF delta = selection.topLeft() - op.crop.topLeft();
+      if (!delta.isNull()) {
         for (Annotation &annotation : annotations)
-          translateAnnotation(annotation, originDelta);
+          translateAnnotation(annotation, delta);
+
       }
       selection = op.crop;
       break;
     }
     case Operation::Type::Background:
       background = op.background;
+      imageShadow = op.imageShadow;
       break;
     case Operation::Type::Annotate:
       for (const Annotation &annotation : op.annotations)
@@ -2301,12 +2364,14 @@ void CaptureEditor::replayLog() {
 
   annotations_ = std::move(annotations);
   backgroundStyle_ = background;
+  imageShadow_ = imageShadow;
   if (cuts != cuts_) {
     cuts_ = std::move(cuts);
     refreshComposedCapture();
   }
   if (!selection.isEmpty())
     selection_ = selection;
+  refreshCanvasRect();
   nextMarker = 1;
   for (const Annotation &annotation : annotations_) {
     if (annotation.kind == Annotation::Kind::Marker)
@@ -2391,7 +2456,8 @@ void CaptureEditor::scheduleSnapshot() {
 }
 
 QImage CaptureEditor::renderCurrentOutput() const {
-  return renderCapture(capture_, selection_, annotations_, backgroundStyle_);
+  return renderCapture(capture_, selection_, annotations_, backgroundStyle_,
+                       imageShadow_);
 }
 
 void CaptureEditor::startSnapshotRender() {
@@ -2460,11 +2526,13 @@ void CaptureEditor::pinSnapshot() {
   const QVector<Annotation> annotations = annotations_;
   const QRectF selection = selection_;
   const BackgroundStyle background = backgroundStyle_;
+  const bool imageShadow = imageShadow_;
   pinWatcher_.setFuture(QtConcurrent::run(
-      [captureCopy, annotations, selection, background, path] {
+      [captureCopy, annotations, selection, background, imageShadow, path] {
         PinResult result;
-        const QImage image =
-            renderCapture(captureCopy, selection, annotations, background);
+        const QImage image = renderCapture(captureCopy, selection,
+                                           annotations, background,
+                                           imageShadow);
         if (image.isNull() ||
             !savePinnedSnapshot(image, path, selection.size().toSize(),
                                 result.error)) {
@@ -2496,6 +2564,7 @@ void CaptureEditor::startCapture(CaptureMode mode, bool includeWindows) {
 void CaptureEditor::enterEdit(QString status) {
   phase_ = Phase::Edit;
   tool_ = Tool::Select;
+  refreshCanvasRect();
   viewZoom_ = 1.0;
   viewOffset_ = {};
   setStatus(std::move(status));
@@ -2678,9 +2747,9 @@ void CaptureEditor::beginText(const QPointF &point, int annotationIndex,
     textSize_ = kTextSizes.at(static_cast<std::size_t>(textSizeIndex_));
   }
 
-  const QRectF image = editImageRect();
+  const QRectF sourceFrame = sourceFrameWidgetRect();
   const qreal scale = editScale();
-  const QPointF position = image.topLeft() + textPoint_ * scale;
+  const QPointF position = sourceFrame.topLeft() + textPoint_ * scale;
   QFont displayFont = annotationTextFont(textSize_);
   displayFont.setPixelSize(
       std::max(12, qRound(displayFont.pixelSize() * scale)));
@@ -2950,15 +3019,16 @@ void CaptureEditor::finish(OutputMode mode) {
   const QRectF selection = selection_;
   const QVector<Annotation> annotations = annotations_;
   const BackgroundStyle background = backgroundStyle_;
+  const bool imageShadow = imageShadow_;
   const QString appSlug =
       appFilenameSlug(dominantAppClass(capture_.windows, selection_));
   finishWatcher_.setFuture(QtConcurrent::run([captureCopy, selection,
-                                              annotations, background, appSlug,
-                                              mode]() {
+                                              annotations, background,
+                                              imageShadow, appSlug, mode]() {
     FinishResult result;
     result.mode = mode;
-    const QImage image =
-        renderCapture(captureCopy, selection, annotations, background);
+    const QImage image = renderCapture(captureCopy, selection, annotations,
+                                       background, imageShadow);
     if (!image.isNull())
       result.thumbnail = image.scaled(kRecentThumbEdge, kRecentThumbEdge,
                                       Qt::KeepAspectRatio,
@@ -3125,13 +3195,9 @@ void CaptureEditor::handleToolbar(const QString &action) {
     customColorPickerOpen_ = !customColorPickerOpen_;
   } else if (action == QStringLiteral("ocr"))
     runOcr();
-  else if (action == QStringLiteral("background")) {
-    const auto next = static_cast<BackgroundStyle>(
-        (static_cast<int>(backgroundStyle_) + 1) % 5);
-    setStatus(QStringLiteral("Backdrop: %1 · B cycles")
-                  .arg(backgroundName(next)));
-    commitBackground(next);
-  } else if (action == QStringLiteral("undo")) {
+  else if (action == QStringLiteral("background"))
+    cycleBackground();
+  else if (action == QStringLiteral("undo")) {
     undoEdit();
   } else if (action == QStringLiteral("redo")) {
     redoEdit();
@@ -3298,7 +3364,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     setStatus(QStringLiteral("Zoom %1% · + / - zoom · 0 fits · wheel scrolls")
                   .arg(qRound(viewZoom_ *
                               (baseImageRect().width() /
-                               std::max<qreal>(selection_.width(), 1)) *
+                               std::max<qreal>(canvasRect_.width(), 1)) *
                               100)));
     return;
   } else if (event->matches(QKeySequence::ZoomOut) ||
@@ -3308,7 +3374,7 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     setStatus(QStringLiteral("Zoom %1% · + / - zoom · 0 fits · wheel scrolls")
                   .arg(qRound(viewZoom_ *
                               (baseImageRect().width() /
-                               std::max<qreal>(selection_.width(), 1)) *
+                               std::max<qreal>(canvasRect_.width(), 1)) *
                               100)));
     return;
   } else if (zoomModifier && event->key() == Qt::Key_0) {
@@ -3474,11 +3540,13 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     pinSnapshot();
     return;
   } else if (event->key() == Qt::Key_B) {
-    const auto next = static_cast<BackgroundStyle>(
-        (static_cast<int>(backgroundStyle_) + 1) % 5);
-    setStatus(QStringLiteral("Backdrop: %1 · B cycles")
-                  .arg(backgroundName(next)));
-    commitBackground(next);
+    if (event->modifiers().testFlag(Qt::ShiftModifier)) {
+      const bool next = !imageShadow_;
+      setStatus(QStringLiteral("Drop shadow: %1 · Shift+B toggles")
+                    .arg(next ? QStringLiteral("on") : QStringLiteral("off")));
+      commitBackground(backgroundStyle_, next);
+    } else
+      cycleBackground();
   } else if (event->key() >= Qt::Key_1 && event->key() <= Qt::Key_8) {
     colorIndex_ = event->key() - Qt::Key_1;
     usingCustomColor_ = false;
@@ -3611,7 +3679,11 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
                 isLayerResize(interaction_)) &&
                dragging_ && selectedAnnotation_ >= 0 &&
                selectedAnnotation_ < annotations_.size()) {
-      const QPointF point = toAnnotationPoint(cursor_);
+      // Keep the drag in the canvas mapping that existed at press time. The
+      // canvas settles once on release; re-fitting it under the pointer on
+      // every motion would feed the new scale back into the geometry and
+      // make an edge drag jitter.
+      const QPointF point = toUnclampedAnnotationPoint(cursor_);
       if (selectedAnnotations_.size() > 1 && interaction_ == Interaction::Move) {
         const QPointF delta = point - dragStart_;
         for (int position = 0;
@@ -3687,7 +3759,9 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
       dragChanged_ = true;
     }
     if (tool_ == Tool::Cut && dragging_) {
-      const QPointF point = toAnnotationPoint(cursor_);
+      QPointF point = toUnclampedAnnotationPoint(cursor_);
+      point.setX(std::clamp(point.x(), 0.0, selection_.width()));
+      point.setY(std::clamp(point.y(), 0.0, selection_.height()));
       const QPointF delta = point - cutDragStart_;
       if (!cutDragActive_ &&
           std::max(std::abs(delta.x()), std::abs(delta.y())) > 3.0) {
@@ -3734,7 +3808,7 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
     }
     if ((tool_ == Tool::Freehand || tool_ == Tool::Highlighter) && dragging_ &&
         interaction_ == Interaction::None) {
-      const QPointF point = toAnnotationPoint(cursor_);
+      const QPointF point = toUnclampedAnnotationPoint(cursor_);
       if (freehandPoints_.isEmpty() ||
           QLineF(freehandPoints_.last(), point).length() >= 1.5)
         freehandPoints_.push_back(point);
@@ -3923,11 +3997,11 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       return;
     }
   }
-  if (tool_ == Tool::Select) {
+  if (tool_ == Tool::Select && selectedAnnotations_.isEmpty()) {
     const int cropHandle = cropHandleAt(cursor_);
     if (cropHandle >= 0) {
       originalSelection_ = selection_;
-      cropDragImageRect_ = editImageRect();
+      cropDragImageRect_ = sourceFrameWidgetRect();
       interaction_ = static_cast<Interaction>(
           static_cast<int>(Interaction::CropTopLeft) + cropHandle);
       dragStartState_ = editState();
@@ -3943,8 +4017,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
   }
   // A layer that ran off the capture keeps its handles and body live outside
   // the canvas, so it can be resized or dragged back in instead of being
-  // stranded. Drags still follow the clamped pointer, so this only ever pulls
-  // layers back; anything else outside the canvas stays inert.
+  // stranded. Anything else outside the canvas stays inert.
   const bool insideImage = editImageRect().contains(cursor_);
   const QPointF point = insideImage ? toAnnotationPoint(cursor_)
                                     : toUnclampedAnnotationPoint(cursor_);
@@ -3952,8 +4025,11 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       (tool_ != Tool::Select || !selectedLayerAcceptsPoint(point)))
     return;
   if (tool_ == Tool::Eyedropper) {
+    if (!sourceFrameWidgetRect().contains(cursor_))
+      return;
     customColor_ = sampleSourceColor(capture_.source, capture_.previewSize,
-                                     selection_, editImageRect(), cursor_);
+                                     selection_, sourceFrameWidgetRect(),
+                                     cursor_);
     usingCustomColor_ = true;
     if (customColor_.hsvHueF() >= 0)
       customHue_ = customColor_.hsvHueF();
@@ -4301,7 +4377,8 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     return;
   }
 
-  const QLineF span = creationSpan(toAnnotationPoint(event->position()));
+  const QLineF span =
+      creationSpan(toUnclampedAnnotationPoint(event->position()));
   const QPointF start = span.p1();
   const QPointF end = span.p2();
   creationConstraintActive_ = false;
@@ -4454,7 +4531,7 @@ void CaptureEditor::wheelEvent(QWheelEvent *event) {
                              "sideways · Ctrl+0 fits")
                   .arg(qRound(viewZoom_ *
                               (baseImageRect().width() /
-                               std::max<qreal>(selection_.width(), 1)) *
+                               std::max<qreal>(canvasRect_.width(), 1)) *
                               100)));
   };
   // One notch is one step; a touchpad's finer increments are a fraction of
@@ -4615,7 +4692,8 @@ void CaptureEditor::updatePointerCursor() {
     return;
   }
   if (tool_ == Tool::Select) {
-    int cropHandle = cropHandleAt(cursor_);
+    int cropHandle =
+        selectedAnnotations_.isEmpty() ? cropHandleAt(cursor_) : -1;
     if (dragging_ && interaction_ >= Interaction::CropTopLeft) {
       cropHandle = static_cast<int>(interaction_) -
                    static_cast<int>(Interaction::CropTopLeft);
@@ -5367,31 +5445,28 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         QRectF(0, top, width(), std::max<qreal>(1, height() - top - 58)));
   }
   const QRectF image = editImageRect();
-  const bool hasBackground = backgroundStyle_ != BackgroundStyle::None;
-  if (hasBackground) {
+  const QRectF sourceImage = sourceFrameWidgetRect();
+  const bool grown = canvasGrown();
+  const BackgroundStyle background = effectiveBackgroundStyle();
+  const bool hasBackground = background != BackgroundStyle::None;
+  if (grown) {
+    // Extension is the canvas itself, while the source remains the image card
+    // floating above it. Never shadow the expanded canvas edge.
+    paintCaptureBackground(painter, image, background);
+    if (imageShadow_)
+      paintCaptureImageShadow(painter, sourceImage);
+  } else if (hasBackground) {
     const QRectF backing = image.adjusted(-28, -28, 28, 28);
-    painter.setPen(Qt::NoPen);
-    for (int layer = 20; layer > 0; --layer) {
-      const qreal spread = layer * 0.7;
-      painter.setBrush(QColor(0, 0, 0, 3 + (20 - layer) / 3));
-      painter.drawRoundedRect(
-          image.adjusted(-spread, -spread + 12, spread, spread + 12),
-          15 + spread, 15 + spread);
-    }
-    for (int layer = 10; layer > 0; --layer) {
-      const qreal spread = layer * 0.45;
-      painter.setBrush(QColor(0, 0, 0, 5 + (10 - layer) * 2));
-      painter.drawRoundedRect(
-          image.adjusted(-spread, -spread + 7, spread, spread + 7), 12 + spread,
-          12 + spread);
-    }
-    paintCaptureBackground(painter, backing, backgroundStyle_);
+    paintCaptureBackground(painter, backing, background);
+    if (imageShadow_)
+      paintCaptureImageShadow(painter, image);
   }
 
   QPainterPath clip;
-  clip.addRoundedRect(image, hasBackground ? 10 : 0, hasBackground ? 10 : 0);
-  const QSize targetSize(qRound(image.width() * devicePixelRatioF()),
-                         qRound(image.height() * devicePixelRatioF()));
+  const qreal sourceRadius = !grown && hasBackground ? 10.0 : 0.0;
+  clip.addRoundedRect(sourceImage, sourceRadius, sourceRadius);
+  const QSize targetSize(qRound(sourceImage.width() * devicePixelRatioF()),
+                         qRound(sourceImage.height() * devicePixelRatioF()));
   // Cache the un-annotated selection at display resolution. Rebuilding it
   // from the native source every pointer move would stall large captures.
   if (redactionBaseStale_ || redactionBaseSize_ != targetSize ||
@@ -5425,7 +5500,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     Annotation preview;
     preview.kind = Annotation::Kind::Redaction;
     preview.start = dragStart_;
-    preview.end = toAnnotationPoint(cursor_);
+    preview.end = toUnclampedAnnotationPoint(cursor_);
     preview.redactionStyle = redactionStyle_;
     preview.redactionSeed = activeRedactionSeed_;
     redactionLayer = applyRedactionsScaled(redactionLayerCache_, {preview},
@@ -5435,17 +5510,23 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   painter.save();
   painter.setClipPath(clip);
   if (!redactionLayer.isNull())
-    painter.drawImage(image, redactionLayer);
+    painter.drawImage(sourceImage, redactionLayer);
   else
-    painter.drawImage(image, capture_.source, sourceRect(selection_));
+    painter.drawImage(sourceImage, capture_.source, sourceRect(selection_));
 
   painter.restore();
 
+  QImage defaultLayerSource = redactionLayer;
+  QRectF defaultLayerBounds(QPointF(), selection_.size());
+
   painter.save();
-  painter.translate(image.topLeft());
+  painter.translate(sourceImage.topLeft());
   painter.scale(editScale(), editScale());
   painter.save();
-  painter.setClipRect(QRectF(QPointF(), selection_.size()));
+  // While a layer is being carried, let it remain visible over the surround;
+  // the background settles to its final integer bounds once on release.
+  if (!dragging_)
+    painter.setClipRect(canvasRect_);
   QVector<Annotation> defaultAnnotations;
   defaultAnnotations.reserve(annotations_.size() + 1);
   for (int index = 0; index < annotations_.size(); ++index) {
@@ -5479,7 +5560,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         if (tool_ == Tool::Rectangle)
           preview.cornerRadius = cornerRadius_;
       }
-      const QLineF span = creationSpan(toAnnotationPoint(cursor_));
+      const QLineF span =
+          creationSpan(toUnclampedAnnotationPoint(cursor_));
       preview.start = span.p1();
       preview.end = span.p2();
     }
@@ -5505,11 +5587,53 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     preview.size = annotationSize_;
     defaultAnnotations.push_back(std::move(preview));
   }
-  // Default-layer tools (including spotlight) sample the redaction layer,
-  // never the raw capture. The layer image is already the selection crop.
-  if (!redactionLayer.isNull()) {
-    paintDefaultLayer(painter, redactionLayer,
-                      QRectF(QPointF(), selection_.size()), defaultAnnotations);
+  const bool hasSpotlight = std::any_of(
+      defaultAnnotations.cbegin(), defaultAnnotations.cend(),
+      [](const Annotation &item) {
+        return item.kind == Annotation::Kind::Spotlight;
+      });
+  if (hasSpotlight && !redactionLayer.isNull()) {
+    // Spotlights sample the complete composed canvas. Build that source only
+    // when one is present; a dragged preview may temporarily make it larger
+    // than the settled canvas, so its opening stays live beyond the old edge.
+    const QRectF spotlightCanvas =
+        captureCanvasRect(selection_.size(), defaultAnnotations);
+    const bool spotlightGrown = spotlightCanvas !=
+                                QRectF(QPointF(), selection_.size());
+    if (grown || spotlightGrown) {
+      const qreal pixelScale = editScale() * devicePixelRatioF();
+      const QSize canvasPixels(
+          std::max(1, qCeil(spotlightCanvas.width() * pixelScale)),
+          std::max(1, qCeil(spotlightCanvas.height() * pixelScale)));
+      defaultLayerSource =
+          QImage(canvasPixels, QImage::Format_ARGB32_Premultiplied);
+      defaultLayerSource.fill(Qt::transparent);
+      QPainter basePainter(&defaultLayerSource);
+      basePainter.setRenderHints(QPainter::SmoothPixmapTransform);
+      const BackgroundStyle spotlightBackground =
+          spotlightGrown && backgroundStyle_ == BackgroundStyle::None
+              ? BackgroundStyle::Slate
+              : background;
+      paintCaptureBackground(basePainter, defaultLayerSource.rect(),
+                             spotlightBackground);
+      const QRectF sourcePixels(-spotlightCanvas.left() * pixelScale,
+                                -spotlightCanvas.top() * pixelScale,
+                                selection_.width() * pixelScale,
+                                selection_.height() * pixelScale);
+      if (imageShadow_)
+        paintCaptureImageShadow(basePainter, sourcePixels, pixelScale,
+                                pixelScale);
+      basePainter.drawImage(sourcePixels, redactionLayer);
+      basePainter.end();
+      defaultLayerBounds = spotlightCanvas;
+    }
+  }
+  // Default-layer tools (including spotlight) sample the redacted composed
+  // canvas, never the raw capture. Once grown this includes the background,
+  // so a spotlight carried past the old frame has valid pixels to sample.
+  if (!defaultLayerSource.isNull()) {
+    paintDefaultLayer(painter, defaultLayerSource, defaultLayerBounds,
+                      defaultAnnotations);
   } else {
     for (const Annotation &annotation : defaultAnnotations)
       paintAnnotation(painter, annotation);
@@ -5569,26 +5693,19 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       selectedAnnotation_ != editingAnnotation_) {
     const qreal scale = std::max<qreal>(editScale(), 0.01);
     const bool multiple = selectedAnnotations_.size() > 1;
-    const QRectF bounds =
-        (multiple ? selectedAnnotationsBounds()
-                  : annotationBounds(annotations_.at(selectedAnnotation_)))
-            .adjusted(-4, -4, 4, 4);
     // Faint while a wheel adjustment is in flight: the handles sit exactly
     // where the change shows, so at full strength they hide it.
     const qreal chromeOpacity = adjustingSelection_ ? 0.25 : 1.0;
     painter.setOpacity(chromeOpacity);
-    if (multiple ||
+    if (!multiple &&
         showsSelectionBounds(annotations_.at(selectedAnnotation_).kind)) {
-      // The union reads as the group's extent, so draw it faintly and outline
-      // each member on top: otherwise a select-all looks like one box with no
-      // way to tell what is in it, and a flat arrow shows nothing at all.
-      painter.setPen(QPen(QColor(255, 255, 255, multiple ? 110 : 220),
-                          1.0 / scale, Qt::DashLine));
+      const Annotation &selected = annotations_.at(selectedAnnotation_);
+      const QRectF bounds =
+          annotationBounds(selected).adjusted(-4, -4, 4, 4);
+      painter.setPen(
+          QPen(QColor(255, 255, 255, 220), 1.0 / scale, Qt::DashLine));
       painter.setBrush(Qt::NoBrush);
-      const qreal boxRadius =
-          multiple ? 0.0
-                   : selectionBoundsRadius(
-                         annotations_.at(selectedAnnotation_), 4.0);
+      const qreal boxRadius = selectionBoundsRadius(selected, 4.0);
       if (boxRadius > 0.0)
         painter.drawRoundedRect(bounds, boxRadius, boxRadius);
       else
@@ -5598,6 +5715,9 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       painter.setPen(
           QPen(QColor(255, 255, 255, 220), 1.0 / scale, Qt::DashLine));
       painter.setBrush(Qt::NoBrush);
+      // A multi-selection has no synthetic outer object: that reads as if the
+      // whole grown canvas were selected. Outline each actual layer instead,
+      // consistently for Ctrl-click, marquee, and Ctrl+A groups.
       for (const int index : selectedAnnotations_) {
         if (index < 0 || index >= annotations_.size() ||
             index == editingAnnotation_)
@@ -5622,12 +5742,19 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     painter.setOpacity(1.0);
   }
   painter.restore();
-  paintOcrOverlay(painter, image, editScale());
+  paintOcrOverlay(painter, sourceImage, editScale());
 
-  if (tool_ == Tool::Select) {
+  // Screenshot chrome means "crop this source", not "this is another
+  // selected object". Keep it out of the layer-selection state entirely;
+  // clicking empty canvas puts the layers down and brings cropping back.
+  if (tool_ == Tool::Select && selectedAnnotations_.isEmpty()) {
     painter.setPen(QPen(QColor(QStringLiteral("#0a84ff")), 1, Qt::DashLine));
     painter.setBrush(Qt::NoBrush);
     painter.drawRect(image.adjusted(-1, -1, 1, 1));
+    if (grown) {
+      painter.setPen(QPen(QColor(10, 132, 255, 100), 1, Qt::DashLine));
+      painter.drawRect(sourceImage);
+    }
     painter.setPen(QPen(QColor(QStringLiteral("#0a84ff")), 2));
     painter.setBrush(QColor(QStringLiteral("#f5f5f7")));
     for (const QRectF &handle : cropHandleRects())

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -491,6 +491,18 @@ QString backgroundName(BackgroundStyle style) {
   }
   return {};
 }
+
+QString canvasBoundaryName(CanvasBoundaryMode mode) {
+  switch (mode) {
+  case CanvasBoundaryMode::Grow:
+    return QStringLiteral("Grow");
+  case CanvasBoundaryMode::Frame:
+    return QStringLiteral("Frame");
+  case CanvasBoundaryMode::Image:
+    return QStringLiteral("Image");
+  }
+  return {};
+}
 } // namespace
 
 QPointF constrainedCreationEndpoint(CaptureEditor::Tool tool,
@@ -2049,15 +2061,16 @@ void CaptureEditor::setStatus(QString status) {
 }
 
 CaptureEditor::EditState CaptureEditor::editState() const {
-  return {annotations_,        backgroundStyle_,     imageShadow_,
-          selection_,          selectedAnnotation_,  selectedAnnotations_,
-          nextMarker_,         cuts_};
+  return {annotations_,       backgroundStyle_,     imageShadow_,
+          canvasBoundaryMode_, selection_,           selectedAnnotation_,
+          selectedAnnotations_, nextMarker_,         cuts_};
 }
 
 void CaptureEditor::refreshCanvasRect() {
   const QRectF next = selection_.isEmpty()
                           ? QRectF()
-                          : captureCanvasRect(selection_.size(), annotations_);
+                          : captureCanvasRect(selection_.size(), annotations_,
+                                              canvasBoundaryMode_);
   if (next == canvasRect_)
     return;
   canvasRect_ = next;
@@ -2086,6 +2099,7 @@ void CaptureEditor::applyEditState(const EditState &state) {
   annotations_ = state.annotations;
   backgroundStyle_ = state.backgroundStyle;
   imageShadow_ = state.imageShadow;
+  canvasBoundaryMode_ = state.canvasBoundary;
   selection_ = state.selection;
   selectedAnnotation_ = std::clamp(state.selectedAnnotation, -1,
                                    static_cast<int>(annotations_.size()) - 1);
@@ -2232,6 +2246,45 @@ void CaptureEditor::commitBackground(BackgroundStyle style, bool imageShadow) {
   commitOp(std::move(op));
 }
 
+void CaptureEditor::commitCanvasBoundary(CanvasBoundaryMode mode) {
+  Operation op;
+  op.type = Operation::Type::CanvasBoundary;
+  op.canvasBoundary = mode;
+  commitOp(std::move(op));
+}
+
+void CaptureEditor::cycleCanvasBoundary(bool reverse) {
+  CanvasBoundaryMode next = CanvasBoundaryMode::Grow;
+  if (reverse) {
+    switch (canvasBoundaryMode_) {
+    case CanvasBoundaryMode::Grow:
+      next = CanvasBoundaryMode::Image;
+      break;
+    case CanvasBoundaryMode::Frame:
+      next = CanvasBoundaryMode::Grow;
+      break;
+    case CanvasBoundaryMode::Image:
+      next = CanvasBoundaryMode::Frame;
+      break;
+    }
+  } else {
+    switch (canvasBoundaryMode_) {
+    case CanvasBoundaryMode::Grow:
+      next = CanvasBoundaryMode::Frame;
+      break;
+    case CanvasBoundaryMode::Frame:
+      next = CanvasBoundaryMode::Image;
+      break;
+    case CanvasBoundaryMode::Image:
+      next = CanvasBoundaryMode::Grow;
+      break;
+    }
+  }
+  setStatus(QStringLiteral("Canvas: %1 · G cycles · Shift+G reverses")
+                .arg(canvasBoundaryName(next)));
+  commitCanvasBoundary(next);
+}
+
 void CaptureEditor::cycleBackground() {
   BackgroundStyle next = BackgroundStyle::None;
   bool nextShadow = true;
@@ -2284,6 +2337,7 @@ void CaptureEditor::replayLog() {
   QRectF selection{QPointF(), QSizeF(startSize)};
   BackgroundStyle background = BackgroundStyle::None;
   bool imageShadow = true;
+  CanvasBoundaryMode canvasBoundary = CanvasBoundaryMode::Grow;
   QVector<Annotation> annotations;
   QVector<CutOp> cuts;
   int nextMarker = 1;
@@ -2306,6 +2360,9 @@ void CaptureEditor::replayLog() {
     case Operation::Type::Background:
       background = op.background;
       imageShadow = op.imageShadow;
+      break;
+    case Operation::Type::CanvasBoundary:
+      canvasBoundary = op.canvasBoundary;
       break;
     case Operation::Type::Annotate:
       for (const Annotation &annotation : op.annotations)
@@ -2365,6 +2422,7 @@ void CaptureEditor::replayLog() {
   annotations_ = std::move(annotations);
   backgroundStyle_ = background;
   imageShadow_ = imageShadow;
+  canvasBoundaryMode_ = canvasBoundary;
   if (cuts != cuts_) {
     cuts_ = std::move(cuts);
     refreshComposedCapture();
@@ -2457,7 +2515,7 @@ void CaptureEditor::scheduleSnapshot() {
 
 QImage CaptureEditor::renderCurrentOutput() const {
   return renderCapture(capture_, selection_, annotations_, backgroundStyle_,
-                       imageShadow_);
+                       imageShadow_, canvasBoundaryMode_);
 }
 
 void CaptureEditor::startSnapshotRender() {
@@ -2527,12 +2585,14 @@ void CaptureEditor::pinSnapshot() {
   const QRectF selection = selection_;
   const BackgroundStyle background = backgroundStyle_;
   const bool imageShadow = imageShadow_;
+  const CanvasBoundaryMode canvasBoundary = canvasBoundaryMode_;
   pinWatcher_.setFuture(QtConcurrent::run(
-      [captureCopy, annotations, selection, background, imageShadow, path] {
+      [captureCopy, annotations, selection, background, imageShadow,
+       canvasBoundary, path] {
         PinResult result;
-        const QImage image = renderCapture(captureCopy, selection,
-                                           annotations, background,
-                                           imageShadow);
+        const QImage image =
+            renderCapture(captureCopy, selection, annotations, background,
+                          imageShadow, canvasBoundary);
         if (image.isNull() ||
             !savePinnedSnapshot(image, path, selection.size().toSize(),
                                 result.error)) {
@@ -3020,15 +3080,18 @@ void CaptureEditor::finish(OutputMode mode) {
   const QVector<Annotation> annotations = annotations_;
   const BackgroundStyle background = backgroundStyle_;
   const bool imageShadow = imageShadow_;
+  const CanvasBoundaryMode canvasBoundary = canvasBoundaryMode_;
   const QString appSlug =
       appFilenameSlug(dominantAppClass(capture_.windows, selection_));
   finishWatcher_.setFuture(QtConcurrent::run([captureCopy, selection,
                                               annotations, background,
-                                              imageShadow, appSlug, mode]() {
+                                              imageShadow, canvasBoundary,
+                                              appSlug, mode]() {
     FinishResult result;
     result.mode = mode;
     const QImage image = renderCapture(captureCopy, selection, annotations,
-                                       background, imageShadow);
+                                       background, imageShadow,
+                                       canvasBoundary);
     if (!image.isNull())
       result.thumbnail = image.scaled(kRecentThumbEdge, kRecentThumbEdge,
                                       Qt::KeepAspectRatio,
@@ -3539,6 +3602,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if (event->key() == Qt::Key_P) {
     pinSnapshot();
     return;
+  } else if (event->key() == Qt::Key_G) {
+    cycleCanvasBoundary(
+        event->modifiers().testFlag(Qt::ShiftModifier));
   } else if (event->key() == Qt::Key_B) {
     if (event->modifiers().testFlag(Qt::ShiftModifier)) {
       const bool next = !imageShadow_;
@@ -5587,6 +5653,32 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     preview.size = annotationSize_;
     defaultAnnotations.push_back(std::move(preview));
   }
+  QRectF previewClip = canvasRect_;
+  if (dragging_ && canvasBoundaryMode_ != CanvasBoundaryMode::Grow) {
+    previewClip = captureCanvasRect(selection_.size(), defaultAnnotations,
+                                    canvasBoundaryMode_);
+  }
+  if (previewClip != canvasRect_) {
+    QPainterPath overscan;
+    overscan.addRect(previewClip);
+    QPainterPath settledCanvas;
+    settledCanvas.addRect(canvasRect_);
+    overscan = overscan.subtracted(settledCanvas);
+    const bool previewGrown =
+        previewClip != QRectF(QPointF(), selection_.size());
+    const BackgroundStyle previewBackground =
+        previewGrown && backgroundStyle_ == BackgroundStyle::None
+            ? BackgroundStyle::Slate
+            : background;
+    painter.save();
+    painter.setClipPath(overscan, Qt::IntersectClip);
+    paintCaptureBackground(painter, previewClip, previewBackground);
+    painter.restore();
+  }
+  // Grow shows the complete layer while it is being carried and settles the
+  // background on release. The two clipping modes preview their cutoff live.
+  if (!dragging_ || canvasBoundaryMode_ != CanvasBoundaryMode::Grow)
+    painter.setClipRect(previewClip, Qt::IntersectClip);
   const bool hasSpotlight = std::any_of(
       defaultAnnotations.cbegin(), defaultAnnotations.cend(),
       [](const Annotation &item) {
@@ -5597,7 +5689,8 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     // when one is present; a dragged preview may temporarily make it larger
     // than the settled canvas, so its opening stays live beyond the old edge.
     const QRectF spotlightCanvas =
-        captureCanvasRect(selection_.size(), defaultAnnotations);
+        captureCanvasRect(selection_.size(), defaultAnnotations,
+                          canvasBoundaryMode_);
     const bool spotlightGrown = spotlightCanvas !=
                                 QRectF(QPointF(), selection_.size());
     if (grown || spotlightGrown) {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -478,6 +478,8 @@ QString backgroundName(BackgroundStyle style) {
   switch (style) {
   case BackgroundStyle::None:
     return QStringLiteral("None");
+  case BackgroundStyle::Off:
+    return QStringLiteral("Off");
   case BackgroundStyle::Slate:
     return QStringLiteral("Window gray");
   case BackgroundStyle::Aurora:
@@ -494,10 +496,10 @@ QString backgroundName(BackgroundStyle style) {
 
 QString canvasBoundaryName(CanvasBoundaryMode mode) {
   switch (mode) {
-  case CanvasBoundaryMode::Grow:
-    return QStringLiteral("Grow");
-  case CanvasBoundaryMode::Frame:
-    return QStringLiteral("Frame");
+  case CanvasBoundaryMode::Framed:
+    return QStringLiteral("Framed");
+  case CanvasBoundaryMode::Overflow:
+    return QStringLiteral("Overflow");
   case CanvasBoundaryMode::Image:
     return QStringLiteral("Image");
   }
@@ -2090,9 +2092,11 @@ bool CaptureEditor::canvasGrown() const {
 }
 
 BackgroundStyle CaptureEditor::effectiveBackgroundStyle() const {
-  return canvasGrown() && backgroundStyle_ == BackgroundStyle::None
-             ? BackgroundStyle::Slate
-             : backgroundStyle_;
+  const bool automaticFramedBackground =
+      canvasBoundaryMode_ == CanvasBoundaryMode::Framed && canvasGrown() &&
+      backgroundStyle_ == BackgroundStyle::None;
+  return automaticFramedBackground ? BackgroundStyle::Slate
+                                   : backgroundStyle_;
 }
 
 void CaptureEditor::applyEditState(const EditState &state) {
@@ -2254,29 +2258,29 @@ void CaptureEditor::commitCanvasBoundary(CanvasBoundaryMode mode) {
 }
 
 void CaptureEditor::cycleCanvasBoundary(bool reverse) {
-  CanvasBoundaryMode next = CanvasBoundaryMode::Grow;
+  CanvasBoundaryMode next = CanvasBoundaryMode::Framed;
   if (reverse) {
     switch (canvasBoundaryMode_) {
-    case CanvasBoundaryMode::Grow:
+    case CanvasBoundaryMode::Framed:
       next = CanvasBoundaryMode::Image;
       break;
-    case CanvasBoundaryMode::Frame:
-      next = CanvasBoundaryMode::Grow;
+    case CanvasBoundaryMode::Overflow:
+      next = CanvasBoundaryMode::Framed;
       break;
     case CanvasBoundaryMode::Image:
-      next = CanvasBoundaryMode::Frame;
+      next = CanvasBoundaryMode::Overflow;
       break;
     }
   } else {
     switch (canvasBoundaryMode_) {
-    case CanvasBoundaryMode::Grow:
-      next = CanvasBoundaryMode::Frame;
+    case CanvasBoundaryMode::Framed:
+      next = CanvasBoundaryMode::Overflow;
       break;
-    case CanvasBoundaryMode::Frame:
+    case CanvasBoundaryMode::Overflow:
       next = CanvasBoundaryMode::Image;
       break;
     case CanvasBoundaryMode::Image:
-      next = CanvasBoundaryMode::Grow;
+      next = CanvasBoundaryMode::Framed;
       break;
     }
   }
@@ -2290,13 +2294,16 @@ void CaptureEditor::cycleBackground() {
   bool nextShadow = true;
   switch (backgroundStyle_) {
   case BackgroundStyle::None:
-    // None starts the fullscreen/grown-canvas cycle at Aurora.
+  case BackgroundStyle::Off:
     next = BackgroundStyle::Aurora;
     break;
   case BackgroundStyle::Slate:
-    // Slate alternates shadowed and flat before wrapping to Aurora.
-    next = imageShadow_ ? BackgroundStyle::Slate : BackgroundStyle::Aurora;
-    nextShadow = !imageShadow_;
+    if (imageShadow_) {
+      next = BackgroundStyle::Slate;
+      nextShadow = false;
+    } else {
+      next = BackgroundStyle::Off;
+    }
     break;
   case BackgroundStyle::Aurora:
     next = BackgroundStyle::Sunset;
@@ -2311,11 +2318,15 @@ void CaptureEditor::cycleBackground() {
     next = BackgroundStyle::Slate;
     break;
   }
-  setStatus(QStringLiteral("Backdrop: %1 · shadow %2 · B cycles · Shift+B "
-                           "toggles shadow")
-                .arg(backgroundName(next),
-                     nextShadow ? QStringLiteral("on")
-                                : QStringLiteral("off")));
+  if (next == BackgroundStyle::Off) {
+    setStatus(QStringLiteral("Backdrop: Off · B cycles"));
+  } else {
+    setStatus(QStringLiteral("Backdrop: %1 · shadow %2 · B cycles · Shift+B "
+                             "toggles shadow")
+                  .arg(backgroundName(next),
+                       nextShadow ? QStringLiteral("on")
+                                  : QStringLiteral("off")));
+  }
   commitBackground(next, nextShadow);
 }
 
@@ -2337,7 +2348,7 @@ void CaptureEditor::replayLog() {
   QRectF selection{QPointF(), QSizeF(startSize)};
   BackgroundStyle background = BackgroundStyle::None;
   bool imageShadow = true;
-  CanvasBoundaryMode canvasBoundary = CanvasBoundaryMode::Grow;
+  CanvasBoundaryMode canvasBoundary = CanvasBoundaryMode::Framed;
   QVector<Annotation> annotations;
   QVector<CutOp> cuts;
   int nextMarker = 1;
@@ -5514,14 +5525,17 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   const QRectF sourceImage = sourceFrameWidgetRect();
   const bool grown = canvasGrown();
   const BackgroundStyle background = effectiveBackgroundStyle();
-  const bool hasBackground = background != BackgroundStyle::None;
+  const bool hasBackground = background != BackgroundStyle::None &&
+                             background != BackgroundStyle::Off;
+  const bool framedBackground =
+      hasBackground && canvasBoundaryMode_ == CanvasBoundaryMode::Framed;
   if (grown) {
     // Extension is the canvas itself, while the source remains the image card
     // floating above it. Never shadow the expanded canvas edge.
     paintCaptureBackground(painter, image, background);
-    if (imageShadow_)
+    if (imageShadow_ && hasBackground)
       paintCaptureImageShadow(painter, sourceImage);
-  } else if (hasBackground) {
+  } else if (framedBackground) {
     const QRectF backing = image.adjusted(-28, -28, 28, 28);
     paintCaptureBackground(painter, backing, background);
     if (imageShadow_)
@@ -5529,7 +5543,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   }
 
   QPainterPath clip;
-  const qreal sourceRadius = !grown && hasBackground ? 10.0 : 0.0;
+  const qreal sourceRadius = !grown && framedBackground ? 10.0 : 0.0;
   clip.addRoundedRect(sourceImage, sourceRadius, sourceRadius);
   const QSize targetSize(qRound(sourceImage.width() * devicePixelRatioF()),
                          qRound(sourceImage.height() * devicePixelRatioF()));
@@ -5654,7 +5668,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     defaultAnnotations.push_back(std::move(preview));
   }
   QRectF previewClip = canvasRect_;
-  if (dragging_ && canvasBoundaryMode_ != CanvasBoundaryMode::Grow) {
+  if (dragging_ && canvasBoundaryMode_ != CanvasBoundaryMode::Framed) {
     previewClip = captureCanvasRect(selection_.size(), defaultAnnotations,
                                     canvasBoundaryMode_);
   }
@@ -5666,18 +5680,20 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     overscan = overscan.subtracted(settledCanvas);
     const bool previewGrown =
         previewClip != QRectF(QPointF(), selection_.size());
+    const bool automaticPreviewBackground =
+        canvasBoundaryMode_ == CanvasBoundaryMode::Framed && previewGrown &&
+        backgroundStyle_ == BackgroundStyle::None;
     const BackgroundStyle previewBackground =
-        previewGrown && backgroundStyle_ == BackgroundStyle::None
-            ? BackgroundStyle::Slate
-            : background;
+        automaticPreviewBackground ? BackgroundStyle::Slate : background;
     painter.save();
     painter.setClipPath(overscan, Qt::IntersectClip);
     paintCaptureBackground(painter, previewClip, previewBackground);
     painter.restore();
   }
-  // Grow shows the complete layer while it is being carried and settles the
-  // background on release. The two clipping modes preview their cutoff live.
-  if (!dragging_ || canvasBoundaryMode_ != CanvasBoundaryMode::Grow)
+  // Framed mode shows the complete layer while it is being carried and
+  // settles the background on release. Overflow and Image preview their final
+  // canvas bounds live.
+  if (!dragging_ || canvasBoundaryMode_ != CanvasBoundaryMode::Framed)
     painter.setClipRect(previewClip, Qt::IntersectClip);
   const bool hasSpotlight = std::any_of(
       defaultAnnotations.cbegin(), defaultAnnotations.cend(),
@@ -5703,17 +5719,21 @@ void CaptureEditor::paintEdit(QPainter &painter) {
       defaultLayerSource.fill(Qt::transparent);
       QPainter basePainter(&defaultLayerSource);
       basePainter.setRenderHints(QPainter::SmoothPixmapTransform);
+      const bool automaticSpotlightBackground =
+          canvasBoundaryMode_ == CanvasBoundaryMode::Framed &&
+          spotlightGrown && backgroundStyle_ == BackgroundStyle::None;
       const BackgroundStyle spotlightBackground =
-          spotlightGrown && backgroundStyle_ == BackgroundStyle::None
-              ? BackgroundStyle::Slate
-              : background;
+          automaticSpotlightBackground ? BackgroundStyle::Slate : background;
       paintCaptureBackground(basePainter, defaultLayerSource.rect(),
                              spotlightBackground);
       const QRectF sourcePixels(-spotlightCanvas.left() * pixelScale,
                                 -spotlightCanvas.top() * pixelScale,
                                 selection_.width() * pixelScale,
                                 selection_.height() * pixelScale);
-      if (imageShadow_)
+      const bool spotlightHasBackground =
+          spotlightBackground != BackgroundStyle::None &&
+          spotlightBackground != BackgroundStyle::Off;
+      if (imageShadow_ && spotlightHasBackground)
         paintCaptureImageShadow(basePainter, sourcePixels, pixelScale,
                                 pixelScale);
       basePainter.drawImage(sourcePixels, redactionLayer);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -92,6 +92,19 @@ public:
   /** Current monitor data (background capture may be in flight). */
   const CaptureData &captureData() const { return capture_; }
   [[nodiscard]] QRectF currentSelection() const { return selection_; }
+  /** Annotation-space canvas, including any strips grown past the source. */
+  [[nodiscard]] QRectF currentCanvasForTest() const { return canvasRect_; }
+  /** Fitted canvas and source-frame geometry used by headless interactions. */
+  [[nodiscard]] QRectF sourceFrameWidgetRectForTest() const {
+    return sourceFrameWidgetRect();
+  }
+  [[nodiscard]] QPointF annotationPointToWidgetForTest(
+      const QPointF &point) const {
+    return sourceFrameWidgetRect().topLeft() + point * editScale();
+  }
+  [[nodiscard]] const QVector<Annotation> &currentAnnotationsForTest() const {
+    return annotations_;
+  }
   [[nodiscard]] const QVector<Operation> &operationLog() const { return ops_; }
   [[nodiscard]] int operationIndex() const { return opIndex_; }
   [[nodiscard]] QString workingSourcePath() const { return snapshotPath_; }
@@ -201,6 +214,7 @@ private:
   struct EditState {
     QVector<Annotation> annotations;
     BackgroundStyle backgroundStyle = BackgroundStyle::None;
+    bool imageShadow = true;
     QRectF selection;
     int selectedAnnotation = -1;
     QVector<int> selectedAnnotations;
@@ -209,7 +223,6 @@ private:
   };
 
   [[nodiscard]] QRectF annotationBounds(const Annotation &annotation) const;
-  [[nodiscard]] QRectF selectedAnnotationsBounds() const;
   void selectAllAnnotations();
   [[nodiscard]] bool annotationSelected(int index) const;
   /// What a pointer event reports, or nothing until a key event has confirmed
@@ -366,6 +379,8 @@ private:
   /// baseImageRect transformed by the current view zoom and pan (content and
   /// annotations map through this). Equals baseImageRect at zoom 1.
   [[nodiscard]] QRectF editImageRect() const;
+  /// The unmodified screenshot's frame inside the possibly-grown canvas.
+  [[nodiscard]] QRectF sourceFrameWidgetRect() const;
   [[nodiscard]] qreal editScale() const;
   /// Multiplier from the fit scale to the largest useful zoom (1 source px ->
   /// a few screen px); 1.0 when the image already fits comfortably.
@@ -455,6 +470,9 @@ private:
   void completeReopenRecent(const ReopenResult &result);
   void duplicateSelectedAnnotation();
   [[nodiscard]] EditState editState() const;
+  void refreshCanvasRect();
+  [[nodiscard]] bool canvasGrown() const;
+  [[nodiscard]] BackgroundStyle effectiveBackgroundStyle() const;
   void enterEdit(QString status);
   /// Routes a confirmed screen selection to quick export or the editor.
   void enterSelectedCapture(QString editStatus);
@@ -474,7 +492,8 @@ private:
   void commitDelete(const QVector<int> &indices);
   void commitCrop(const QRectF &crop);
   void commitCut(CutOp cut);
-  void commitBackground(BackgroundStyle style);
+  void commitBackground(BackgroundStyle style, bool imageShadow);
+  void cycleBackground();
   void replayLog();
   void redoEdit();
   void selectWindowInDirection(int key);
@@ -547,6 +566,10 @@ private:
   QElapsedTimer recentsAnimClock_;
   QTimer recentsAnimTimer_;
   QRectF selection_;
+  // Annotation coordinates stay anchored to the source frame at 0,0. This
+  // derived rect expands around them without translating either the source or
+  // existing layers; replaying the op log reconstructs it exactly.
+  QRectF canvasRect_;
   QPointF dragStart_;
   QRectF originalSelection_;
   QRectF cropDragImageRect_;
@@ -573,6 +596,7 @@ private:
   qreal cutDragOriginOffset_ = 0.0;
   bool windowMode_ = false;
   BackgroundStyle backgroundStyle_ = BackgroundStyle::None;
+  bool imageShadow_ = true;
   bool busy_ = false;
   bool colorPaletteOpen_ = false;
   bool customColorPickerOpen_ = false;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -94,6 +94,9 @@ public:
   [[nodiscard]] QRectF currentSelection() const { return selection_; }
   /** Annotation-space canvas, including any strips grown past the source. */
   [[nodiscard]] QRectF currentCanvasForTest() const { return canvasRect_; }
+  [[nodiscard]] CanvasBoundaryMode currentCanvasBoundaryForTest() const {
+    return canvasBoundaryMode_;
+  }
   /** Fitted canvas and source-frame geometry used by headless interactions. */
   [[nodiscard]] QRectF sourceFrameWidgetRectForTest() const {
     return sourceFrameWidgetRect();
@@ -215,6 +218,7 @@ private:
     QVector<Annotation> annotations;
     BackgroundStyle backgroundStyle = BackgroundStyle::None;
     bool imageShadow = true;
+    CanvasBoundaryMode canvasBoundary = CanvasBoundaryMode::Grow;
     QRectF selection;
     int selectedAnnotation = -1;
     QVector<int> selectedAnnotations;
@@ -493,6 +497,8 @@ private:
   void commitCrop(const QRectF &crop);
   void commitCut(CutOp cut);
   void commitBackground(BackgroundStyle style, bool imageShadow);
+  void commitCanvasBoundary(CanvasBoundaryMode mode);
+  void cycleCanvasBoundary(bool reverse);
   void cycleBackground();
   void replayLog();
   void redoEdit();
@@ -597,6 +603,7 @@ private:
   bool windowMode_ = false;
   BackgroundStyle backgroundStyle_ = BackgroundStyle::None;
   bool imageShadow_ = true;
+  CanvasBoundaryMode canvasBoundaryMode_ = CanvasBoundaryMode::Grow;
   bool busy_ = false;
   bool colorPaletteOpen_ = false;
   bool customColorPickerOpen_ = false;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -218,7 +218,7 @@ private:
     QVector<Annotation> annotations;
     BackgroundStyle backgroundStyle = BackgroundStyle::None;
     bool imageShadow = true;
-    CanvasBoundaryMode canvasBoundary = CanvasBoundaryMode::Grow;
+    CanvasBoundaryMode canvasBoundary = CanvasBoundaryMode::Framed;
     QRectF selection;
     int selectedAnnotation = -1;
     QVector<int> selectedAnnotations;
@@ -603,7 +603,7 @@ private:
   bool windowMode_ = false;
   BackgroundStyle backgroundStyle_ = BackgroundStyle::None;
   bool imageShadow_ = true;
-  CanvasBoundaryMode canvasBoundaryMode_ = CanvasBoundaryMode::Grow;
+  CanvasBoundaryMode canvasBoundaryMode_ = CanvasBoundaryMode::Framed;
   bool busy_ = false;
   bool colorPaletteOpen_ = false;
   bool customColorPickerOpen_ = false;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -3255,13 +3255,29 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
                       QPoint(700, 500));
   application.processEvents();
   const QRectF selection(100, 100, 600, 400);
-  const auto expected = [&](const QVector<Annotation> &annotations) {
-    return renderCapture(capture, selection, annotations,
-                         BackgroundStyle::None);
+  const QRectF sourceCanvas(QPointF(), selection.size());
+  const auto widgetPoint = [&](const QPointF &point) {
+    const QPointF mapped = editor.annotationPointToWidgetForTest(point);
+    return QPoint(qRound(mapped.x()), qRound(mapped.y()));
   };
-  const auto snapshotMatches = [&](const QImage &image) {
-    return flushedSnapshot(editor, snapshotPath)
-                   .convertToFormat(image.format()) == image;
+  const auto currentOutput = [&] {
+    return flushedSnapshot(editor, snapshotPath);
+  };
+  const auto expectedCurrent = [&](BackgroundStyle background,
+                                   bool imageShadow = true) {
+    return renderCapture(capture, selection,
+                         editor.currentAnnotationsForTest(), background,
+                         imageShadow);
+  };
+  const auto canvasIsDerived = [&] {
+    return editor.currentCanvasForTest() ==
+           captureCanvasRect(selection.size(),
+                             editor.currentAnnotationsForTest());
+  };
+  const QColor slate(QStringLiteral("#242424"));
+  const auto isSlateShadow = [&](const QColor &pixel) {
+    return pixel.alpha() == 255 && pixel.red() < slate.red() &&
+           pixel.green() < slate.green() && pixel.blue() < slate.blue();
   };
   const auto drag = [&](const QPoint &from, const QPoint &to) {
     QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, from);
@@ -3270,6 +3286,13 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
     application.processEvents();
   };
 
+  // Start with a layer wholly inside the source frame.
+  QTest::keyClick(&editor, Qt::Key_R);
+  drag(widgetPoint({300, 140}), widgetPoint({450, 260}));
+  if (editor.currentAnnotationsForTest().size() != 1 ||
+      editor.currentAnnotationsForTest().constFirst().kind !=
+          Annotation::Kind::Rectangle ||
+      editor.currentCanvasForTest() != sourceCanvas || !canvasIsDerived()) {
   // A rectangle at annotation (400,195)-(550,345); the widget offset is
   // (100,117). Drag it 100 px right so its right side leaves the canvas.
   QTest::keyClick(&editor, Qt::Key_R);
@@ -3284,7 +3307,24 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
     error = QStringLiteral("Outside-canvas smoke: rectangle did not render");
     return false;
   }
+
+  const QImage inside = currentOutput();
+  if (inside != expectedCurrent(BackgroundStyle::None)) {
+    error = QStringLiteral("Inside rectangle output did not match its layers");
+    return false;
+  }
+
+  // Carry it across the right edge. Canvas mapping stays fixed for the whole
+  // drag and refits only after the patch commits.
   QTest::keyClick(&editor, Qt::Key_V);
+  const Annotation initial = editor.currentAnnotationsForTest().constFirst();
+  const QPointF initialMovePoint(
+      initial.start.x() + (initial.end.x() - initial.start.x()) * 0.3,
+      initial.start.y());
+  const QPoint moveStart = widgetPoint(initialMovePoint);
+  drag(moveStart, moveStart + QPoint(220, 0));
+  if (editor.currentAnnotationsForTest().size() != 1 || !canvasIsDerived() ||
+      editor.currentCanvasForTest().right() <= sourceCanvas.right()) {
   // Press the top edge, clear of the corner and mid-side handles (eight on
   // a box), so this is a move.
   drag(QPoint(540, 312), QPoint(640, 312));
@@ -3295,7 +3335,31 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
     error = QStringLiteral("Outside-canvas smoke: rectangle did not move");
     return false;
   }
+  const Annotation shifted = editor.currentAnnotationsForTest().constFirst();
+  const QRectF shiftedCanvas = editor.currentCanvasForTest();
+  const QImage shiftedOutput = currentOutput();
+  if (shiftedOutput != expectedCurrent(BackgroundStyle::None) ||
+      shiftedOutput.size() != shiftedCanvas.size().toSize() ||
+      !isSlateShadow(shiftedOutput.pixelColor(610, 350)) ||
+      shiftedOutput.pixelColor(650, 350) != slate ||
+      shiftedOutput.pixelColor(599, 350) !=
+          QColor(QStringLiteral("#182030"))) {
+    error = QStringLiteral(
+        "Right-side growth did not shadow only the source card");
+    return false;
+  }
 
+  // Resize its exposed bottom-right handle farther out, then verify that undo
+  // and redo derive the exact prior/new canvases instead of accumulating a
+  // copied extension.
+  const QPoint resizeStart = widgetPoint(shifted.end);
+  drag(resizeStart, widgetPoint(shifted.end + QPointF(50, 170)));
+  const Annotation resized = editor.currentAnnotationsForTest().constFirst();
+  const QRectF resizedCanvas = editor.currentCanvasForTest();
+  const QImage resizedOutput = currentOutput();
+  if (!canvasIsDerived() || resizedCanvas.right() <= shiftedCanvas.right() ||
+      resizedCanvas.bottom() <= sourceCanvas.bottom() ||
+      resizedOutput != expectedCurrent(BackgroundStyle::None)) {
   // Its bottom-right handle now sits outside the canvas (widget (750,462));
   // dragging it back in resizes the layer.
   drag(QPoint(750, 462), QPoint(650, 412));
@@ -3303,46 +3367,399 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
   resized.end = {550, 295};
   if (!snapshotMatches(expected({resized}))) {
     error = QStringLiteral(
-        "Dragging a handle that lies outside the canvas did not resize");
+        "Dragging an exposed handle did not grow the canvas again");
     return false;
   }
   QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
   application.processEvents();
-  if (!snapshotMatches(expected({shifted}))) {
+  if (editor.currentAnnotationsForTest().constFirst() != shifted ||
+      editor.currentCanvasForTest() != shiftedCanvas ||
+      currentOutput() != shiftedOutput) {
     error = QStringLiteral("Undo did not restore the outside-handle resize");
     return false;
   }
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentAnnotationsForTest().constFirst() != resized ||
+      editor.currentCanvasForTest() != resizedCanvas ||
+      currentOutput() != resizedOutput) {
+    error = QStringLiteral("Redo did not replay the grown-handle resize");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
 
+  // Carry the layer through the top-left. This forces a non-zero source
+  // offset and verifies that the shadow stays anchored to the old frame.
+  const QPointF shiftedMovePoint(
+      shifted.start.x() + (shifted.end.x() - shifted.start.x()) * 0.3,
+      shifted.start.y());
+  const QPoint shiftedStart = widgetPoint(shiftedMovePoint);
+  drag(shiftedStart, shiftedStart + QPoint(-600, -190));
+  const QRectF offsetCanvas = editor.currentCanvasForTest();
+  const QImage slateOutput = currentOutput();
+  if (!canvasIsDerived() || offsetCanvas.left() >= 0 ||
+      offsetCanvas.top() >= 0 ||
+      slateOutput != expectedCurrent(BackgroundStyle::None)) {
+    error = QStringLiteral(
+        "Top-left drag did not grow a stable offset canvas");
+    return false;
+  }
+  const QPoint sourceOrigin(qRound(-offsetCanvas.left()),
+                            qRound(-offsetCanvas.top()));
+  if (slateOutput.pixelColor(sourceOrigin + QPoint(300, 300)) !=
+          QColor(QStringLiteral("#182030")) ||
+      !isSlateShadow(
+          slateOutput.pixelColor(sourceOrigin + QPoint(-5, 300))) ||
+      slateOutput.pixelColor(0, sourceOrigin.y() + 300) != slate ||
+      slateOutput.pixelColor(sourceOrigin + QPoint(0, 300)) !=
+          QColor(QStringLiteral("#182030")) ||
+      slateOutput != currentOutput()) {
   // Its right edge is outside the canvas too (widget x 750); grab off the
   // mid-side handle so this is a move, not a one-axis resize.
   drag(QPoint(750, 352), QPoint(650, 352));
   if (!snapshotMatches(expected({rectangle}))) {
     error = QStringLiteral(
-        "Grabbing a selected layer outside the canvas did not move it");
+        "Grown output shifted the source or misplaced its shadow");
     return false;
   }
 
+  // Shift+B is a document edit, not another backdrop step: it removes only
+  // the source card's shadow, can be undone/redone, and survives sidecar
+  // persistence with the implicit Slate backdrop still implicit.
+  QTest::keyClick(&editor, Qt::Key_B, Qt::ShiftModifier);
   // Outside the canvas, anything but the selected layer stays inert: a
   // click on the surround neither deselects nor changes anything, so
   // Delete still removes the layer.
   QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(760, 162));
   application.processEvents();
-  if (!snapshotMatches(expected({rectangle}))) {
-    error = QStringLiteral("A click outside the canvas changed the capture");
+  const QImage noShadowOutput = currentOutput();
+  if (noShadowOutput == slateOutput ||
+      noShadowOutput != expectedCurrent(BackgroundStyle::None, false) ||
+      noShadowOutput.pixelColor(sourceOrigin + QPoint(-5, 300)) != slate ||
+      editor.operationLog().isEmpty() ||
+      editor.operationLog().constLast().type != Operation::Type::Background ||
+      editor.operationLog().constLast().background != BackgroundStyle::None ||
+      editor.operationLog().constLast().imageShadow) {
+    error = QStringLiteral("Shift+B did not disable only the drop shadow");
+    return false;
+  }
+  if (!editor.waitForSnapshot() || editor.workingLogPath().isEmpty()) {
+    error = QStringLiteral("Disabled shadow operation was not persisted");
+    return false;
+  }
+  CaptureEditor shadowRestored(capture);
+  QString shadowRestoreError;
+  if (!shadowRestored.restoreOperationLog(editor.workingLogPath(),
+                                          shadowRestoreError) ||
+      shadowRestored.renderCurrentOutput() != noShadowOutput) {
+    error = QStringLiteral("Restoring disabled shadow changed output: %1")
+                .arg(shadowRestoreError);
+    return false;
+  }
+  shadowRestored.close();
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (currentOutput() != slateOutput) {
+    error = QStringLiteral("Undo did not restore the default drop shadow");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  if (currentOutput() != noShadowOutput) {
+    error = QStringLiteral("Redo did not disable the drop shadow again");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_B, Qt::ShiftModifier);
+  application.processEvents();
+  if (currentOutput() != slateOutput) {
+    error = QStringLiteral("Shift+B did not toggle the drop shadow back on");
+    return false;
+  }
+
+  // Automatic growth starts on an implicit shadowed-gray mat but remains in
+  // fullscreen mode: B runs through every shadowed color, then shadowed gray,
+  // flat gray, and back to blue.
+  struct BackdropStep {
+    BackgroundStyle style;
+    bool shadow;
+  };
+  const std::array<BackdropStep, 7> grownCycle{{
+      {BackgroundStyle::Aurora, true},
+      {BackgroundStyle::Sunset, true},
+      {BackgroundStyle::Lagoon, true},
+      {BackgroundStyle::Violet, true},
+      {BackgroundStyle::Slate, true},
+      {BackgroundStyle::Slate, false},
+      {BackgroundStyle::Aurora, true},
+  }};
+  for (const BackdropStep step : grownCycle) {
+    QTest::keyClick(&editor, Qt::Key_B);
+    application.processEvents();
+    const Operation &operation = editor.operationLog().constLast();
+    if (operation.type != Operation::Type::Background ||
+        operation.background != step.style ||
+        operation.imageShadow != step.shadow ||
+        currentOutput() != expectedCurrent(step.style, step.shadow) ||
+        editor.currentCanvasForTest() != offsetCanvas) {
+      error = QStringLiteral("Grown backdrop cycle reached the wrong state");
+      return false;
+    }
+  }
+  // Leave this larger fixture on shadowed gray for the movement, contraction,
+  // and operation-log checks below.
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (currentOutput() != slateOutput) {
+    error = QStringLiteral(
+        "Undoing the grown backdrop wrap did not restore shadowed Slate");
+    return false;
+  }
+
+  // Moving the layer wholly back over the source contracts the canvas. Undo
+  // grows it from vector geometry again; delete contracts it for the same
+  // reason, with no special raster-resize operation to replay.
+  const Annotation offset = editor.currentAnnotationsForTest().constFirst();
+  const QPointF offsetMovePoint(
+      offset.start.x() + (offset.end.x() - offset.start.x()) * 0.3,
+      offset.start.y());
+  const QPoint offsetStart = widgetPoint(offsetMovePoint);
+  drag(offsetStart, offsetStart + QPoint(300, 150));
+  if (editor.currentCanvasForTest() != sourceCanvas || !canvasIsDerived()) {
+    error = QStringLiteral("Moving a layer back in did not contract canvas");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentCanvasForTest() != offsetCanvas ||
+      currentOutput() != slateOutput) {
+    error = QStringLiteral("Undo did not regrow the offset canvas");
     return false;
   }
   QTest::keyClick(&editor, Qt::Key_Delete);
   application.processEvents();
-  if (!snapshotMatches(expected({}))) {
-    error = QStringLiteral("A click outside the canvas deselected the layer");
+  if (!editor.currentAnnotationsForTest().isEmpty() ||
+      editor.currentCanvasForTest() != sourceCanvas) {
+    error = QStringLiteral("Deleting the outside layer did not contract canvas");
     return false;
   }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentCanvasForTest() != offsetCanvas ||
+      currentOutput() != slateOutput) {
+    error = QStringLiteral("Undo delete did not regrow canvas");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+
+  // Typing across the frame grows by the committed glyph/pill bounds. Undo,
+  // redo, and operation-log restore all derive the same canvas and pixels.
+  QTest::keyClick(&editor, Qt::Key_T);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier,
+                    widgetPoint({570, 100}));
+  application.processEvents();
+  auto *inlineEditor =
+      qobject_cast<QPlainTextEdit *>(QApplication::focusWidget());
+  if (inlineEditor == nullptr) {
+    error = QStringLiteral("Text growth did not open the inline editor");
+    return false;
+  }
+  QTest::keyClicks(inlineEditor,
+                   QStringLiteral("Canvas grows for typed labels"));
+  QTest::keyClick(inlineEditor, Qt::Key_Return, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentAnnotationsForTest().size() != 1 ||
+      editor.currentAnnotationsForTest().constFirst().kind !=
+          Annotation::Kind::Text ||
+      editor.currentCanvasForTest().right() <= sourceCanvas.right() ||
+      !canvasIsDerived()) {
+    error = QStringLiteral("Committed text did not grow past the frame");
+    return false;
+  }
+  const QVector<Annotation> textAnnotations =
+      editor.currentAnnotationsForTest();
+  const QRectF textCanvas = editor.currentCanvasForTest();
+  const QImage textOutput = currentOutput();
+  if (textOutput != expectedCurrent(BackgroundStyle::None) ||
+      !isSlateShadow(textOutput.pixelColor(610, 350)) ||
+      textOutput.pixelColor(650, 350) != slate) {
+    error = QStringLiteral(
+        "Text growth did not keep the source shadow on default Slate");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!editor.currentAnnotationsForTest().isEmpty() ||
+      editor.currentCanvasForTest() != sourceCanvas) {
+    error = QStringLiteral("Undo text did not contract canvas");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentAnnotationsForTest() != textAnnotations ||
+      editor.currentCanvasForTest() != textCanvas ||
+      currentOutput() != textOutput) {
+    error = QStringLiteral("Redo text did not replay canvas growth");
+    return false;
+  }
+
+  // Crop handles still belong to the source frame inside the wider canvas.
+  // Moving its left edge keeps the text at the same absolute capture point,
+  // including after Crop replay.
+  const QPointF absoluteTextStart =
+      editor.currentSelection().topLeft() + textAnnotations.constFirst().start;
+  QTest::keyClick(&editor, Qt::Key_V);
+  const QRectF sourceFrame = editor.sourceFrameWidgetRectForTest();
+  const QPoint cropLeft(qRound(sourceFrame.left() - 7),
+                        qRound(sourceFrame.center().y()));
+  drag(cropLeft, cropLeft + QPoint(20, 0));
+  const QRectF croppedSelection = editor.currentSelection();
+  const QVector<Annotation> croppedAnnotations =
+      editor.currentAnnotationsForTest();
+  const QRectF croppedCanvas = editor.currentCanvasForTest();
+  const QImage croppedOutput = currentOutput();
+  const QPointF replayedAbsoluteStart =
+      croppedSelection.topLeft() + croppedAnnotations.constFirst().start;
+  if (croppedSelection.left() <= selection.left() || !canvasIsDerived() ||
+      QLineF(absoluteTextStart, replayedAbsoluteStart).length() > 0.01) {
+    error = QStringLiteral("Source recrop shifted grown text");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentSelection() != selection ||
+      editor.currentAnnotationsForTest() != textAnnotations ||
+      editor.currentCanvasForTest() != textCanvas ||
+      currentOutput() != textOutput) {
+    error = QStringLiteral("Undo recrop changed grown text coordinates");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentSelection() != croppedSelection ||
+      editor.currentAnnotationsForTest() != croppedAnnotations ||
+      editor.currentCanvasForTest() != croppedCanvas ||
+      currentOutput() != croppedOutput) {
+    error = QStringLiteral("Redo recrop did not replay grown coordinates");
+    return false;
+  }
+
+  if (!editor.waitForSnapshot() || editor.workingLogPath().isEmpty()) {
+    error = QStringLiteral("Text growth operation log was not persisted");
+    return false;
+  }
+  CaptureEditor restored(capture);
+  QString restoreError;
+  if (!restored.restoreOperationLog(editor.workingLogPath(), restoreError) ||
+      restored.currentSelection() != croppedSelection ||
+      restored.currentAnnotationsForTest() != croppedAnnotations ||
+      restored.currentCanvasForTest() != croppedCanvas ||
+      restored.renderCurrentOutput() != croppedOutput) {
+    error = QStringLiteral("Restoring text growth changed canvas: %1")
+                .arg(restoreError);
+    return false;
+  }
+  restored.close();
   editor.close();
   QFile::remove(snapshotPath);
   return true;
 }
 
-/** Runs the interaction and rendering smoke checks. */
+/** Fullscreen B starts with blue, runs through every shadowed color, then
+ *  demonstrates shadowed gray before its flat-gray hint. */
+bool runFullscreenBackdropCycleSmoke(QApplication &application,
+                                     QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 180, 120};
+  capture.monitor.pixelSize = {180, 120};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(180, 120, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#527196")));
+  capture.previewSize = capture.source.size();
+
+  struct BackdropStep {
+    BackgroundStyle style;
+    bool shadow;
+  };
+  const std::array<BackdropStep, 7> fullscreenCycle{{
+      {BackgroundStyle::Aurora, true},
+      {BackgroundStyle::Sunset, true},
+      {BackgroundStyle::Lagoon, true},
+      {BackgroundStyle::Violet, true},
+      {BackgroundStyle::Slate, true},
+      {BackgroundStyle::Slate, false},
+      {BackgroundStyle::Aurora, true},
+  }};
+
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::File);
+  editor.resize(640, 480);
+  editor.show();
+  application.processEvents();
+  QImage shadowedGray;
+  QImage flatGray;
+  for (const BackdropStep step : fullscreenCycle) {
+    QTest::keyClick(&editor, Qt::Key_B);
+    application.processEvents();
+    const Operation &operation = editor.operationLog().constLast();
+    const QImage output = editor.renderCurrentOutput();
+    const QImage expected = renderCapture(capture, editor.currentSelection(),
+                                          {}, step.style, step.shadow);
+    if (operation.type != Operation::Type::Background ||
+        operation.background != step.style ||
+        operation.imageShadow != step.shadow || output != expected) {
+      error =
+          QStringLiteral("Fullscreen backdrop cycle reached the wrong state");
+      return false;
+    }
+    if (step.style == BackgroundStyle::Slate && step.shadow)
+      shadowedGray = output;
+    else if (step.style == BackgroundStyle::Slate && !step.shadow)
+      flatGray = output;
+  }
+  if (shadowedGray.isNull() || flatGray.isNull() || shadowedGray == flatGray) {
+    error = QStringLiteral(
+        "Shadowed and flat fullscreen gray rendered identically");
+    return false;
+  }
+  editor.close();
+
+  CaptureEditor overrideEditor(capture, CaptureEditor::CaptureMode::File);
+  overrideEditor.resize(640, 480);
+  overrideEditor.show();
+  application.processEvents();
+  QTest::keyClick(&overrideEditor, Qt::Key_B, Qt::ShiftModifier);
+  QTest::keyClick(&overrideEditor, Qt::Key_B);
+  const Operation &firstColor = overrideEditor.operationLog().constLast();
+  if (firstColor.background != BackgroundStyle::Aurora ||
+      !firstColor.imageShadow) {
+    error = QStringLiteral(
+        "Fullscreen B did not restore shadow on its first blue backdrop");
+    return false;
+  }
+  QTest::keyClick(&overrideEditor, Qt::Key_B, Qt::ShiftModifier);
+  application.processEvents();
+  const Operation &manualOff = overrideEditor.operationLog().constLast();
+  if (manualOff.background != BackgroundStyle::Aurora ||
+      manualOff.imageShadow) {
+    error = QStringLiteral("Shift+B did not disable the current color shadow");
+    return false;
+  }
+  QTest::keyClick(&overrideEditor, Qt::Key_B);
+  application.processEvents();
+  const Operation &nextColor = overrideEditor.operationLog().constLast();
+  if (nextColor.background != BackgroundStyle::Sunset ||
+      !nextColor.imageShadow) {
+    error = QStringLiteral(
+        "B did not restore the next color's canonical shadow");
+    return false;
+  }
+  overrideEditor.close();
+  return true;
+}
+
 /** Checks that sampling a color is not a change of tool: the eyedropper
  *  hands back whatever was in hand, and recolors the layer that was selected
  *  rather than dropping the selection with it. */
@@ -4409,6 +4826,260 @@ bool runSelectAllDeleteSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** A grown canvas keeps selection chrome on real layers only. Screenshot
+ *  crop chrome disappears for both single- and multi-layer selections, then
+ *  returns when the layers are put down. */
+bool runGrownCanvasSelectAllChromeSmoke(QApplication &application,
+                                        QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 600, 400};
+  capture.monitor.pixelSize = {600, 400};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(600, 400, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+
+  Annotation inside;
+  inside.id = 1;
+  inside.kind = Annotation::Kind::Rectangle;
+  inside.start = {60, 100};
+  inside.end = {160, 200};
+  inside.color = QColor(QStringLiteral("#ff375f"));
+  inside.size = 4;
+  Annotation outside = inside;
+  outside.id = 2;
+  outside.start = {650, 250};
+  outside.end = {750, 350};
+
+  Operation annotate;
+  annotate.type = Operation::Type::Annotate;
+  annotate.annotations = {inside, outside};
+  OperationLog log;
+  log.ops = {annotate};
+  log.index = 1;
+  log.nextId = 3;
+  log.previewSize = capture.previewSize;
+
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::File,
+                       QuickOutputMode::None, log);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  if (editor.currentCanvasForTest().right() <= capture.previewSize.width()) {
+    error = QStringLiteral("Select-all chrome fixture did not grow its canvas");
+    return false;
+  }
+
+  const QImage idle = editor.grab().toImage();
+  const QColor liveShadow = grabLogicalPixel(
+      idle, editor, editor.annotationPointToWidgetForTest({610, 220}));
+  const QColor liveMatte = grabLogicalPixel(
+      idle, editor, editor.annotationPointToWidgetForTest({645, 220}));
+  if (liveShadow.alpha() != 255 || liveShadow.red() >= 36 ||
+      liveShadow.green() >= 36 || liveShadow.blue() >= 36 ||
+      liveMatte != QColor(QStringLiteral("#242424"))) {
+    error = QStringLiteral(
+        "Live grown canvas did not shadow only the source frame");
+    return false;
+  }
+
+  // This canvas already shows the shadowed-gray opening state, so B advances
+  // directly to the first shadowed color rather than repeating gray.
+  QTest::keyClick(&editor, Qt::Key_B);
+  application.processEvents();
+  if (editor.operationLog().constLast().background !=
+          BackgroundStyle::Aurora ||
+      !editor.operationLog().constLast().imageShadow) {
+    error = QStringLiteral(
+        "B did not advance live grown gray to shadowed Aurora");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  const QColor automaticShadow = grabLogicalPixel(
+      editor.grab().toImage(), editor,
+      editor.annotationPointToWidgetForTest({610, 220}));
+  if (automaticShadow.alpha() != 255 || automaticShadow.red() >= 36 ||
+      automaticShadow.green() >= 36 || automaticShadow.blue() >= 36) {
+    error = QStringLiteral(
+        "Undo did not restore automatic grown-canvas shadow");
+    return false;
+  }
+
+  QTest::keyClick(&editor, Qt::Key_B, Qt::ShiftModifier);
+  application.processEvents();
+  const QImage shadowDisabled = editor.grab().toImage();
+  const QColor formerShadow = grabLogicalPixel(
+      shadowDisabled, editor, editor.annotationPointToWidgetForTest({610, 220}));
+  if (formerShadow != QColor(QStringLiteral("#242424"))) {
+    error = QStringLiteral("Shift+B did not remove the live source shadow");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  const QColor restoredShadow = grabLogicalPixel(
+      editor.grab().toImage(), editor,
+      editor.annotationPointToWidgetForTest({610, 220}));
+  if (restoredShadow.alpha() != 255 || restoredShadow.red() >= 36 ||
+      restoredShadow.green() >= 36 || restoredShadow.blue() >= 36) {
+    error = QStringLiteral("Undo did not restore the live source shadow");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_A, Qt::ControlModifier);
+  application.processEvents();
+  const QImage selected = editor.grab().toImage();
+  if (editor.selectedCountForTest() != 2) {
+    error = QStringLiteral("Ctrl+A did not select both grown-canvas layers");
+    return false;
+  }
+
+  const auto widgetRectForAnnotationRect = [&](const QRectF &logical) {
+    return QRectF(editor.annotationPointToWidgetForTest(logical.topLeft()),
+                  editor.annotationPointToWidgetForTest(logical.bottomRight()))
+        .normalized();
+  };
+  const auto imageRectForWidgetRect = [&](const QRectF &widgetRect) {
+    const qreal scaleX =
+        selected.width() / static_cast<qreal>(std::max(1, editor.width()));
+    const qreal scaleY =
+        selected.height() / static_cast<qreal>(std::max(1, editor.height()));
+    return QRect(qFloor(widgetRect.left() * scaleX),
+                 qFloor(widgetRect.top() * scaleY),
+                 std::max(1, qCeil(widgetRect.width() * scaleX)),
+                 std::max(1, qCeil(widgetRect.height() * scaleY)))
+        .intersected(selected.rect());
+  };
+  const auto differenceCount = [](const QImage &first, const QImage &second,
+                                  const QRect &region) {
+    int differences = 0;
+    for (int y = region.top(); y <= region.bottom(); ++y) {
+      for (int x = region.left(); x <= region.right(); ++x) {
+        if (first.pixel(x, y) != second.pixel(x, y))
+          ++differences;
+      }
+    }
+    return differences;
+  };
+  const auto blueChromeCount = [](const QImage &image, const QRect &region) {
+    int bluePixels = 0;
+    for (int y = region.top(); y <= region.bottom(); ++y) {
+      for (int x = region.left(); x <= region.right(); ++x) {
+        const QColor pixel = image.pixelColor(x, y);
+        if (pixel.blue() > 80 && pixel.blue() > pixel.red() + 50 &&
+            pixel.blue() > pixel.green() + 30)
+          ++bluePixels;
+      }
+    }
+    return bluePixels;
+  };
+  const auto brightChromeCount = [](const QImage &image,
+                                    const QRect &region) {
+    int brightPixels = 0;
+    for (int y = region.top(); y <= region.bottom(); ++y) {
+      for (int x = region.left(); x <= region.right(); ++x) {
+        const QColor pixel = image.pixelColor(x, y);
+        if (pixel.red() > 220 && pixel.green() > 220 && pixel.blue() > 220)
+          ++brightPixels;
+      }
+    }
+    return brightPixels;
+  };
+
+  const QRectF canvas = editor.currentCanvasForTest();
+  const QPointF outerEdgeTop =
+      editor.annotationPointToWidgetForTest({canvas.right(), 40});
+  const QPointF outerEdgeBottom =
+      editor.annotationPointToWidgetForTest({canvas.right(), 180});
+  const QRect outerCanvasEdge = imageRectForWidgetRect(
+      QRectF(outerEdgeTop - QPointF(3, 0),
+             outerEdgeBottom + QPointF(3, 0))
+          .normalized());
+  if (blueChromeCount(idle, outerCanvasEdge) == 0 ||
+      blueChromeCount(selected, outerCanvasEdge) != 0) {
+    error = QStringLiteral(
+        "Ctrl+A did not remove the grown-canvas selection perimeter");
+    return false;
+  }
+
+  // The old union's top edge crossed this empty gap. Ctrl+A must leave it
+  // untouched while adding dashed chrome around each actual rectangle.
+  const QRect groupOnly = imageRectForWidgetRect(
+      widgetRectForAnnotationRect(QRectF(230, 94, 360, 6)));
+  const QRect firstLayer = imageRectForWidgetRect(
+      widgetRectForAnnotationRect(QRectF(55, 94, 110, 8)));
+  const QRect secondLayer = imageRectForWidgetRect(
+      widgetRectForAnnotationRect(QRectF(645, 244, 110, 8)));
+  if (differenceCount(idle, selected, groupOnly) != 0 ||
+      differenceCount(idle, selected, firstLayer) == 0 ||
+      differenceCount(idle, selected, secondLayer) == 0) {
+    error = QStringLiteral(
+        "Multi-selection drew a union box instead of per-layer chrome");
+    return false;
+  }
+
+  const QRectF sourceFrame = editor.sourceFrameWidgetRectForTest();
+  const QRect sourceFrameEdge = imageRectForWidgetRect(
+      QRectF(QPointF(sourceFrame.right() - 3, sourceFrame.top() + 40),
+             QPointF(sourceFrame.right() + 3, sourceFrame.top() + 180)));
+  if (blueChromeCount(idle, sourceFrameEdge) == 0 ||
+      blueChromeCount(selected, sourceFrameEdge) != 0 ||
+      differenceCount(idle, selected, sourceFrameEdge) == 0) {
+    error = QStringLiteral("Ctrl+A left the source-frame border selected");
+    return false;
+  }
+  const QRect cropHandle = imageRectForWidgetRect(
+      QRectF(sourceFrame.right() + 1, sourceFrame.center().y() - 6, 12, 12));
+  if (brightChromeCount(idle, cropHandle) == 0 ||
+      brightChromeCount(selected, cropHandle) != 0 ||
+      differenceCount(idle, selected, cropHandle) == 0) {
+    error = QStringLiteral("Ctrl+A left the source crop handles selected");
+    return false;
+  }
+
+  // Putting the group down restores the source-frame border and crop handles.
+  QTest::mouseClick(
+      &editor, Qt::LeftButton, Qt::NoModifier,
+      editor.annotationPointToWidgetForTest({400, 50}).toPoint());
+  application.processEvents();
+  const QImage restored = editor.grab().toImage();
+  if (editor.selectedCountForTest() != 0 ||
+      blueChromeCount(restored, outerCanvasEdge) == 0 ||
+      blueChromeCount(restored, sourceFrameEdge) == 0 ||
+      brightChromeCount(restored, cropHandle) == 0) {
+    error = QStringLiteral(
+        "Putting layers down did not restore screenshot crop chrome");
+    return false;
+  }
+
+  // A single selected layer must hide the same screenshot chrome while
+  // retaining that layer's own bounds and handles.
+  QTest::mouseClick(
+      &editor, Qt::LeftButton, Qt::NoModifier,
+      editor.annotationPointToWidgetForTest({60, 150}).toPoint());
+  application.processEvents();
+  const QImage single = editor.grab().toImage();
+  if (editor.selectedCountForTest() != 1) {
+    error = QStringLiteral("Single-layer chrome check did not select a layer");
+    return false;
+  }
+  if (blueChromeCount(single, sourceFrameEdge) != 0) {
+    error = QStringLiteral("Single selection left the source border visible");
+    return false;
+  }
+  if (brightChromeCount(single, cropHandle) != 0) {
+    error = QStringLiteral("Single selection left a crop handle visible");
+    return false;
+  }
+  if (differenceCount(restored, single, firstLayer) == 0) {
+    error = QStringLiteral("Single selection did not retain layer chrome");
+    return false;
+  }
+
+  editor.close();
+  return true;
+}
+
 /** Runs the interaction and rendering smoke checks. */
 bool runDuplicateLayerSmoke(QApplication &application, QString &error) {
   CaptureData capture;
@@ -4703,6 +5374,26 @@ bool runKeyboardNudgeSmoke(QApplication &application, QString &error) {
   application.processEvents();
   if (!snapshotMatches(rectangle({100, 95}, {400, 215}))) {
     error = QStringLiteral("Plain resize was constrained without Shift");
+    return false;
+  }
+
+  // A held keyboard nudge refits immediately, before the coalesced patch is
+  // persisted, so an edge crossing never clips and then pops into place.
+  for (int step = 0; step < 21; ++step)
+    QTest::keyClick(&editor, Qt::Key_Right, Qt::ShiftModifier);
+  application.processEvents();
+  const Annotation nudgedOutside = rectangle({310, 95}, {610, 215});
+  if (editor.currentCanvasForTest().right() <= selection.width() ||
+      !snapshotMatches(nudgedOutside)) {
+    error = QStringLiteral("Edge-crossing nudge did not refit immediately");
+    return false;
+  }
+  settle();
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!snapshotMatches(rectangle({100, 95}, {400, 215})) ||
+      editor.currentCanvasForTest() != QRectF(QPointF(), selection.size())) {
+    error = QStringLiteral("Undo did not contract a nudged canvas");
     return false;
   }
 
@@ -5998,6 +6689,10 @@ int main(int argc, char **argv) {
     qWarning().noquote() << snapshotError;
     return 106;
   }
+  if (!runFullscreenBackdropCycleSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 142;
+  }
   if (!runCenteredCreationSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 112;
@@ -6029,6 +6724,10 @@ int main(int argc, char **argv) {
   if (!runSelectAllDeleteSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 101;
+  }
+  if (!runGrownCanvasSelectAllChromeSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 134;
   }
   if (!runDuplicateLayerSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
@@ -6843,9 +7542,15 @@ int main(int argc, char **argv) {
                       QPoint(520, 277));
   QTest::keyClick(&cropEditor, Qt::Key_V);
   QTest::mouseClick(&cropEditor, Qt::LeftButton, Qt::NoModifier,
+                    QPoint(390, 238));
+  // Layer selection owns the chrome until it is put down. Clicking empty
+  // canvas restores the source crop handles before the crop begins.
+  QTest::mouseClick(&cropEditor, Qt::LeftButton, Qt::NoModifier,
+                    QPoint(600, 400));
                     QPoint(390, 250));
   application.processEvents();
   const QImage beforeCrop = cropEditor.grab().toImage();
+  const QRectF beforeCropFrame = cropEditor.sourceFrameWidgetRectForTest();
   if (!beforeCrop.save(outputRoot + QStringLiteral("-crop-handles.png"), "PNG"))
     return 31;
   QTest::mouseMove(&cropEditor, QPoint(682, 509), 20);
@@ -6857,10 +7562,12 @@ int main(int argc, char **argv) {
   application.processEvents();
   const QImage afterCrop = cropEditor.grab().toImage();
   if (beforeCrop == afterCrop ||
+      cropEditor.sourceFrameWidgetRectForTest() == beforeCropFrame ||
       !afterCrop.save(outputRoot + QStringLiteral("-cropped.png"), "PNG"))
     return 32;
   QTest::keyClick(&cropEditor, Qt::Key_Z, Qt::ControlModifier);
   application.processEvents();
+  if (cropEditor.sourceFrameWidgetRectForTest() != beforeCropFrame)
   if (cropEditor.grab().toImage().pixelColor(260, 222) !=
       QColor(QStringLiteral("#0a84ff")))
     return 58;
@@ -6963,19 +7670,108 @@ int main(int argc, char **argv) {
   croppedOut.end = {150, 60};
   croppedOut.color = QColor(QStringLiteral("#ff00ff"));
   croppedOut.size = 4;
-  const QImage clippedExport =
+  const QRectF grownCanvas =
+      captureCanvasRect(QSizeF(100, 100), {croppedOut});
+  const QImage grownExport =
       renderCapture(clippingCapture, QRectF(0, 0, 100, 100), {croppedOut},
                     BackgroundStyle::Aurora);
-  const QRect exportedImageBounds(64, 64, 100, 100);
-  for (int y = 0; y < clippedExport.height(); ++y) {
-    for (int x = 0; x < clippedExport.width(); ++x) {
-      if (exportedImageBounds.contains(x, y))
-        continue;
-      const QColor pixel = clippedExport.pixelColor(x, y);
+  bool paintedOutsideSource = false;
+  for (int y = 0; y < grownExport.height(); ++y) {
+    for (int x = 100; x < grownExport.width(); ++x) {
+      const QColor pixel = grownExport.pixelColor(x, y);
       if (pixel.red() > 240 && pixel.green() < 32 && pixel.blue() > 240)
-        return 65;
+        paintedOutsideSource = true;
     }
   }
+  const QImage slateExport =
+      renderCapture(clippingCapture, QRectF(0, 0, 100, 100), {croppedOut},
+                    BackgroundStyle::None);
+  const QImage unshadowedSlateExport =
+      renderCapture(clippingCapture, QRectF(0, 0, 100, 100), {croppedOut},
+                    BackgroundStyle::None, false);
+  CaptureData highDpiGrowth = clippingCapture;
+  highDpiGrowth.monitor.scale = 2.0;
+  highDpiGrowth.monitor.pixelSize = {200, 200};
+  highDpiGrowth.source = clippingCapture.source.scaled(
+      200, 200, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+  const QImage highDpiGrowthExport =
+      renderCapture(highDpiGrowth, QRectF(0, 0, 100, 100), {croppedOut},
+                    BackgroundStyle::None);
+  const QColor slate(QStringLiteral("#242424"));
+  const auto isSlateShadow = [&](const QColor &pixel) {
+    return pixel.alpha() == 255 && pixel.red() < slate.red() &&
+           pixel.green() < slate.green() && pixel.blue() < slate.blue();
+  };
+  QImage shadowProbe(220, 220, QImage::Format_ARGB32_Premultiplied);
+  shadowProbe.fill(slate);
+  {
+    QPainter shadowPainter(&shadowProbe);
+    const QRectF sourceCard(60, 50, 100, 100);
+    paintCaptureImageShadow(shadowPainter, sourceCard);
+    shadowPainter.fillRect(sourceCard, Qt::white);
+  }
+  const std::array<int, 6> bottomShadowProfile = {
+      shadowProbe.pixelColor(110, 150).red(),
+      shadowProbe.pixelColor(110, 157).red(),
+      shadowProbe.pixelColor(110, 170).red(),
+      shadowProbe.pixelColor(110, 190).red(),
+      shadowProbe.pixelColor(110, 202).red(),
+      shadowProbe.pixelColor(110, 206).red()};
+  const bool softAmbientAndKeyShadow =
+      bottomShadowProfile.at(0) <= bottomShadowProfile.at(1) &&
+      bottomShadowProfile.at(1) < bottomShadowProfile.at(2) &&
+      bottomShadowProfile.at(2) < bottomShadowProfile.at(3) &&
+      bottomShadowProfile.at(3) < bottomShadowProfile.at(4) &&
+      bottomShadowProfile.at(4) < bottomShadowProfile.at(5) &&
+      bottomShadowProfile.back() == slate.red() &&
+      isSlateShadow(shadowProbe.pixelColor(110, 40)) &&
+      shadowProbe.pixelColor(110, 20) == slate;
+  const std::array<int, 5> slateShadowProfile = {
+      slateExport.pixelColor(100, 90).red(),
+      slateExport.pixelColor(111, 90).red(),
+      slateExport.pixelColor(123, 90).red(),
+      slateExport.pixelColor(138, 90).red(),
+      slateExport.pixelColor(142, 90).red()};
+  const std::array<int, 5> highDpiShadowProfile = {
+      highDpiGrowthExport.pixelColor(200, 180).red(),
+      highDpiGrowthExport.pixelColor(222, 180).red(),
+      highDpiGrowthExport.pixelColor(246, 180).red(),
+      highDpiGrowthExport.pixelColor(276, 180).red(),
+      highDpiGrowthExport.pixelColor(284, 180).red()};
+  bool scaleIndependentShadow = true;
+  for (std::size_t i = 0; i < slateShadowProfile.size(); ++i) {
+    scaleIndependentShadow =
+        scaleIndependentShadow &&
+        std::abs(slateShadowProfile.at(i) - highDpiShadowProfile.at(i)) <= 2;
+  }
+  const bool softlyFadingShadow =
+      slateShadowProfile.at(0) < slateShadowProfile.at(1) &&
+      slateShadowProfile.at(1) < slateShadowProfile.at(2) &&
+      slateShadowProfile.at(2) < slateShadowProfile.at(3) &&
+      slateShadowProfile.at(3) < slateShadowProfile.at(4) &&
+      slateShadowProfile.back() == slate.red();
+  const bool restrainedShadowStrength =
+      bottomShadowProfile.front() >= 20 && slateShadowProfile.front() >= 20;
+  if (grownCanvas != QRectF(0, 0, 153, 100) ||
+      grownExport.size() != QSize(153, 100) || !paintedOutsideSource ||
+      grownExport.pixelColor(0, 0) != QColor(Qt::white) ||
+      slateExport.size() != grownExport.size() ||
+      slateExport.pixelColor(99, 90) != QColor(Qt::white) ||
+      unshadowedSlateExport.size() != slateExport.size() ||
+      unshadowedSlateExport.pixelColor(99, 90) != QColor(Qt::white) ||
+      unshadowedSlateExport.pixelColor(100, 90) != slate ||
+      unshadowedSlateExport.pixelColor(152, 90) != slate ||
+      !softAmbientAndKeyShadow || !softlyFadingShadow ||
+      !restrainedShadowStrength ||
+      !scaleIndependentShadow ||
+      slateExport.pixelColor(152, 90) != slate ||
+      highDpiGrowthExport.size() != QSize(306, 200) ||
+      highDpiGrowthExport.pixelColor(199, 180) != QColor(Qt::white) ||
+      !isSlateShadow(highDpiGrowthExport.pixelColor(200, 180)) ||
+      highDpiGrowthExport.pixelColor(304, 180) != slate ||
+      slateExport != renderCapture(clippingCapture, QRectF(0, 0, 100, 100),
+                                   {croppedOut}, BackgroundStyle::None))
+    return 65;
 
   CaptureData highDpiCapture = capture;
   highDpiCapture.monitor.scale = 2.0;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -3238,6 +3238,151 @@ bool runSpotlightHandleSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Canvas boundary policies clip the presentation, never the stored layer. */
+bool runCanvasBoundaryModeSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 100, 100};
+  capture.monitor.pixelSize = {100, 100};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(100, 100, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+
+  Annotation outside;
+  outside.kind = Annotation::Kind::Rectangle;
+  outside.start = {50, 40};
+  outside.end = {260, 80};
+  outside.color = QColor(QStringLiteral("#ff375f"));
+  outside.size = 4.0;
+  outside.id = 1;
+
+  Operation annotate;
+  annotate.type = Operation::Type::Annotate;
+  annotate.annotations = {outside};
+  OperationLog log;
+  log.ops = {annotate};
+  log.index = 1;
+  log.nextId = 2;
+  log.previewSize = capture.previewSize;
+
+  const QRectF sourceFrame(QPointF(), QSizeF(capture.previewSize));
+  const QRectF growCanvas = captureCanvasRect(
+      sourceFrame.size(), {outside}, CanvasBoundaryMode::Grow);
+  const QRectF frameCanvas = captureCanvasRect(
+      sourceFrame.size(), {outside}, CanvasBoundaryMode::Frame);
+  const QRectF imageCanvas = captureCanvasRect(
+      sourceFrame.size(), {outside}, CanvasBoundaryMode::Image);
+  if (captureCanvasRect(sourceFrame.size(), {outside}) != growCanvas ||
+      growCanvas != QRectF(-64, -64, 327, 228) ||
+      frameCanvas != QRectF(-64, -64, 228, 228) ||
+      imageCanvas != sourceFrame ||
+      captureCanvasRect(sourceFrame.size(), {}, CanvasBoundaryMode::Frame) !=
+          sourceFrame) {
+    error = QStringLiteral("Canvas boundary geometry reached the wrong bounds");
+    return false;
+  }
+
+  const auto expectedOutput = [&](CanvasBoundaryMode mode) {
+    return renderCapture(capture, sourceFrame, {outside},
+                         BackgroundStyle::None, true, mode);
+  };
+  const QImage growOutput = expectedOutput(CanvasBoundaryMode::Grow);
+  const QImage frameOutput = expectedOutput(CanvasBoundaryMode::Frame);
+  const QImage imageOutput = expectedOutput(CanvasBoundaryMode::Image);
+  if (growOutput.size() != growCanvas.size().toSize() ||
+      frameOutput.size() != frameCanvas.size().toSize() ||
+      imageOutput.size() != imageCanvas.size().toSize() ||
+      !(growOutput.width() > frameOutput.width() &&
+        frameOutput.width() > imageOutput.width())) {
+    error = QStringLiteral("Canvas boundary exports were not clipped in order");
+    return false;
+  }
+
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::File,
+                       QuickOutputMode::None, log);
+  editor.resize(640, 480);
+  editor.show();
+  application.processEvents();
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Grow ||
+      editor.currentCanvasForTest() != growCanvas ||
+      editor.renderCurrentOutput() != growOutput) {
+    error = QStringLiteral("Canvas did not default to Grow");
+    return false;
+  }
+
+  QTest::keyClick(&editor, Qt::Key_G);
+  application.processEvents();
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Frame ||
+      editor.currentCanvasForTest() != frameCanvas ||
+      editor.currentAnnotationsForTest() != QVector<Annotation>{outside} ||
+      editor.renderCurrentOutput() != frameOutput ||
+      !editor.statusForTest().contains(QStringLiteral("Canvas: Frame")) ||
+      editor.operationLog().constLast().type !=
+          Operation::Type::CanvasBoundary ||
+      editor.operationLog().constLast().canvasBoundary !=
+          CanvasBoundaryMode::Frame) {
+    error = QStringLiteral("G did not switch non-destructively to Frame");
+    return false;
+  }
+
+  if (!editor.waitForSnapshot() || editor.workingLogPath().isEmpty()) {
+    error = QStringLiteral("Frame boundary was not persisted");
+    return false;
+  }
+  CaptureEditor restored(capture, CaptureEditor::CaptureMode::File);
+  QString restoreError;
+  if (!restored.restoreOperationLog(editor.workingLogPath(), restoreError) ||
+      restored.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Frame ||
+      restored.currentCanvasForTest() != frameCanvas ||
+      restored.currentAnnotationsForTest() != QVector<Annotation>{outside} ||
+      restored.renderCurrentOutput() != frameOutput) {
+    error = QStringLiteral("Restoring Frame changed its layers or clipping: %1")
+                .arg(restoreError);
+    return false;
+  }
+  restored.close();
+
+  QTest::keyClick(&editor, Qt::Key_G);
+  application.processEvents();
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Image ||
+      editor.currentCanvasForTest() != imageCanvas ||
+      editor.currentAnnotationsForTest() != QVector<Annotation>{outside} ||
+      editor.renderCurrentOutput() != imageOutput ||
+      !editor.statusForTest().contains(QStringLiteral("Canvas: Image"))) {
+    error = QStringLiteral("G did not switch non-destructively to Image");
+    return false;
+  }
+
+  QTest::keyClick(&editor, Qt::Key_G, Qt::ShiftModifier);
+  QTest::keyClick(&editor, Qt::Key_G, Qt::ShiftModifier);
+  application.processEvents();
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Grow ||
+      editor.currentCanvasForTest() != growCanvas ||
+      editor.currentAnnotationsForTest() != QVector<Annotation>{outside} ||
+      editor.renderCurrentOutput() != growOutput) {
+    error = QStringLiteral("Shift+G did not cycle backward to Grow");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Frame ||
+      editor.renderCurrentOutput() != frameOutput) {
+    error = QStringLiteral("Undo did not restore the prior canvas boundary");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Grow ||
+      editor.renderCurrentOutput() != growOutput) {
+    error = QStringLiteral("Redo did not restore the Grow boundary");
+    return false;
+  }
+
+  editor.close();
+  return true;
+}
+
 /** Runs the interaction and rendering smoke checks. */
 bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
   CaptureData capture;
@@ -6700,6 +6845,10 @@ int main(int argc, char **argv) {
   if (!runContinuousAnnotationToolsSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 80;
+  }
+  if (!runCanvasBoundaryModeSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 202;
   }
   if (!runSelectOutsideCanvasSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -1707,8 +1707,13 @@ bool runAnnotationLayerChecks(QApplication &application, QString &error) {
   const QImage overlayExport =
       renderCapture(capture, QRectF(0, 0, 80, 40), {redaction, arrow, label},
                     BackgroundStyle::None);
-  const QColor overlayFill = overlayExport.pixelColor(22, 12);
-  const QColor overlayStroke = overlayExport.pixelColor(26, 20);
+  const QRectF overlayCanvas =
+      captureCanvasRect(QSizeF(80, 40), {redaction, arrow, label});
+  const QPoint overlayOrigin = (-overlayCanvas.topLeft()).toPoint();
+  const QColor overlayFill =
+      overlayExport.pixelColor(overlayOrigin + QPoint(22, 12));
+  const QColor overlayStroke =
+      overlayExport.pixelColor(overlayOrigin + QPoint(26, 20));
   if (overlayExport.isNull() || redactionOnly.isNull() ||
       redactionOnly.pixelColor(22, 12) != solid || showsSecretRed(overlayFill) ||
       overlayStroke.blue() <= overlayStroke.red() + 20) {
@@ -3338,11 +3343,15 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
   const Annotation shifted = editor.currentAnnotationsForTest().constFirst();
   const QRectF shiftedCanvas = editor.currentCanvasForTest();
   const QImage shiftedOutput = currentOutput();
+  const QPoint shiftedSourceOrigin(qRound(-shiftedCanvas.left()),
+                                   qRound(-shiftedCanvas.top()));
   if (shiftedOutput != expectedCurrent(BackgroundStyle::None) ||
       shiftedOutput.size() != shiftedCanvas.size().toSize() ||
-      !isSlateShadow(shiftedOutput.pixelColor(610, 350)) ||
-      shiftedOutput.pixelColor(650, 350) != slate ||
-      shiftedOutput.pixelColor(599, 350) !=
+      !isSlateShadow(shiftedOutput.pixelColor(shiftedSourceOrigin +
+                                              QPoint(610, 350))) ||
+      shiftedOutput.pixelColor(shiftedSourceOrigin + QPoint(650, 350)) !=
+          slate ||
+      shiftedOutput.pixelColor(shiftedSourceOrigin + QPoint(599, 350)) !=
           QColor(QStringLiteral("#182030"))) {
     error = QStringLiteral(
         "Right-side growth did not shadow only the source card");
@@ -3582,9 +3591,12 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
       editor.currentAnnotationsForTest();
   const QRectF textCanvas = editor.currentCanvasForTest();
   const QImage textOutput = currentOutput();
+  const QPoint textSourceOrigin(qRound(-textCanvas.left()),
+                                qRound(-textCanvas.top()));
   if (textOutput != expectedCurrent(BackgroundStyle::None) ||
-      !isSlateShadow(textOutput.pixelColor(610, 350)) ||
-      textOutput.pixelColor(650, 350) != slate) {
+      !isSlateShadow(textOutput.pixelColor(textSourceOrigin +
+                                           QPoint(610, 350))) ||
+      textOutput.pixelColor(textSourceOrigin + QPoint(650, 350)) != slate) {
     error = QStringLiteral(
         "Text growth did not keep the source shadow on default Slate");
     return false;
@@ -4551,7 +4563,11 @@ bool runTextPillRenderingCheck(QString &error) {
                               qRound(text.start.y() +
                                      QFontMetricsF(annotationTextFont(text.size))
                                          .lineSpacing()));
-  if (multilineImage.pixelColor(secondLinePill) != QColor(248, 245, 235)) {
+  const QRectF multilineCanvas =
+      captureCanvasRect(QSizeF(300, 100), {multiline});
+  const QPoint multilineOrigin = (-multilineCanvas.topLeft()).toPoint();
+  if (multilineImage.pixelColor(multilineOrigin + secondLinePill) !=
+      QColor(248, 245, 235)) {
     error = QStringLiteral("Multiline text pill did not cover the second line");
     return false;
   }
@@ -7675,9 +7691,11 @@ int main(int argc, char **argv) {
   const QImage grownExport =
       renderCapture(clippingCapture, QRectF(0, 0, 100, 100), {croppedOut},
                     BackgroundStyle::Aurora);
+  const QPoint grownOrigin(qRound(-grownCanvas.left()),
+                           qRound(-grownCanvas.top()));
   bool paintedOutsideSource = false;
   for (int y = 0; y < grownExport.height(); ++y) {
-    for (int x = 100; x < grownExport.width(); ++x) {
+    for (int x = grownOrigin.x() + 100; x < grownExport.width(); ++x) {
       const QColor pixel = grownExport.pixelColor(x, y);
       if (pixel.red() > 240 && pixel.green() < 32 && pixel.blue() > 240)
         paintedOutsideSource = true;
@@ -7727,17 +7745,23 @@ int main(int argc, char **argv) {
       isSlateShadow(shadowProbe.pixelColor(110, 40)) &&
       shadowProbe.pixelColor(110, 20) == slate;
   const std::array<int, 5> slateShadowProfile = {
-      slateExport.pixelColor(100, 90).red(),
-      slateExport.pixelColor(111, 90).red(),
-      slateExport.pixelColor(123, 90).red(),
-      slateExport.pixelColor(138, 90).red(),
-      slateExport.pixelColor(142, 90).red()};
+      slateExport.pixelColor(grownOrigin + QPoint(100, 90)).red(),
+      slateExport.pixelColor(grownOrigin + QPoint(111, 90)).red(),
+      slateExport.pixelColor(grownOrigin + QPoint(123, 90)).red(),
+      slateExport.pixelColor(grownOrigin + QPoint(138, 90)).red(),
+      slateExport.pixelColor(grownOrigin + QPoint(142, 90)).red()};
+  const QPoint highDpiGrowthOrigin = grownOrigin * 2;
   const std::array<int, 5> highDpiShadowProfile = {
-      highDpiGrowthExport.pixelColor(200, 180).red(),
-      highDpiGrowthExport.pixelColor(222, 180).red(),
-      highDpiGrowthExport.pixelColor(246, 180).red(),
-      highDpiGrowthExport.pixelColor(276, 180).red(),
-      highDpiGrowthExport.pixelColor(284, 180).red()};
+      highDpiGrowthExport.pixelColor(highDpiGrowthOrigin + QPoint(200, 180))
+          .red(),
+      highDpiGrowthExport.pixelColor(highDpiGrowthOrigin + QPoint(222, 180))
+          .red(),
+      highDpiGrowthExport.pixelColor(highDpiGrowthOrigin + QPoint(246, 180))
+          .red(),
+      highDpiGrowthExport.pixelColor(highDpiGrowthOrigin + QPoint(276, 180))
+          .red(),
+      highDpiGrowthExport.pixelColor(highDpiGrowthOrigin + QPoint(284, 180))
+          .red()};
   bool scaleIndependentShadow = true;
   for (std::size_t i = 0; i < slateShadowProfile.size(); ++i) {
     scaleIndependentShadow =
@@ -7752,23 +7776,30 @@ int main(int argc, char **argv) {
       slateShadowProfile.back() == slate.red();
   const bool restrainedShadowStrength =
       bottomShadowProfile.front() >= 20 && slateShadowProfile.front() >= 20;
-  if (grownCanvas != QRectF(0, 0, 153, 100) ||
-      grownExport.size() != QSize(153, 100) || !paintedOutsideSource ||
-      grownExport.pixelColor(0, 0) != QColor(Qt::white) ||
+  if (grownCanvas != QRectF(-64, -64, 228, 228) ||
+      grownExport.size() != QSize(228, 228) || !paintedOutsideSource ||
+      grownExport.pixelColor(grownOrigin) != QColor(Qt::white) ||
       slateExport.size() != grownExport.size() ||
-      slateExport.pixelColor(99, 90) != QColor(Qt::white) ||
+      slateExport.pixelColor(grownOrigin + QPoint(99, 90)) !=
+          QColor(Qt::white) ||
       unshadowedSlateExport.size() != slateExport.size() ||
-      unshadowedSlateExport.pixelColor(99, 90) != QColor(Qt::white) ||
-      unshadowedSlateExport.pixelColor(100, 90) != slate ||
-      unshadowedSlateExport.pixelColor(152, 90) != slate ||
+      unshadowedSlateExport.pixelColor(grownOrigin + QPoint(99, 90)) !=
+          QColor(Qt::white) ||
+      unshadowedSlateExport.pixelColor(grownOrigin + QPoint(100, 90)) !=
+          slate ||
+      unshadowedSlateExport.pixelColor(grownOrigin + QPoint(152, 90)) !=
+          slate ||
       !softAmbientAndKeyShadow || !softlyFadingShadow ||
       !restrainedShadowStrength ||
       !scaleIndependentShadow ||
-      slateExport.pixelColor(152, 90) != slate ||
-      highDpiGrowthExport.size() != QSize(306, 200) ||
-      highDpiGrowthExport.pixelColor(199, 180) != QColor(Qt::white) ||
-      !isSlateShadow(highDpiGrowthExport.pixelColor(200, 180)) ||
-      highDpiGrowthExport.pixelColor(304, 180) != slate ||
+      slateExport.pixelColor(grownOrigin + QPoint(152, 90)) != slate ||
+      highDpiGrowthExport.size() != QSize(456, 456) ||
+      highDpiGrowthExport.pixelColor(highDpiGrowthOrigin + QPoint(199, 180)) !=
+          QColor(Qt::white) ||
+      !isSlateShadow(highDpiGrowthExport.pixelColor(highDpiGrowthOrigin +
+                                                    QPoint(200, 180))) ||
+      highDpiGrowthExport.pixelColor(highDpiGrowthOrigin +
+                                     QPoint(304, 180)) != slate ||
       slateExport != renderCapture(clippingCapture, QRectF(0, 0, 100, 100),
                                    {croppedOut}, BackgroundStyle::None))
     return 65;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -3267,18 +3267,18 @@ bool runCanvasBoundaryModeSmoke(QApplication &application, QString &error) {
   log.previewSize = capture.previewSize;
 
   const QRectF sourceFrame(QPointF(), QSizeF(capture.previewSize));
-  const QRectF growCanvas = captureCanvasRect(
-      sourceFrame.size(), {outside}, CanvasBoundaryMode::Grow);
-  const QRectF frameCanvas = captureCanvasRect(
-      sourceFrame.size(), {outside}, CanvasBoundaryMode::Frame);
+  const QRectF framedCanvas = captureCanvasRect(
+      sourceFrame.size(), {outside}, CanvasBoundaryMode::Framed);
+  const QRectF overflowCanvas = captureCanvasRect(
+      sourceFrame.size(), {outside}, CanvasBoundaryMode::Overflow);
   const QRectF imageCanvas = captureCanvasRect(
       sourceFrame.size(), {outside}, CanvasBoundaryMode::Image);
-  if (captureCanvasRect(sourceFrame.size(), {outside}) != growCanvas ||
-      growCanvas != QRectF(-64, -64, 327, 228) ||
-      frameCanvas != QRectF(-64, -64, 228, 228) ||
+  if (captureCanvasRect(sourceFrame.size(), {outside}) != framedCanvas ||
+      framedCanvas != QRectF(-64, -64, 327, 228) ||
+      overflowCanvas != QRectF(0, 0, 263, 100) ||
       imageCanvas != sourceFrame ||
-      captureCanvasRect(sourceFrame.size(), {}, CanvasBoundaryMode::Frame) !=
-          sourceFrame) {
+      captureCanvasRect(sourceFrame.size(), {},
+                        CanvasBoundaryMode::Overflow) != sourceFrame) {
     error = QStringLiteral("Canvas boundary geometry reached the wrong bounds");
     return false;
   }
@@ -3287,14 +3287,30 @@ bool runCanvasBoundaryModeSmoke(QApplication &application, QString &error) {
     return renderCapture(capture, sourceFrame, {outside},
                          BackgroundStyle::None, true, mode);
   };
-  const QImage growOutput = expectedOutput(CanvasBoundaryMode::Grow);
-  const QImage frameOutput = expectedOutput(CanvasBoundaryMode::Frame);
+  const QImage framedOutput = expectedOutput(CanvasBoundaryMode::Framed);
+  const QImage overflowOutput = expectedOutput(CanvasBoundaryMode::Overflow);
   const QImage imageOutput = expectedOutput(CanvasBoundaryMode::Image);
-  if (growOutput.size() != growCanvas.size().toSize() ||
-      frameOutput.size() != frameCanvas.size().toSize() ||
+  const QImage framedOff =
+      renderCapture(capture, sourceFrame, {outside}, BackgroundStyle::Off, true,
+                    CanvasBoundaryMode::Framed);
+  const QImage overflowColor = renderCapture(
+      capture, sourceFrame, {outside}, BackgroundStyle::Aurora, true,
+      CanvasBoundaryMode::Overflow);
+  const QImage imageColor = renderCapture(capture, sourceFrame, {outside},
+                                          BackgroundStyle::Aurora, true,
+                                          CanvasBoundaryMode::Image);
+  if (framedOutput.size() != framedCanvas.size().toSize() ||
+      overflowOutput.size() != overflowCanvas.size().toSize() ||
       imageOutput.size() != imageCanvas.size().toSize() ||
-      !(growOutput.width() > frameOutput.width() &&
-        frameOutput.width() > imageOutput.width())) {
+      !(framedOutput.width() > overflowOutput.width() &&
+        overflowOutput.width() > imageOutput.width()) ||
+      framedOutput.pixelColor(0, 0).alpha() != 255 ||
+      framedOff.size() != framedOutput.size() ||
+      framedOff.pixelColor(0, 0).alpha() != 0 ||
+      overflowOutput.pixelColor(200, 10).alpha() != 0 ||
+      overflowColor.size() != overflowOutput.size() ||
+      overflowColor.pixelColor(200, 10).alpha() != 255 ||
+      imageColor != imageOutput) {
     error = QStringLiteral("Canvas boundary exports were not clipped in order");
     return false;
   }
@@ -3304,41 +3320,43 @@ bool runCanvasBoundaryModeSmoke(QApplication &application, QString &error) {
   editor.resize(640, 480);
   editor.show();
   application.processEvents();
-  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Grow ||
-      editor.currentCanvasForTest() != growCanvas ||
-      editor.renderCurrentOutput() != growOutput) {
-    error = QStringLiteral("Canvas did not default to Grow");
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Framed ||
+      editor.currentCanvasForTest() != framedCanvas ||
+      editor.renderCurrentOutput() != framedOutput) {
+    error = QStringLiteral("Canvas did not default to Framed");
     return false;
   }
 
   QTest::keyClick(&editor, Qt::Key_G);
   application.processEvents();
-  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Frame ||
-      editor.currentCanvasForTest() != frameCanvas ||
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Overflow ||
+      editor.currentCanvasForTest() != overflowCanvas ||
       editor.currentAnnotationsForTest() != QVector<Annotation>{outside} ||
-      editor.renderCurrentOutput() != frameOutput ||
-      !editor.statusForTest().contains(QStringLiteral("Canvas: Frame")) ||
+      editor.renderCurrentOutput() != overflowOutput ||
+      !editor.statusForTest().contains(QStringLiteral("Canvas: Overflow")) ||
       editor.operationLog().constLast().type !=
           Operation::Type::CanvasBoundary ||
       editor.operationLog().constLast().canvasBoundary !=
-          CanvasBoundaryMode::Frame) {
-    error = QStringLiteral("G did not switch non-destructively to Frame");
+          CanvasBoundaryMode::Overflow) {
+    error = QStringLiteral("G did not switch non-destructively to Overflow");
     return false;
   }
 
   if (!editor.waitForSnapshot() || editor.workingLogPath().isEmpty()) {
-    error = QStringLiteral("Frame boundary was not persisted");
+    error = QStringLiteral("Overflow boundary was not persisted");
     return false;
   }
   CaptureEditor restored(capture, CaptureEditor::CaptureMode::File);
   QString restoreError;
   if (!restored.restoreOperationLog(editor.workingLogPath(), restoreError) ||
-      restored.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Frame ||
-      restored.currentCanvasForTest() != frameCanvas ||
+      restored.currentCanvasBoundaryForTest() !=
+          CanvasBoundaryMode::Overflow ||
+      restored.currentCanvasForTest() != overflowCanvas ||
       restored.currentAnnotationsForTest() != QVector<Annotation>{outside} ||
-      restored.renderCurrentOutput() != frameOutput) {
-    error = QStringLiteral("Restoring Frame changed its layers or clipping: %1")
-                .arg(restoreError);
+      restored.renderCurrentOutput() != overflowOutput) {
+    error =
+        QStringLiteral("Restoring Overflow changed its layers or clipping: %1")
+            .arg(restoreError);
     return false;
   }
   restored.close();
@@ -3357,25 +3375,26 @@ bool runCanvasBoundaryModeSmoke(QApplication &application, QString &error) {
   QTest::keyClick(&editor, Qt::Key_G, Qt::ShiftModifier);
   QTest::keyClick(&editor, Qt::Key_G, Qt::ShiftModifier);
   application.processEvents();
-  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Grow ||
-      editor.currentCanvasForTest() != growCanvas ||
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Framed ||
+      editor.currentCanvasForTest() != framedCanvas ||
       editor.currentAnnotationsForTest() != QVector<Annotation>{outside} ||
-      editor.renderCurrentOutput() != growOutput) {
-    error = QStringLiteral("Shift+G did not cycle backward to Grow");
+      editor.renderCurrentOutput() != framedOutput) {
+    error = QStringLiteral("Shift+G did not cycle backward to Framed");
     return false;
   }
   QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
   application.processEvents();
-  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Frame ||
-      editor.renderCurrentOutput() != frameOutput) {
+  if (editor.currentCanvasBoundaryForTest() !=
+          CanvasBoundaryMode::Overflow ||
+      editor.renderCurrentOutput() != overflowOutput) {
     error = QStringLiteral("Undo did not restore the prior canvas boundary");
     return false;
   }
   QTest::keyClick(&editor, Qt::Key_Y, Qt::ControlModifier);
   application.processEvents();
-  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Grow ||
-      editor.renderCurrentOutput() != growOutput) {
-    error = QStringLiteral("Redo did not restore the Grow boundary");
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Framed ||
+      editor.renderCurrentOutput() != framedOutput) {
+    error = QStringLiteral("Redo did not restore the Framed boundary");
     return false;
   }
 
@@ -3443,17 +3462,6 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
       editor.currentAnnotationsForTest().constFirst().kind !=
           Annotation::Kind::Rectangle ||
       editor.currentCanvasForTest() != sourceCanvas || !canvasIsDerived()) {
-  // A rectangle at annotation (400,195)-(550,345); the widget offset is
-  // (100,117). Drag it 100 px right so its right side leaves the canvas.
-  QTest::keyClick(&editor, Qt::Key_R);
-  drag(QPoint(500, 312), QPoint(650, 462));
-  Annotation rectangle;
-  rectangle.kind = Annotation::Kind::Rectangle;
-  rectangle.start = {400, 195};
-  rectangle.end = {550, 345};
-  rectangle.color = QColor(QStringLiteral("#ff375f"));
-  rectangle.size = 4;
-  if (!snapshotMatches(expected({rectangle}))) {
     error = QStringLiteral("Outside-canvas smoke: rectangle did not render");
     return false;
   }
@@ -3475,13 +3483,6 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
   drag(moveStart, moveStart + QPoint(220, 0));
   if (editor.currentAnnotationsForTest().size() != 1 || !canvasIsDerived() ||
       editor.currentCanvasForTest().right() <= sourceCanvas.right()) {
-  // Press the top edge, clear of the corner and mid-side handles (eight on
-  // a box), so this is a move.
-  drag(QPoint(540, 312), QPoint(640, 312));
-  Annotation shifted = rectangle;
-  shifted.start.rx() += 100;
-  shifted.end.rx() += 100;
-  if (!snapshotMatches(expected({shifted}))) {
     error = QStringLiteral("Outside-canvas smoke: rectangle did not move");
     return false;
   }
@@ -3514,12 +3515,6 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
   if (!canvasIsDerived() || resizedCanvas.right() <= shiftedCanvas.right() ||
       resizedCanvas.bottom() <= sourceCanvas.bottom() ||
       resizedOutput != expectedCurrent(BackgroundStyle::None)) {
-  // Its bottom-right handle now sits outside the canvas (widget (750,462));
-  // dragging it back in resizes the layer.
-  drag(QPoint(750, 462), QPoint(650, 412));
-  Annotation resized = shifted;
-  resized.end = {550, 295};
-  if (!snapshotMatches(expected({resized}))) {
     error = QStringLiteral(
         "Dragging an exposed handle did not grow the canvas again");
     return false;
@@ -3569,10 +3564,6 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
       slateOutput.pixelColor(sourceOrigin + QPoint(0, 300)) !=
           QColor(QStringLiteral("#182030")) ||
       slateOutput != currentOutput()) {
-  // Its right edge is outside the canvas too (widget x 750); grab off the
-  // mid-side handle so this is a move, not a one-axis resize.
-  drag(QPoint(750, 352), QPoint(650, 352));
-  if (!snapshotMatches(expected({rectangle}))) {
     error = QStringLiteral(
         "Grown output shifted the source or misplaced its shadow");
     return false;
@@ -3582,10 +3573,6 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
   // the source card's shadow, can be undone/redone, and survives sidecar
   // persistence with the implicit Slate backdrop still implicit.
   QTest::keyClick(&editor, Qt::Key_B, Qt::ShiftModifier);
-  // Outside the canvas, anything but the selected layer stays inert: a
-  // click on the surround neither deselects nor changes anything, so
-  // Delete still removes the layer.
-  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, QPoint(760, 162));
   application.processEvents();
   const QImage noShadowOutput = currentOutput();
   if (noShadowOutput == slateOutput ||
@@ -3633,7 +3620,7 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
 
   // Automatic growth starts on an implicit shadowed-gray mat but remains in
   // fullscreen mode: B runs through every shadowed color, then shadowed gray,
-  // flat gray, and back to blue.
+  // flat gray, and explicit Off before wrapping back to blue.
   struct BackdropStep {
     BackgroundStyle style;
     bool shadow;
@@ -3645,7 +3632,7 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
       {BackgroundStyle::Violet, true},
       {BackgroundStyle::Slate, true},
       {BackgroundStyle::Slate, false},
-      {BackgroundStyle::Aurora, true},
+      {BackgroundStyle::Off, true},
   }};
   for (const BackdropStep step : grownCycle) {
     QTest::keyClick(&editor, Qt::Key_B);
@@ -3825,7 +3812,7 @@ bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
 }
 
 /** Fullscreen B starts with blue, runs through every shadowed color, then
- *  demonstrates shadowed gray before its flat-gray hint. */
+ *  demonstrates shadowed gray, flat gray, Off, and its blue wrap. */
 bool runFullscreenBackdropCycleSmoke(QApplication &application,
                                      QString &error) {
   CaptureData capture;
@@ -3841,13 +3828,14 @@ bool runFullscreenBackdropCycleSmoke(QApplication &application,
     BackgroundStyle style;
     bool shadow;
   };
-  const std::array<BackdropStep, 7> fullscreenCycle{{
+  const std::array<BackdropStep, 8> fullscreenCycle{{
       {BackgroundStyle::Aurora, true},
       {BackgroundStyle::Sunset, true},
       {BackgroundStyle::Lagoon, true},
       {BackgroundStyle::Violet, true},
       {BackgroundStyle::Slate, true},
       {BackgroundStyle::Slate, false},
+      {BackgroundStyle::Off, true},
       {BackgroundStyle::Aurora, true},
   }};
 
@@ -5036,7 +5024,7 @@ bool runGrownCanvasSelectAllChromeSmoke(QApplication &application,
   const QColor liveShadow = grabLogicalPixel(
       idle, editor, editor.annotationPointToWidgetForTest({610, 220}));
   const QColor liveMatte = grabLogicalPixel(
-      idle, editor, editor.annotationPointToWidgetForTest({645, 220}));
+      idle, editor, editor.annotationPointToWidgetForTest({648, 220}));
   if (liveShadow.alpha() != 255 || liveShadow.red() >= 36 ||
       liveShadow.green() >= 36 || liveShadow.blue() >= 36 ||
       liveMatte != QColor(QStringLiteral("#242424"))) {
@@ -7712,7 +7700,6 @@ int main(int argc, char **argv) {
   // canvas restores the source crop handles before the crop begins.
   QTest::mouseClick(&cropEditor, Qt::LeftButton, Qt::NoModifier,
                     QPoint(600, 400));
-                    QPoint(390, 250));
   application.processEvents();
   const QImage beforeCrop = cropEditor.grab().toImage();
   const QRectF beforeCropFrame = cropEditor.sourceFrameWidgetRectForTest();


### PR DESCRIPTION
Annotations can now move, resize, draw, or type past the screenshot edge. Their complete vector geometry stays in the operation log even when the selected output boundary clips it.

`G` cycles three non-destructive output modes: Framed (the default auto-grow behavior with the normal backdrop frame), Overflow (tight growth only on sides crossed by annotations, with no frame), and Image (the original canvas size, clipping all outside annotations). The canvas contracts again when an outside layer is moved back, deleted, or undone.

`B` owns the visual backdrop and now cycles through the colors, shadowed and flat window gray, and an explicit Off state, fixing the regression that made the background impossible to remove. Overflow without a backdrop leaves its added pixels transparent; Image always exports only the original canvas. `Shift+B` still toggles the shadow directly, and select-all continues to select annotation layers only.

![Canvas growing around off-image annotations](https://github.com/user-attachments/assets/1633a28e-da6d-44ea-b712-2f8ed32b0d46)

Tested with `make check`.
