### PR TITLE
Allow annotations to start outside the canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
 - Window capture is a crop of the focused-monitor frame. Overlapping windows stay
   visible; there is no second clean-window recapture.
 - Select/move/resize layers, mouse-wheel scaling, and eight external recropping handles.
-- Draw, type, resize, or carry a layer past the screenshot edge to grow the canvas.
+- Start arrows, shapes, strokes, markers, spotlights, or text in the unused
+  fullscreen workspace around a screenshot, or resize and carry an existing
+  layer past its edge, to grow the canvas. Source-based tools (redact, cut,
+  OCR, and eyedropper) stay on the screenshot.
   Framed growth is the default; `G` cycles to tight Overflow growth (only the
   sides needed by annotations, with no frame), then Image (the original canvas
   size, clipping every outside annotation). `Shift+G` cycles backward without

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -366,6 +366,34 @@ bool supportsCenteredCreation(CaptureEditor::Tool tool) {
          tool == CaptureEditor::Tool::Spotlight;
 }
 
+bool supportsOffCanvasCreation(CaptureEditor::Tool tool) {
+  switch (tool) {
+  case CaptureEditor::Tool::Arrow:
+  case CaptureEditor::Tool::Line:
+  case CaptureEditor::Tool::Freehand:
+  case CaptureEditor::Tool::Highlighter:
+  case CaptureEditor::Tool::Spotlight:
+  case CaptureEditor::Tool::Marker:
+  case CaptureEditor::Tool::Rectangle:
+  case CaptureEditor::Tool::Ellipse:
+  case CaptureEditor::Tool::Text:
+    return true;
+  case CaptureEditor::Tool::Select:
+  case CaptureEditor::Tool::Redact:
+  case CaptureEditor::Tool::Cut:
+  case CaptureEditor::Tool::Ocr:
+  case CaptureEditor::Tool::Eyedropper:
+    return false;
+  }
+  return false;
+}
+
+bool requiresSourcePixels(CaptureEditor::Tool tool) {
+  return tool == CaptureEditor::Tool::Redact ||
+         tool == CaptureEditor::Tool::Cut || tool == CaptureEditor::Tool::Ocr ||
+         tool == CaptureEditor::Tool::Eyedropper;
+}
+
 QString toolAction(CaptureEditor::Tool tool) {
   switch (tool) {
   case CaptureEditor::Tool::Select:
@@ -1842,6 +1870,31 @@ QRectF CaptureEditor::editImageRect() const {
       .translated(viewOffset_);
 }
 
+QRectF CaptureEditor::annotationWorkspaceRect() const {
+  const qreal top = imageTopMargin();
+  return {0, top, static_cast<qreal>(width()),
+          std::max<qreal>(0.0, height() - top - 58.0)};
+}
+
+bool CaptureEditor::canStartAnnotationAt(const QPointF &position) const {
+  if (requiresSourcePixels(tool_))
+    return sourceFrameWidgetRect().contains(position);
+  if (editImageRect().contains(position))
+    return true;
+  if (canvasBoundaryMode_ == CanvasBoundaryMode::Image ||
+      !supportsOffCanvasCreation(tool_) ||
+      !annotationWorkspaceRect().contains(position))
+    return false;
+  // Popovers overlap the content band. Their buttons are handled before the
+  // workspace, while their padding must remain chrome rather than canvas.
+  if ((colorPaletteOpen_ && colorPaletteRect().contains(position)) ||
+      (customColorPickerOpen_ && customColorPanelRect().contains(position)) ||
+      (shapeMenuOpen_ && shapeMenuRect().contains(position)) ||
+      (textSizeMenuOpen_ && textSizePanelRect().contains(position)))
+    return false;
+  return true;
+}
+
 qreal CaptureEditor::maxViewZoom() const {
   const QRectF base = baseImageRect();
   if (base.isEmpty() || canvasRect_.width() <= 0)
@@ -1979,7 +2032,10 @@ CaptureEditor::toUnclampedAnnotationPoint(const QPointF &position) const {
 QPointF CaptureEditor::markerPlacementPoint(const QPointF &position) const {
   constexpr qreal kPointerLead = 9.0;
   const qreal lead = kPointerLead / std::max<qreal>(editScale(), 0.001);
-  return toAnnotationPoint(position) - QPointF(lead, lead);
+  const QPointF point = editImageRect().contains(position)
+                            ? toAnnotationPoint(position)
+                            : toUnclampedAnnotationPoint(position);
+  return point - QPointF(lead, lead);
 }
 
 bool CaptureEditor::selectedLayerAcceptsPoint(const QPointF &point) const {
@@ -4639,14 +4695,23 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
     }
   }
   // A layer that ran off the capture keeps its handles and body live outside
-  // the canvas, so it can be resized or dragged back in instead of being
-  // stranded. Anything else outside the canvas stays inert.
+  // the canvas. In the fullscreen content band, paint-producing tools may
+  // also begin in the unused surround; committing derives a larger canvas
+  // from their actual painted bounds.
   const bool insideImage = editImageRect().contains(cursor_);
   const QPointF point = insideImage ? toAnnotationPoint(cursor_)
                                     : toUnclampedAnnotationPoint(cursor_);
-  if (!insideImage &&
-      (tool_ != Tool::Select || !selectedLayerAcceptsPoint(point)))
-    return;
+  if (tool_ == Tool::Select) {
+    if (!insideImage && !selectedLayerAcceptsPoint(point))
+      return;
+  } else if (!canStartAnnotationAt(cursor_)) {
+    // Drawing tools may still grab an existing layer edge in the surround;
+    // only a new source-dependent operation is forbidden there.
+    const Interaction handle = selectedHandleAt(point);
+    const int edge = annotationEdgeAt(point);
+    if (handle == Interaction::None && !toolGrabsLayer(edge))
+      return;
+  }
   if (tool_ == Tool::Eyedropper) {
     if (!sourceFrameWidgetRect().contains(cursor_))
       return;
@@ -5381,6 +5446,9 @@ void CaptureEditor::updatePointerCursor() {
     clearHighlighterPreview();
     // An I-beam over committed text reads as edit, although the click moves it.
     applyCursor(Qt::SizeAllCursor);
+  } else if (!dragging_ && !canStartAnnotationAt(cursor_)) {
+    clearHighlighterPreview();
+    applyCursor(Qt::ArrowCursor);
   } else if (tool_ == Tool::Marker) {
     clearHighlighterPreview();
     applyCursor(Qt::PointingHandCursor);
@@ -5395,8 +5463,8 @@ void CaptureEditor::updatePointerCursor() {
       if (dragging_) {
         highlighterPreview_ = highlighterLock_;
         highlighterPreviewPoint_.reset();
-      } else if (editImageRect().contains(cursor_)) {
-        scheduleHighlighterProbe(toAnnotationPoint(cursor_));
+      } else if (canStartAnnotationAt(cursor_)) {
+        scheduleHighlighterProbe(toUnclampedAnnotationPoint(cursor_));
       } else {
         clearHighlighterPreview();
       }
@@ -6222,6 +6290,12 @@ void CaptureEditor::paintEdit(QPainter &painter) {
 
   QImage defaultLayerSource = redactionLayer;
   QRectF defaultLayerBounds(QPointF(), selection_.size());
+  const bool markerPreview = tool_ == Tool::Marker && !dragging_ &&
+                             canStartAnnotationAt(cursor_) &&
+                             !pointerGrabsLayer();
+  const bool markerPreviewOutsideCanvas =
+      markerPreview && !image.contains(cursor_);
+  const bool liveOutsidePreview = dragging_ || markerPreviewOutsideCanvas;
 
   painter.save();
   painter.translate(sourceImage.topLeft());
@@ -6229,7 +6303,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   painter.save();
   // While a layer is being carried, let it remain visible over the surround;
   // the background settles to its final integer bounds once on release.
-  if (!dragging_)
+  if (!liveOutsidePreview)
     painter.setClipRect(canvasRect_);
   QVector<Annotation> defaultAnnotations;
   defaultAnnotations.reserve(annotations_.size() + 1);
@@ -6279,8 +6353,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
                        ? highlighterLock_->annotationSize
                        : annotationSize_;
     defaultAnnotations.push_back(std::move(preview));
-  } else if (tool_ == Tool::Marker && image.contains(cursor_) && !dragging_ &&
-             !pointerGrabsLayer()) {
+  } else if (markerPreview) {
     // The ghost counter shows where the next one would land, so it belongs
     // only where the press would actually place one: over another counter the
     // press moves that counter instead.
@@ -6294,7 +6367,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     defaultAnnotations.push_back(std::move(preview));
   }
   QRectF previewClip = canvasRect_;
-  if (dragging_ && canvasBoundaryMode_ != CanvasBoundaryMode::Framed) {
+  if (liveOutsidePreview && canvasBoundaryMode_ != CanvasBoundaryMode::Framed) {
     previewClip = captureCanvasRect(selection_.size(), defaultAnnotations,
                                     canvasBoundaryMode_);
   }
@@ -6319,7 +6392,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
   // Framed mode shows the complete layer while it is being carried and
   // settles the background on release. Overflow and Image preview their final
   // canvas bounds live.
-  if (!dragging_ || canvasBoundaryMode_ != CanvasBoundaryMode::Framed)
+  if (!liveOutsidePreview || canvasBoundaryMode_ != CanvasBoundaryMode::Framed)
     painter.setClipRect(previewClip, Qt::IntersectClip);
   const bool hasSpotlight = std::any_of(
       defaultAnnotations.cbegin(), defaultAnnotations.cend(),

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1877,13 +1877,7 @@ QRectF CaptureEditor::annotationWorkspaceRect() const {
 }
 
 bool CaptureEditor::canStartAnnotationAt(const QPointF &position) const {
-  if (requiresSourcePixels(tool_))
-    return sourceFrameWidgetRect().contains(position);
-  if (editImageRect().contains(position))
-    return true;
-  if (canvasBoundaryMode_ == CanvasBoundaryMode::Image ||
-      !supportsOffCanvasCreation(tool_) ||
-      !annotationWorkspaceRect().contains(position))
+  if (!annotationWorkspaceRect().contains(position))
     return false;
   // Popovers overlap the content band. Their buttons are handled before the
   // workspace, while their padding must remain chrome rather than canvas.
@@ -1892,7 +1886,12 @@ bool CaptureEditor::canStartAnnotationAt(const QPointF &position) const {
       (shapeMenuOpen_ && shapeMenuRect().contains(position)) ||
       (textSizeMenuOpen_ && textSizePanelRect().contains(position)))
     return false;
-  return true;
+  if (requiresSourcePixels(tool_))
+    return sourceFrameWidgetRect().contains(position);
+  if (editImageRect().contains(position))
+    return true;
+  return canvasBoundaryMode_ != CanvasBoundaryMode::Image &&
+         supportsOffCanvasCreation(tool_);
 }
 
 qreal CaptureEditor::maxViewZoom() const {
@@ -4159,7 +4158,7 @@ QRegion CaptureEditor::pointerMotionRegion(const QPointF &point) const {
            QRegion(widgetBounds);
   };
 
-  if (tool_ == Tool::Marker && !dragging_ && editImageRect().contains(point) &&
+  if (tool_ == Tool::Marker && !dragging_ && canStartAnnotationAt(point) &&
       !pointerGrabsLayer()) {
     Annotation marker;
     marker.kind = Annotation::Kind::Marker;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -3151,8 +3151,13 @@ void CaptureEditor::ensureTextEditor() {
     const int sidePadding =
         textEditPill_ ? qRound(std::max(4.0, metrics.height() * 0.18)) : 0;
     const int desiredWidth = std::max(48, widestLine + sidePadding * 2);
+    const bool newOffCanvasText = editingAnnotation_ < 0 &&
+        canvasBoundaryMode_ != CanvasBoundaryMode::Image &&
+        !canvasRect_.contains(textPoint_);
+    const qreal rightEdge = newOffCanvasText ? annotationWorkspaceRect().right()
+                                             : editImageRect().right();
     const int availableWidth =
-        std::max(48, qRound(editImageRect().right() - textEditor_->x()));
+        std::max(48, qRound(rightEdge - textEditor_->x()));
     const int lineCount = std::max(1, static_cast<int>(lines.size()));
     const int desiredHeight =
         lineCount * metrics.lineSpacing() + metrics.descent() + 4;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2071,16 +2071,17 @@ QPointF CaptureEditor::sourcePoint(const QPointF &logicalPoint) const {
 void CaptureEditor::scheduleHighlighterProbe(
     const QPointF &annotationPoint) {
   pendingHighlighterProbePoint_ = annotationPoint;
-  if (highlighterProbeWatcher_.isRunning())
-    return;
   if (capture_.source.isNull() || capture_.previewSize.isEmpty() ||
       !QRectF(QPointF(), selection_.size()).contains(annotationPoint)) {
+    ++highlighterProbeGeneration_;
     pendingHighlighterProbePoint_.reset();
     highlighterPreview_.reset();
     highlighterPreviewPoint_.reset();
     return;
   }
 
+  if (highlighterProbeWatcher_.isRunning())
+    return;
   const QPointF probePoint = *pendingHighlighterProbePoint_;
   pendingHighlighterProbePoint_.reset();
   const quint64 generation = ++highlighterProbeGeneration_;
@@ -2117,7 +2118,8 @@ void CaptureEditor::completeHighlighterProbe() {
   const HighlighterProbeResult result = highlighterProbeWatcher_.result();
   if (result.generation == highlighterProbeGeneration_ &&
       phase_ == Phase::Edit && tool_ == Tool::Highlighter &&
-      highlighterMode_ == HighlighterMode::Snap && !dragging_) {
+      highlighterMode_ == HighlighterMode::Snap && !dragging_ &&
+      sourceFrameWidgetRect().contains(cursor_)) {
     const QRegion oldVisual = pointerMotionRegion(cursor_);
     highlighterPreview_ = result.lock;
     highlighterPreviewPoint_ = result.annotationPoint;
@@ -4928,7 +4930,7 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
       QPointF strokeStart = point;
       if (tool_ == Tool::Highlighter &&
           highlighterMode_ == HighlighterMode::Snap && highlighterPreview_ &&
-          highlighterPreviewPoint_ &&
+          highlighterPreviewPoint_ && sourceFrameWidgetRect().contains(cursor_) &&
           QLineF(*highlighterPreviewPoint_, point).length() <= 24.0)
         highlighterLock_ = highlighterPreview_;
       if (highlighterLock_)
@@ -5462,7 +5464,7 @@ void CaptureEditor::updatePointerCursor() {
       if (dragging_) {
         highlighterPreview_ = highlighterLock_;
         highlighterPreviewPoint_.reset();
-      } else if (canStartAnnotationAt(cursor_)) {
+      } else if (sourceFrameWidgetRect().contains(cursor_)) {
         scheduleHighlighterProbe(toUnclampedAnnotationPoint(cursor_));
       } else {
         clearHighlighterPreview();

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -416,6 +416,13 @@ private:
   /// baseImageRect transformed by the current view zoom and pan (content and
   /// annotations map through this). Equals baseImageRect at zoom 1.
   [[nodiscard]] QRectF editImageRect() const;
+  /// Fullscreen content band where a canvas-growing tool may begin outside
+  /// the current canvas, excluding the toolbar and bottom status chrome.
+  [[nodiscard]] QRectF annotationWorkspaceRect() const;
+  /// Whether the armed tool may start at this widget position: source-based
+  /// tools stay on the screenshot, while paint-producing tools may use the
+  /// canvas and its surrounding workspace.
+  [[nodiscard]] bool canStartAnnotationAt(const QPointF &position) const;
   /// The unmodified screenshot's frame inside the possibly-grown canvas.
   [[nodiscard]] QRectF sourceFrameWidgetRect() const;
   [[nodiscard]] qreal editScale() const;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4063,6 +4063,218 @@ bool runCanvasBoundaryModeSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+/** Fullscreen edit chrome is a workspace around the current canvas: a layer
+ *  may begin there and grow the document, while source tools, chrome, and the
+ *  strict Image boundary remain inert. */
+bool runOffCanvasCreationSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 400, 300};
+  capture.monitor.pixelSize = {400, 300};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(400, 300, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#182030")));
+  capture.previewSize = capture.source.size();
+
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::Fullscreen);
+  editor.setSuppressSnapshots(true);
+  editor.resize(1200, 700);
+  editor.show();
+  application.processEvents();
+
+  const QRectF sourceCanvas(QPointF(), capture.previewSize);
+  const QRectF initialImage = editor.editImageRectForTest();
+  const QPoint outside(qRound(initialImage.left() - 180.0),
+                       qRound(initialImage.center().y()));
+  const QPoint inside(qRound(initialImage.left() + 120.0), outside.y());
+  if (outside.x() < 1 || initialImage.contains(outside) ||
+      !initialImage.contains(inside)) {
+    error = QStringLiteral("Off-canvas fixture had no fullscreen workspace");
+    return false;
+  }
+  const auto drag = [&](const QPoint &from, const QPoint &to) {
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::NoModifier, from);
+    QTest::mouseMove(&editor, to, 20);
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::NoModifier, to);
+    application.processEvents();
+  };
+
+  // The start is in unused fullscreen space and the head is over the source.
+  QTest::keyClick(&editor, Qt::Key_A);
+  QTest::mouseMove(&editor, outside, 20);
+  application.processEvents();
+  if (editor.cursor().shape() != Qt::CrossCursor) {
+    error = QStringLiteral("Arrow did not advertise the off-canvas workspace");
+    return false;
+  }
+  drag(outside, inside);
+  if (editor.currentAnnotationsForTest().size() != 1 ||
+      editor.currentAnnotationsForTest().constFirst().kind !=
+          Annotation::Kind::Arrow ||
+      editor.currentAnnotationsForTest().constFirst().start.x() >= -100.0 ||
+      editor.currentAnnotationsForTest().constFirst().end.x() <= 0.0 ||
+      editor.currentCanvasForTest().left() >= 0.0 ||
+      editor.operationLog().constLast().type != Operation::Type::Annotate) {
+    error =
+        QStringLiteral("Arrow could not begin outside and point into canvas");
+    return false;
+  }
+  const Annotation arrow = editor.currentAnnotationsForTest().constFirst();
+
+  // Once the arrow grows the canvas, its outer tail is a normal place to add
+  // a label. This is the intended callout workflow, not a special arrow/text
+  // relationship: both remain ordinary undoable vector operations.
+  QTest::keyClick(&editor, Qt::Key_T);
+  const QPointF labelPoint = arrow.start + QPointF(8, -34);
+  QTest::mouseClick(
+      &editor, Qt::LeftButton, Qt::NoModifier,
+      editor.annotationPointToWidgetForTest(labelPoint).toPoint());
+  application.processEvents();
+  auto *textEditor =
+      qobject_cast<QPlainTextEdit *>(QApplication::focusWidget());
+  if (textEditor == nullptr) {
+    error = QStringLiteral("Arrow tail did not accept a text annotation");
+    return false;
+  }
+  QTest::keyClicks(textEditor, QStringLiteral("Outside note"));
+  QTest::keyClick(textEditor, Qt::Key_Return, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentAnnotationsForTest().size() != 2 ||
+      editor.currentAnnotationsForTest().constLast().kind !=
+          Annotation::Kind::Text ||
+      annotationTextBounds(editor.currentAnnotationsForTest().constLast())
+              .left() >= 0.0 ||
+      editor.currentCanvasForTest() !=
+          captureCanvasRect(sourceCanvas.size(),
+                            editor.currentAnnotationsForTest()) ||
+      editor.renderCurrentOutput().size() !=
+          editor.currentCanvasForTest().size().toSize()) {
+    error = QStringLiteral("Off-canvas arrow label did not enter the output");
+    return false;
+  }
+
+  // The grown strip is canvas for vector paint, but it is not screenshot
+  // data. Redaction cannot begin there even after another layer made it part
+  // of the document.
+  QTest::keyClick(&editor, Qt::Key_D);
+  const QPoint sourceOutside = editor
+                                   .annotationPointToWidgetForTest(QPointF(
+                                       arrow.start.x(), arrow.start.y() + 80.0))
+                                   .toPoint();
+  const QPoint sourceInside =
+      editor
+          .annotationPointToWidgetForTest(QPointF(80.0, arrow.start.y() + 80.0))
+          .toPoint();
+  drag(sourceOutside, sourceInside);
+  if (editor.currentAnnotationsForTest().size() != 2) {
+    error = QStringLiteral("Redaction began in a grown background strip");
+    return false;
+  }
+
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+  if (!editor.currentAnnotationsForTest().isEmpty() ||
+      editor.currentCanvasForTest() != sourceCanvas) {
+    error = QStringLiteral("Undo did not contract the off-canvas workflow");
+    return false;
+  }
+
+  // Press-to-place tools need an unclamped point too; otherwise every marker
+  // stamped in the surround would pile up on the old canvas edge.
+  QTest::keyClick(&editor, Qt::Key_C);
+  QTest::mouseMove(&editor, outside + QPoint(7, 0), 20);
+  QTest::mouseMove(&editor, outside, 20);
+  application.processEvents();
+  const QImage markerHover = editor.grab().toImage();
+  bool markerGhost = false;
+  for (int y = std::max(0, outside.y() - 30);
+       y <= std::min(markerHover.height() - 1, outside.y() + 20) &&
+       !markerGhost;
+       ++y) {
+    for (int x = std::max(0, outside.x() - 30);
+         x <= std::min(markerHover.width() - 1, outside.x() + 20); ++x) {
+      const QColor pixel = markerHover.pixelColor(x, y);
+      if (pixel.red() > 120 && pixel.red() > pixel.green() + 40 &&
+          pixel.red() > pixel.blue() + 20) {
+        markerGhost = true;
+        break;
+      }
+    }
+  }
+  if (editor.cursor().shape() != Qt::PointingHandCursor || !markerGhost) {
+    error = QStringLiteral("Off-canvas marker preview was not visible");
+    return false;
+  }
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, outside);
+  application.processEvents();
+  if (editor.currentAnnotationsForTest().size() != 1 ||
+      editor.currentAnnotationsForTest().constFirst().kind !=
+          Annotation::Kind::Marker ||
+      editor.currentAnnotationsForTest().constFirst().start.x() >= -100.0 ||
+      editor.currentCanvasForTest().left() >= 0.0) {
+    error = QStringLiteral("Marker placement clamped to the old canvas edge");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+
+  // Text can also be the first layer that grows a side, independently of an
+  // arrow having already made that position part of the canvas.
+  QTest::keyClick(&editor, Qt::Key_T);
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, outside);
+  application.processEvents();
+  textEditor = qobject_cast<QPlainTextEdit *>(QApplication::focusWidget());
+  if (textEditor == nullptr) {
+    error = QStringLiteral("Text could not begin outside the current canvas");
+    return false;
+  }
+  QTest::keyClicks(textEditor, QStringLiteral("Standalone note"));
+  QTest::keyClick(textEditor, Qt::Key_Return, Qt::ControlModifier);
+  application.processEvents();
+  if (editor.currentAnnotationsForTest().size() != 1 ||
+      editor.currentAnnotationsForTest().constFirst().kind !=
+          Annotation::Kind::Text ||
+      annotationTextBounds(editor.currentAnnotationsForTest().constFirst())
+              .left() >= 0.0 ||
+      editor.currentCanvasForTest().left() >= 0.0) {
+    error = QStringLiteral("Standalone text did not grow the canvas");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+
+  // Screenshot-derived operations have nothing meaningful to do in the
+  // surround, and the narrow band occupied by editor chrome is never canvas.
+  QTest::keyClick(&editor, Qt::Key_D);
+  drag(outside, inside);
+  QTest::keyClick(&editor, Qt::Key_A);
+  const QRectF arrowButton =
+      editor.toolbarButtonRectForTest(QStringLiteral("tool-arrow"));
+  const QPoint chromeGap(outside.x(), qRound(arrowButton.bottom() + 2.0));
+  drag(chromeGap, inside);
+  if (!editor.currentAnnotationsForTest().isEmpty()) {
+    error = QStringLiteral("Source tool or editor chrome grew the canvas");
+    return false;
+  }
+
+  // Image is the explicit strict boundary: starting outside it must stay a
+  // no-op even for a tool that grows Framed and Overflow canvases.
+  QTest::keyClick(&editor, Qt::Key_G, Qt::ShiftModifier);
+  application.processEvents();
+  if (editor.currentCanvasBoundaryForTest() != CanvasBoundaryMode::Image) {
+    error = QStringLiteral("Off-canvas fixture did not enter Image boundary");
+    return false;
+  }
+  drag(outside, inside);
+  if (!editor.currentAnnotationsForTest().isEmpty() ||
+      editor.currentCanvasForTest() != sourceCanvas) {
+    error = QStringLiteral("Image boundary accepted an off-canvas start");
+    return false;
+  }
+  return true;
+}
+
 /** Runs the interaction and rendering smoke checks. */
 bool runSelectOutsideCanvasSmoke(QApplication &application, QString &error) {
   CaptureData capture;
@@ -7747,6 +7959,10 @@ int main(int argc, char **argv) {
   if (!runCanvasBoundaryModeSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 202;
+  }
+  if (!runOffCanvasCreationSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 203;
   }
   if (!runSelectOutsideCanvasSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -828,6 +828,56 @@ bool runTextAwareHighlighterEditorCheck(QApplication &application,
   paintTextLikeBand(capture.source, textBand, sourceScale,
                     QColor(QStringLiteral("#d8dbe2")));
 
+  {
+    CaptureData edgeCapture = capture;
+    edgeCapture.source = capture.source.copy();
+    paintTextLikeBand(edgeCapture.source, QRectF(2, 96, 149, 16), sourceScale,
+                      QColor(QStringLiteral("#d8dbe2")));
+    CaptureEditor edge(edgeCapture, CaptureEditor::CaptureMode::Fullscreen);
+    edge.setSuppressSnapshots(true);
+    edge.resize(700, 500);
+    edge.show();
+    application.processEvents();
+    QTest::keyClick(&edge, Qt::Key_H);
+    const auto move = [&](const QPointF &point) {
+      const QPointF at = edge.annotationPointToWidgetForTest(point);
+      QMouseEvent event(QEvent::MouseMove, at, edge.mapToGlobal(at.toPoint()),
+                         Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+      QApplication::sendEvent(&edge, &event);
+    };
+    move({5, 104});
+    for (int attempt = 0; attempt < 200 && edge.highlighterPreviewRectForTest().isEmpty(); ++attempt)
+      QTest::qWait(5);
+    if (edge.highlighterPreviewRectForTest().isEmpty()) {
+      error = QStringLiteral("Edge highlighter fixture did not find its text band");
+      return false;
+    }
+    // Queue a source probe, then leave before its finished signal can apply.
+    move({6, 105});
+    move({-5, 110});
+    if (!edge.highlighterPreviewRectForTest().isEmpty() ||
+        edge.cursor().shape() != Qt::CrossCursor) {
+      error = QStringLiteral("Off-canvas highlighter retained a source preview");
+      return false;
+    }
+    QTest::qWait(30);
+    if (!edge.highlighterPreviewRectForTest().isEmpty()) {
+      error = QStringLiteral("An old probe restored the off-canvas preview");
+      return false;
+    }
+    const QPoint from = edge.annotationPointToWidgetForTest({-5, 110}).toPoint();
+    const QPoint to = edge.annotationPointToWidgetForTest({50, 140}).toPoint();
+    QTest::mousePress(&edge, Qt::LeftButton, Qt::NoModifier, from);
+    QTest::mouseMove(&edge, to, 10);
+    QTest::mouseRelease(&edge, Qt::LeftButton, Qt::NoModifier, to);
+    if (edge.currentAnnotationsForTest().isEmpty() ||
+        std::abs(edge.currentAnnotationsForTest().constFirst().points.first().y() - 110) > 1 ||
+        std::abs(edge.currentAnnotationsForTest().constFirst().points.last().y() - 140) > 1) {
+      error = QStringLiteral("Off-canvas highlighter locked to a stale text row");
+      return false;
+    }
+  }
+
   CaptureEditor editor(capture, CaptureEditor::CaptureMode::Fullscreen);
   editor.setSuppressSnapshots(true);
   // baseImageRect is exactly 400x240 at (30,135), making test gestures map

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4272,6 +4272,26 @@ bool runOffCanvasCreationSmoke(QApplication &application, QString &error) {
     error = QStringLiteral("Image boundary accepted an off-canvas start");
     return false;
   }
+  // A zoomed image may extend underneath chrome, but those pixels must
+  // never become actionable annotation workspace.
+  for (int i = 0; i < 10; ++i) {
+    QWheelEvent zoom(QPointF(inside), editor.mapToGlobal(inside), QPoint(),
+                     QPoint(0, 120), Qt::NoButton, Qt::ControlModifier,
+                     Qt::NoScrollPhase, false);
+    QApplication::sendEvent(&editor, &zoom);
+  }
+  const QPoint underChrome(inside.x(), editor.height() - 2);
+  if (!editor.editImageRectForTest().contains(underChrome)) {
+    error = QStringLiteral("Zoom fixture did not extend under editor chrome");
+    return false;
+  }
+  drag(underChrome, inside);
+  if (!editor.currentAnnotationsForTest().isEmpty()) {
+    error = QStringLiteral("Zoomed image accepted an annotation under chrome");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_0, Qt::ControlModifier);
+
   return true;
 }
 

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -4294,6 +4294,29 @@ bool runOffCanvasCreationSmoke(QApplication &application, QString &error) {
   QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
   application.processEvents();
 
+  const QPoint rightOutside(qRound(initialImage.right() + 40), outside.y());
+  QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier, rightOutside);
+  textEditor = qobject_cast<QPlainTextEdit *>(QApplication::focusWidget());
+  if (!textEditor) {
+    error = QStringLiteral("Right-side workspace did not start a text draft");
+    return false;
+  }
+  QTest::keyClicks(textEditor, QStringLiteral("Right-side note"));
+  application.processEvents();
+  if (textEditor->width() <= 150 ||
+      textEditor->horizontalScrollBar()->maximum() != 0) {
+    error = QStringLiteral("Right-side off-canvas draft was clipped while typing");
+    return false;
+  }
+  QTest::keyClick(textEditor, Qt::Key_Return, Qt::ControlModifier);
+  if (editor.currentAnnotationsForTest().size() != 1 ||
+      editor.currentCanvasForTest().right() <= sourceCanvas.right()) {
+    error = QStringLiteral("Right-side text did not grow the canvas");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Z, Qt::ControlModifier);
+  application.processEvents();
+
   // Screenshot-derived operations have nothing meaningful to do in the
   // surround, and the narrow band occupied by editor chrome is never canvas.
   QTest::keyClick(&editor, Qt::Key_D);


### PR DESCRIPTION
## Summary

- treat unused fullscreen edit space as an annotation workspace for arrows, lines, strokes, shapes, markers, spotlights, and text
- grow the canvas from committed annotation bounds while keeping redact, cut, OCR, and eyedropper limited to source pixels
- preserve strict Image boundary behavior, off-canvas previews, and ordinary operation-log undo/redo

## Test plan

- `make check`
- smoke coverage for arrow-to-canvas callouts, labels at the outer endpoint, marker preview/placement, source-tool rejection, undo contraction, and Image mode