### PR TITLE
Add a custom backdrop image and a default backdrop style

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ add_library(omasnap-core STATIC
   src/cut.hpp
   src/palette-config.cpp
   src/palette-config.hpp
+  src/background-config.cpp
+  src/background-config.hpp
   src/recent-snaps.cpp
   src/recent-snaps.hpp
   src/output-config.cpp

--- a/README.md
+++ b/README.md
@@ -268,6 +268,16 @@ filename = screenshot-{date}_{time}-{app}
 # Up to eight preset colors for the palette, and the initial custom color.
 palette = #ff375f, #ff9f0a, #ffd60a, #30d158, #0a84ff, #bf5af2, #000000, #ffffff
 custom = #ff375f
+
+[background]
+# An image used as a "Custom" backdrop, in addition to the four built-in
+# gradients. B (or the toolbar's backdrop button) cycles through none, the
+# four gradients, then this image, skipping it if unset or unreadable.
+image = ~/Pictures/backdrops/desk.jpg
+# Style a freshly opened capture starts with, instead of no backdrop:
+# none, aurora, sunset, lagoon, violet, or custom. `custom` only takes
+# effect once `image` above loads successfully.
+default = custom
 ```
 
 Filename tokens:

--- a/src/background-config.cpp
+++ b/src/background-config.cpp
@@ -1,0 +1,27 @@
+/** @fileoverview Loads the custom backdrop image path and the default
+ *  backdrop style from the user's INI config. */
+#include "background-config.hpp"
+
+#include <QDir>
+#include <QSettings>
+
+BackgroundConfig loadBackgroundConfig(const QString &filePath) {
+  BackgroundConfig config;
+  QSettings settings(filePath, QSettings::IniFormat);
+  QString image =
+      settings.value(QStringLiteral("background/image")).toString().trimmed();
+  if (image == QStringLiteral("~"))
+    image = QDir::homePath();
+  else if (image.startsWith(QStringLiteral("~/")))
+    image = QDir::homePath() + image.mid(1);
+  config.imagePath = image;
+  BackgroundStyle style;
+  if (backgroundStyleFromName(
+          settings.value(QStringLiteral("background/default"))
+              .toString()
+              .trimmed()
+              .toLower(),
+          style))
+    config.defaultStyle = style;
+  return config;
+}

--- a/src/background-config.hpp
+++ b/src/background-config.hpp
@@ -1,0 +1,25 @@
+/** @fileoverview Loads the custom backdrop image path and the default
+ *  backdrop style from the user's INI config. */
+#pragma once
+
+#include "capture.hpp"
+
+#include <QString>
+
+/** Custom backdrop settings, loaded from the user's INI config or defaults. */
+struct BackgroundConfig {
+  /** Absolute path to an image used as the "Custom" backdrop, or empty when
+   *  none is configured. */
+  QString imagePath;
+  /** Style a freshly opened capture starts with. `None` (today's behavior)
+   *  unless the config asks for something else. */
+  BackgroundStyle defaultStyle = BackgroundStyle::None;
+};
+
+/** Reads `[background] image` (a path, `~` expands to $HOME) and
+ *  `[background] default` (a style name: none, aurora, sunset, lagoon,
+ *  violet, custom) from an INI file. A missing file or key leaves defaults
+ *  untouched; an unrecognized style name is ignored. Whether `default =
+ *  custom` actually takes effect depends on `image` loading successfully,
+ *  which the caller checks. */
+[[nodiscard]] BackgroundConfig loadBackgroundConfig(const QString &filePath);

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -674,9 +674,26 @@ void paintDefaultLayer(QPainter &painter, const QImage &redacted,
 }
 
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
-                            BackgroundStyle backgroundStyle) {
+                            BackgroundStyle backgroundStyle,
+                            const QImage &customBackdrop) {
   if (backgroundStyle == BackgroundStyle::None)
     return;
+  if (backgroundStyle == BackgroundStyle::Custom) {
+    if (customBackdrop.isNull())
+      return; // configured image never loaded; behave like None
+    // Cover-fit: scale to fill `bounds` and center-crop the overhang, the
+    // same way a desktop wallpaper covers a screen of a different aspect.
+    const QSizeF imageSize(customBackdrop.size());
+    const qreal scale = std::max(bounds.width() / imageSize.width(),
+                                 bounds.height() / imageSize.height());
+    const QSizeF scaledSize = imageSize * scale;
+    const QRectF target(
+        bounds.center() -
+            QPointF(scaledSize.width(), scaledSize.height()) / 2.0,
+        scaledSize);
+    painter.drawImage(target, customBackdrop);
+    return;
+  }
 
   struct Blob {
     QPointF center;
@@ -815,7 +832,8 @@ bool captureFocusedMonitor(CaptureData &capture, bool includeWindows,
 
 QImage renderCapture(const CaptureData &capture, const QRectF &selection,
                      const QVector<Annotation> &annotations,
-                     BackgroundStyle backgroundStyle) {
+                     BackgroundStyle backgroundStyle,
+                     const QImage &customBackdrop) {
   const QRect pixels = pixelSelection(capture, selection);
   if (pixels.isEmpty())
     return {};
@@ -850,7 +868,9 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
   applyRedactions(cropped, annotations, resized ? scaleX : sourceScaleX,
                   resized ? scaleY : sourceScaleY,
                   resized ? QPointF{} : sourceOriginOffset);
-  const bool hasBackground = backgroundStyle != BackgroundStyle::None;
+  const bool hasBackground = backgroundStyle == BackgroundStyle::Custom
+                                  ? !customBackdrop.isNull()
+                                  : backgroundStyle != BackgroundStyle::None;
   const int marginX =
       hasBackground ? static_cast<int>(std::round(64.0 * scaleX)) : 0;
   const int marginY =
@@ -864,7 +884,8 @@ QImage renderCapture(const CaptureData &capture, const QRectF &selection,
                          QPainter::SmoothPixmapTransform |
                          QPainter::TextAntialiasing);
   if (hasBackground) {
-    paintCaptureBackground(painter, output.rect(), backgroundStyle);
+    paintCaptureBackground(painter, output.rect(), backgroundStyle,
+                           customBackdrop);
     const QRectF imageRect(marginX, marginY, cropped.width(), cropped.height());
     painter.setPen(Qt::NoPen);
     for (int layer = 24; layer > 0; --layer) {
@@ -1304,6 +1325,8 @@ bool annotationKindFromName(const QString &name, Annotation::Kind &kind) {
   return true;
 }
 
+} // namespace
+
 QString backgroundStyleName(BackgroundStyle style) {
   switch (style) {
   case BackgroundStyle::None:
@@ -1316,6 +1339,8 @@ QString backgroundStyleName(BackgroundStyle style) {
     return QStringLiteral("lagoon");
   case BackgroundStyle::Violet:
     return QStringLiteral("violet");
+  case BackgroundStyle::Custom:
+    return QStringLiteral("custom");
   }
   return QStringLiteral("none");
 }
@@ -1331,10 +1356,14 @@ bool backgroundStyleFromName(const QString &name, BackgroundStyle &style) {
     style = BackgroundStyle::Lagoon;
   else if (name == QStringLiteral("violet"))
     style = BackgroundStyle::Violet;
+  else if (name == QStringLiteral("custom"))
+    style = BackgroundStyle::Custom;
   else
     return false;
   return true;
 }
+
+namespace {
 
 QJsonObject annotationToJson(const Annotation &annotation) {
   QJsonObject object;

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -43,7 +43,7 @@ struct CaptureData {
   QVector<WindowTarget> windows;
 };
 
-enum class BackgroundStyle { None, Aurora, Sunset, Lagoon, Violet };
+enum class BackgroundStyle { None, Aurora, Sunset, Lagoon, Violet, Custom };
 enum class QuickOutputMode { None, Copy, Save, Both };
 
 enum class SpotlightShape { Ellipse, Rectangle, RoundedRectangle };
@@ -188,10 +188,22 @@ void describeFileCapture(CaptureData &capture, QImage image,
 /** Returns an upright image for captured Wayland buffer contents. */
 [[nodiscard]] QImage normalizeWaylandCapture(const QImage &image,
                                              std::uint32_t transform);
+/** `customBackdrop` is the image drawn for `BackgroundStyle::Custom`; unused
+ *  (and safe to omit) for every other style. */
 [[nodiscard]] QImage renderCapture(const CaptureData &capture,
                                    const QRectF &selection,
                                    const QVector<Annotation> &annotations,
-                                   BackgroundStyle backgroundStyle);
+                                   BackgroundStyle backgroundStyle,
+                                   const QImage &customBackdrop = {});
+/** Lowercase serialization name ("aurora", "custom", ...) for a backdrop
+ *  style, used in the operation log and the `[background] default` config
+ *  key. */
+[[nodiscard]] QString backgroundStyleName(BackgroundStyle style);
+/** Parses a backdrop style from its lowercase config/JSON name ("aurora",
+ *  "custom", ...). Leaves `style` untouched and returns false when `name`
+ *  doesn't match one. */
+[[nodiscard]] bool backgroundStyleFromName(const QString &name,
+                                           BackgroundStyle &style);
 /** Loads the current Wayland clipboard image. */
 [[nodiscard]] bool loadClipboardImage(QImage &image, QString &error);
 [[nodiscard]] bool copyPngFileToClipboard(const QString &path, QString &error);
@@ -212,8 +224,12 @@ void paintSpotlights(QPainter &painter, const QImage &source,
 void paintDefaultLayer(QPainter &painter, const QImage &redacted,
                        const QRectF &logicalBounds,
                        const QVector<Annotation> &annotations);
+/** `customBackdrop` is the image drawn (cover-fit) for
+ *  `BackgroundStyle::Custom`; a null image there paints nothing, same as
+ *  `BackgroundStyle::None`. */
 void paintCaptureBackground(QPainter &painter, const QRectF &bounds,
-                            BackgroundStyle backgroundStyle);
+                            BackgroundStyle backgroundStyle,
+                            const QImage &customBackdrop = {});
 /**
  * Renders the selection region at `targetSize` for the redaction layer. The
  * result carries no annotations; callers overlay redactions with

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -484,6 +484,8 @@ QString backgroundName(BackgroundStyle style) {
     return QStringLiteral("Lagoon");
   case BackgroundStyle::Violet:
     return QStringLiteral("Violet");
+  case BackgroundStyle::Custom:
+    return QStringLiteral("Custom");
   }
   return {};
 }
@@ -532,11 +534,28 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
   paletteConfig_ = loadPaletteConfig(defaultConfigPath());
   startupTimingMark("palette config loaded");
   customColor_ = paletteConfig_.custom;
+  backgroundConfig_ = loadBackgroundConfig(defaultConfigPath());
+  if (!backgroundConfig_.imagePath.isEmpty())
+    customBackdrop_.load(backgroundConfig_.imagePath);
   if (!log.ops.isEmpty()) {
     ops_ = std::move(log.ops);
     opIndex_ = std::clamp(log.index, 0, static_cast<int>(ops_.size()));
     nextAnnotationId_ = std::max<quint64>(log.nextId, 1);
     nextMarker_ = std::max(log.nextMarker, 1);
+  } else {
+    // A genuinely fresh capture (no restored history): seed the configured
+    // default backdrop as the first undoable operation, same as pressing B
+    // once, so undo/redo and replay need no special case for it.
+    BackgroundStyle defaultStyle = backgroundConfig_.defaultStyle;
+    if (defaultStyle == BackgroundStyle::Custom && customBackdrop_.isNull())
+      defaultStyle = BackgroundStyle::None;
+    if (defaultStyle != BackgroundStyle::None) {
+      Operation op;
+      op.type = Operation::Type::Background;
+      op.background = defaultStyle;
+      ops_.push_back(std::move(op));
+      opIndex_ = ops_.size();
+    }
   }
   setWindowTitle(QStringLiteral("Omasnap"));
   setWindowFlags(Qt::Window | Qt::FramelessWindowHint |
@@ -2391,7 +2410,8 @@ void CaptureEditor::scheduleSnapshot() {
 }
 
 QImage CaptureEditor::renderCurrentOutput() const {
-  return renderCapture(capture_, selection_, annotations_, backgroundStyle_);
+  return renderCapture(capture_, selection_, annotations_, backgroundStyle_,
+                       customBackdrop_);
 }
 
 void CaptureEditor::startSnapshotRender() {
@@ -2460,11 +2480,12 @@ void CaptureEditor::pinSnapshot() {
   const QVector<Annotation> annotations = annotations_;
   const QRectF selection = selection_;
   const BackgroundStyle background = backgroundStyle_;
+  const QImage backdrop = customBackdrop_;
   pinWatcher_.setFuture(QtConcurrent::run(
-      [captureCopy, annotations, selection, background, path] {
+      [captureCopy, annotations, selection, background, backdrop, path] {
         PinResult result;
-        const QImage image =
-            renderCapture(captureCopy, selection, annotations, background);
+        const QImage image = renderCapture(captureCopy, selection, annotations,
+                                           background, backdrop);
         if (image.isNull() ||
             !savePinnedSnapshot(image, path, selection.size().toSize(),
                                 result.error)) {
@@ -2950,15 +2971,17 @@ void CaptureEditor::finish(OutputMode mode) {
   const QRectF selection = selection_;
   const QVector<Annotation> annotations = annotations_;
   const BackgroundStyle background = backgroundStyle_;
+  const QImage backdrop = customBackdrop_;
   const QString appSlug =
       appFilenameSlug(dominantAppClass(capture_.windows, selection_));
   finishWatcher_.setFuture(QtConcurrent::run([captureCopy, selection,
-                                              annotations, background, appSlug,
-                                              mode]() {
+                                              annotations, background, backdrop,
+                                              appSlug, mode]() {
     FinishResult result;
     result.mode = mode;
     const QImage image =
-        renderCapture(captureCopy, selection, annotations, background);
+        renderCapture(captureCopy, selection, annotations, background,
+                     backdrop);
     if (!image.isNull())
       result.thumbnail = image.scaled(kRecentThumbEdge, kRecentThumbEdge,
                                       Qt::KeepAspectRatio,
@@ -3126,8 +3149,11 @@ void CaptureEditor::handleToolbar(const QString &action) {
   } else if (action == QStringLiteral("ocr"))
     runOcr();
   else if (action == QStringLiteral("background")) {
+    // Custom only joins the cycle once its image has actually loaded, so
+    // cycling never lands on a backdrop that paints nothing.
+    const int cycleLength = customBackdrop_.isNull() ? 5 : 6;
     const auto next = static_cast<BackgroundStyle>(
-        (static_cast<int>(backgroundStyle_) + 1) % 5);
+        (static_cast<int>(backgroundStyle_) + 1) % cycleLength);
     setStatus(QStringLiteral("Backdrop: %1 · B cycles")
                   .arg(backgroundName(next)));
     commitBackground(next);
@@ -3474,8 +3500,11 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     pinSnapshot();
     return;
   } else if (event->key() == Qt::Key_B) {
+    // Custom only joins the cycle once its image has actually loaded, so
+    // cycling never lands on a backdrop that paints nothing.
+    const int cycleLength = customBackdrop_.isNull() ? 5 : 6;
     const auto next = static_cast<BackgroundStyle>(
-        (static_cast<int>(backgroundStyle_) + 1) % 5);
+        (static_cast<int>(backgroundStyle_) + 1) % cycleLength);
     setStatus(QStringLiteral("Backdrop: %1 · B cycles")
                   .arg(backgroundName(next)));
     commitBackground(next);
@@ -5367,7 +5396,9 @@ void CaptureEditor::paintEdit(QPainter &painter) {
         QRectF(0, top, width(), std::max<qreal>(1, height() - top - 58)));
   }
   const QRectF image = editImageRect();
-  const bool hasBackground = backgroundStyle_ != BackgroundStyle::None;
+  const bool hasBackground = backgroundStyle_ == BackgroundStyle::Custom
+                                  ? !customBackdrop_.isNull()
+                                  : backgroundStyle_ != BackgroundStyle::None;
   if (hasBackground) {
     const QRectF backing = image.adjusted(-28, -28, 28, 28);
     painter.setPen(Qt::NoPen);
@@ -5385,7 +5416,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
           image.adjusted(-spread, -spread + 7, spread, spread + 7), 12 + spread,
           12 + spread);
     }
-    paintCaptureBackground(painter, backing, backgroundStyle_);
+    paintCaptureBackground(painter, backing, backgroundStyle_, customBackdrop_);
   }
 
   QPainterPath clip;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "background-config.hpp"
 #include "capture.hpp"
 #include "cut.hpp"
 #include "overlay-chrome.hpp"
@@ -573,6 +574,12 @@ private:
   qreal cutDragOriginOffset_ = 0.0;
   bool windowMode_ = false;
   BackgroundStyle backgroundStyle_ = BackgroundStyle::None;
+  /** `[background]` config: custom image path and the style a fresh capture
+   *  starts with. Loaded once in the constructor. */
+  BackgroundConfig backgroundConfig_;
+  /** Loaded from `backgroundConfig_.imagePath`; null when unset or the file
+   *  failed to load, in which case `BackgroundStyle::Custom` is unavailable. */
+  QImage customBackdrop_;
   bool busy_ = false;
   bool colorPaletteOpen_ = false;
   bool customColorPickerOpen_ = false;


### PR DESCRIPTION
## Summary
- Extends the backdrop cycle (`B`, or the toolbar's backdrop button) with a sixth "Custom" style backed by a user-supplied image, and lets a freshly opened capture start with a chosen style instead of always starting bare.
- Both are configured through the same INI file the color palette and output settings already use - no settings UI, per project convention:

  ```ini
  [background]
  image = ~/Pictures/backdrops/desk.jpg
  default = custom
  ```

- `image` is drawn cover-fit (scaled to fill, center-cropped) behind the capture, the same way the four built-in gradients are. Custom only joins the cycle once the file actually loads, so cycling never lands on a backdrop that paints nothing; `default = custom` with a missing or unreadable image silently falls back to no backdrop instead of starting broken.
- `default` is seeded as the first entry in a fresh capture's undo history, so Ctrl+Z behaves exactly like it does for any other backdrop change - no special-casing needed elsewhere.
- New `src/background-config.{cpp,hpp}` mirror `palette-config`'s load-only-INI pattern. `BackgroundStyle::Custom` is threaded through `renderCapture`/`paintCaptureBackground` behind a default `QImage` argument, so call sites that only ever want the built-in gradients (OCR, quick fullscreen output) needed no changes.

## Test plan
- [x] `make build` - clean, no new warnings
- [x] `make smoke` - reaches the same point as unmodified `main` in my sandbox (a pre-existing `libpng error: Write Error` in the offscreen screencopy path unrelated to this change, confirmed via `git stash` against `main`)
- [ ] Visual check in a real Hyprland session with a real `[background]` config - I don't have one in my environment; would appreciate a maintainer glance before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)