### PR TITLE
feat(capture): keep the region when switching between modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,10 @@ Tabs across the top of the overlay switch the capture kind: **Region**,
 **Window**, **Scrolling Region**, **Fullscreen**. All four are modes of the
 same overlay. Scrolling Region selects exactly like Region; once the region is
 drawn, the page inside it goes live and the scroll controls appear in place.
+Region and Scrolling Region frame the same rectangle, so switching between the
+two keeps it: the frame drawn for a scrolling capture is captured as a region,
+and a region just captured frames the scroll panel. Window and Fullscreen pick
+an area of their own, so switching to either starts over.
 The tabs stay up in the editor too: a tab there drops the edit and goes back to
 capturing in that mode, and a small **Scroll capture** button under the image
 turns the drawn region into a scrolling capture. The keys below do the same

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -5184,8 +5184,15 @@ int CaptureEditor::selectTabAt(const QPointF &position) const {
 }
 
 void CaptureEditor::activateSelectTab(SelectTab tab) {
-  if (scrollPanel_)
+  // A frame drawn for a scrolling capture is the same rectangle a region
+  // capture wants, so it comes along to Region rather than being drawn a
+  // second time. Window and Fullscreen pick an area of their own, so there it
+  // is dropped.
+  QRect scrolled;
+  if (scrollPanel_) {
+    scrolled = scrollPanel_->region();
     endScrollCapture();
+  }
   const bool fromEdit = phase_ == Phase::Edit;
   const QRect edited = selection_.toRect();
   if (fromEdit)
@@ -5194,6 +5201,10 @@ void CaptureEditor::activateSelectTab(SelectTab tab) {
   case SelectTab::Region:
     setScrollMode(false);
     setWindowMode(false);
+    if (!scrolled.isEmpty())
+      commitRegion(QRectF(scrolled),
+                   QStringLiteral("Area selected · Select moves layers · wheel "
+                                  "zooms · outer handles crop"));
     break;
   case SelectTab::Scroll:
     setScrollMode(true);

--- a/src/scroll-capture.hpp
+++ b/src/scroll-capture.hpp
@@ -95,6 +95,10 @@ public:
   /// exclusive again) and hides. Safe to call from inside one of this
   /// panel's own signals; the destructor calls it too.
   void release();
+  /// The frame as it stands, in logical surface pixels. Empty until one has
+  /// been drawn. The editor reads it when another tab is picked, so the
+  /// rectangle carries across instead of having to be drawn again.
+  [[nodiscard]] QRect region() const { return region_; }
 
 signals:
   /// The capture is done: `image` is the stitched result.

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7089,6 +7089,22 @@ bool runSelectTabsSmoke(QApplication &application, QString &error) {
                              "panel up");
       return false;
     }
+    // Region and Scrolling Region frame the same rectangle, so switching
+    // between them keeps it: the frame drawn for the scroll panel is the
+    // region that gets captured.
+    if (!clickOn(scrollEditor, QStringLiteral("REGION")) ||
+        !scrollEditor.editingForTest() ||
+        scrollEditor.renderCurrentOutput().size() != QSize(400, 300)) {
+      error = QStringLiteral("Region tab did not carry the scroll frame over");
+      return false;
+    }
+    // And back again: the region just captured frames the scroll panel.
+    if (!clickOn(scrollEditor, QStringLiteral("SCROLLING REGION")) ||
+        !scrollEditor.scrollPanelActiveForTest()) {
+      error = QStringLiteral("Scrolling Region tab did not carry the region "
+                             "over");
+      return false;
+    }
     QTest::keyClick(QApplication::focusWidget(), Qt::Key_Escape);
     application.processEvents();
     if (scrollEditor.scrollPanelActiveForTest() ||


### PR DESCRIPTION
Region and Scrolling Region frame the same rectangle, so drawing one and then
picking the other tab dropped a selection the new mode was about to ask for
again. The frame the scroll panel holds now carries over to Region and is
captured on the spot; the other direction already carried the region across.
Window and Fullscreen still start over, since each picks an area of its own.

Covered by an addition to runSelectTabsSmoke: the suite fails without the
change (exit 127) and passes with it. `make check` is green.


https://github.com/user-attachments/assets/0bac9b0f-adbc-45fe-a203-d5cc702ba670

