### PR TITLE
fix(editor): hide measurements while browsing recent captures

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1876,6 +1876,8 @@ QString CaptureEditor::measurementText() const {
   if (capture_.source.isNull())
     return {};
   if (phase_ == Phase::Select) {
+    if (recentsOpen_)
+      return {};
     if (windowMode_) {
       if (hoveredWindow_ < 0 || hoveredWindow_ >= capture_.windows.size())
         return {};

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2578,10 +2578,18 @@ bool runRecentsShelfSmoke(QApplication &application, QString &error) {
     }
     QTest::mouseMove(&editor, QPoint(100, 300), 20);
     application.processEvents();
+    if (editor.measurementText().isEmpty()) {
+      error = QStringLiteral("Selection readout disappeared outside the shelf");
+      return false;
+    }
     QTest::mouseMove(&editor, stacked.center().toPoint(), 20);
     application.processEvents();
     if (!editor.recentsOpenForTest()) {
       error = QStringLiteral("Hovering the stack did not fan the shelf out");
+      return false;
+    }
+    if (!editor.measurementText().isEmpty()) {
+      error = QStringLiteral("Selection readout overlapped the open shelf");
       return false;
     }
     const QRectF fanned = editor.recentCardRectForTest(0);


### PR DESCRIPTION
## Summary

- Hide the pointer measurement readout while the recent-capture shelf is open so coordinates do not overlap restore thumbnails.
- Preserve the normal measurement readout everywhere outside the shelf.
- Extend the recents shelf smoke test to cover both states.

## Verification

- `make smoke` against current upstream `main`
- `make check` on the integration branch
