### PR TITLE
perf: bypass the GTK platform theme at startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,11 @@ change that touches the principle, not just this summary.
 - **Omarchy aesthetics.** `omarchy-notification-send` when available,
   `OMASNAP_OCR_LANGS`/`OMARCHY_OCR_LANGS` fallback for OCR languages,
   minimal vector-drawn icons (no icon-theme dependency), the bundled Neucha
-  font.
+  font. Chrome text uses `chromeFont()`/`chromeMonoFont()`
+  (`src/overlay-chrome.cpp`), pinned in code, and `main()` installs
+  `chromeDefaultFont()` as the application font; the Qt platform theme is
+  deliberately disabled at startup (see [docs/dependencies.md](docs/dependencies.md)),
+  so never reach for `QFontDatabase::systemFont`, `QStyle`, or `palette()`.
 
 ## Repository layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,11 @@ change that touches the principle, not just this summary.
   minimal vector-drawn icons (no icon-theme dependency), the bundled Neucha
   font. Chrome text uses `chromeFont()`/`chromeMonoFont()`
   (`src/overlay-chrome.cpp`), pinned in code, and `main()` installs
-  `chromeDefaultFont()` as the application font; the Qt platform theme is
-  deliberately disabled at startup (see [docs/dependencies.md](docs/dependencies.md)),
-  so never reach for `QFontDatabase::systemFont`, `QStyle`, or `palette()`.
+  `chromeDefaultFont()` as the application font; external desktop platform
+  themes are deliberately bypassed at startup in favour of Qt's built-in
+  `generic` theme (see [docs/dependencies.md](docs/dependencies.md)). Chrome
+  must use the pinned fonts and explicit colours; do not derive chrome from
+  `QFontDatabase::systemFont`, `QStyle`, or `palette()`.
 
 ## Repository layout
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -43,6 +43,19 @@ Each of these is invoked through the same small `runProcess`/
 worker (see [threading.md](threading.md)) — never inline on the UI thread,
 and always with a timeout.
 
+## Not a dependency: the Qt platform theme
+
+Omarchy exports `QT_QPA_PLATFORMTHEME=gtk3` for the whole session so Qt apps
+match GTK apps. Omasnap overrides it to empty for its own process in `main()`
+before `QApplication` is constructed: honouring it loads the `qgtk3` plugin,
+which initialises GTK3, GLib/GIO and dconf inside the process — measured at
+81–112 ms of `QApplication` construction and ~40 MB of RSS on an Omarchy
+laptop — for an overlay that is hand-painted, opens no dialogs and reads no
+palette. The only thing the theme supplied was the system font family; that
+is pinned in `chromeFont()` / `chromeMonoFont()` (`src/overlay-chrome.cpp`)
+instead. Do not reintroduce a platform theme, `QStyle`, or icon-theme lookup:
+each is a startup cost with nothing in this codebase to spend it on.
+
 ## The one config file
 
 `~/.config/omasnap/omasnap.conf` is optional INI, read with `QSettings`.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -50,7 +50,7 @@ match GTK apps. Omasnap overrides it to `generic` (Qt's built-in theme) for
 its own process in `main()` before `QApplication` is constructed: honouring
 the session value loads the `qgtk3` plugin,
 which initialises GTK3, GLib/GIO and dconf inside the process — measured at
-81–112 ms of `QApplication` construction and ~40 MB of RSS on an Omarchy
+81–112 ms of `QApplication` construction and ~20–24 MiB of RSS on an Omarchy
 laptop — for an overlay that is hand-painted, opens no dialogs and reads no
 palette. The only relevant values the external theme supplied were its
 general and fixed fonts; their chrome and application-default replacements

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -43,18 +43,22 @@ Each of these is invoked through the same small `runProcess`/
 worker (see [threading.md](threading.md)) — never inline on the UI thread,
 and always with a timeout.
 
-## Not a dependency: the Qt platform theme
+## Not a dependency: external Qt platform themes
 
 Omarchy exports `QT_QPA_PLATFORMTHEME=gtk3` for the whole session so Qt apps
-match GTK apps. Omasnap overrides it to empty for its own process in `main()`
-before `QApplication` is constructed: honouring it loads the `qgtk3` plugin,
+match GTK apps. Omasnap overrides it to `generic` (Qt's built-in theme) for
+its own process in `main()` before `QApplication` is constructed: honouring
+the session value loads the `qgtk3` plugin,
 which initialises GTK3, GLib/GIO and dconf inside the process — measured at
 81–112 ms of `QApplication` construction and ~40 MB of RSS on an Omarchy
 laptop — for an overlay that is hand-painted, opens no dialogs and reads no
-palette. The only thing the theme supplied was the system font family; that
-is pinned in `chromeFont()` / `chromeMonoFont()` (`src/overlay-chrome.cpp`)
-instead. Do not reintroduce a platform theme, `QStyle`, or icon-theme lookup:
-each is a startup cost with nothing in this codebase to spend it on.
+palette. The only relevant values the external theme supplied were its
+general and fixed fonts; their chrome and application-default replacements
+are pinned by `chromeFont()`, `chromeMonoFont()`, and `chromeDefaultFont()`
+(`src/overlay-chrome.cpp`) instead. Do not make startup or chrome rendering
+depend on an external desktop theme, `QStyle`- or palette-derived chrome, or
+icon-theme lookup: each is a startup cost with nothing in this codebase to
+spend it on.
 
 ## The one config file
 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -24,7 +24,6 @@
 #include <QEvent>
 #include <QFile>
 #include <QFileInfo>
-#include <QFontDatabase>
 #include <QFontMetrics>
 #include <QGuiApplication>
 #include <QKeyEvent>
@@ -492,9 +491,7 @@ void drawInstantTooltip(QPainter &painter, const QRect &bounds,
                         const QRectF &anchor, const QString &text) {
   if (text.isEmpty())
     return;
-  QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
-  font.setPixelSize(12);
-  painter.setFont(font);
+  painter.setFont(chromeFont(12));
   const qreal width = painter.fontMetrics().horizontalAdvance(text) + 20;
   const qreal height = 28;
   qreal x = std::clamp(anchor.center().x() - width / 2.0, 8.0,
@@ -534,10 +531,7 @@ void drawMeasureBadge(QPainter &painter, const QRect &bounds,
                       const QPointF &cursor, const QString &text) {
   if (text.isEmpty())
     return;
-  QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-  font.setPixelSize(12);
-  font.setBold(true);
-  painter.setFont(font);
+  painter.setFont(chromeMonoFont(12, true));
   const qreal width = painter.fontMetrics().horizontalAdvance(text) + 16;
   constexpr qreal height = 22;
   constexpr qreal gap = 15;
@@ -6297,9 +6291,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     painter.restore();
 
   const QString currentTool = toolAction(tool_);
-  QFont buttonFont = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
-  buttonFont.setPixelSize(11);
-  buttonFont.setBold(true);
+  const QFont buttonFont = chromeFont(11, true);
   painter.setFont(buttonFont);
   QVector<qreal> toolbarDividers;
   const QVector<ToolbarButton> buttons = toolbarButtons(&toolbarDividers);
@@ -6360,10 +6352,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     painter.setPen(QPen(QColor(255, 255, 255, 34), 1));
     painter.setBrush(QColor(22, 22, 28, 248));
     painter.drawRoundedRect(panel, 9, 9);
-    QFont sizeFont = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
-    sizeFont.setPixelSize(11);
-    sizeFont.setBold(true);
-    painter.setFont(sizeFont);
+    painter.setFont(chromeFont(11, true));
     for (int index = 0; index < 3; ++index) {
       const QRectF item(panel.left() + index * 34, panel.top(), 34,
                         panel.height());

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -3023,10 +3023,10 @@ void CaptureEditor::ensureTextEditor() {
   textEditor_ = new InlineTextEdit(this);
   textEditor_->hide();
   textEditor_->setViewportMargins(0, 0, 0, 0);
-  textEditor_->setStyleSheet(
-      QStringLiteral("QPlainTextEdit { color: #ff375f; background: transparent; "
-                     "border: none; padding: 0;"
-                     " selection-background-color: #0a84ff; }"));
+  textEditor_->setStyleSheet(QStringLiteral(
+      "QPlainTextEdit { color: #ff375f; background: transparent; "
+      "border: none; padding: 0;"
+      " selection-background-color: #0a84ff; selection-color: #ffffff; }"));
   textEditor_->installEventFilter(this);
   connect(textEditor_, &QPlainTextEdit::cursorPositionChanged, this, [this] {
     textCaretOn_ = true;
@@ -3106,9 +3106,10 @@ void CaptureEditor::beginText(const QPointF &point, int annotationIndex,
   textEditPill_ = pill;
   const int pillPad = pill ? qRound(std::max(4.0, metrics.height() * 0.18)) : 0;
   textEditor_->setStyleSheet(
-      QStringLiteral("QPlainTextEdit { color: %1; background: transparent; "
-                     "border: none; margin: 0; padding: 0;"
-                     " selection-background-color: #0a84ff; }")
+      QStringLiteral(
+          "QPlainTextEdit { color: %1; background: transparent; "
+          "border: none; margin: 0; padding: 0;"
+          " selection-background-color: #0a84ff; selection-color: #ffffff; }")
           .arg(textColor_.name()));
   textEditor_->setViewportMargins(pillPad, 0, pillPad, 0);
   textEditor_->setGeometry(qRound(position.x()) - pillPad, qRound(position.y()),

--- a/src/icons.cpp
+++ b/src/icons.cpp
@@ -1,7 +1,8 @@
 #include "icons.hpp"
 
+#include "overlay-chrome.hpp"
+
 #include <QConicalGradient>
-#include <QFontDatabase>
 #include <QPainter>
 #include <QPainterPath>
 
@@ -54,10 +55,7 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     painter.drawEllipse(QPointF(10.5, 10.5), 2.3, 2.3);
   } else if (action == QStringLiteral("tool-marker")) {
     painter.drawEllipse(QPointF(12, 12), 8, 8);
-    QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
-    font.setPixelSize(11);
-    font.setBold(true);
-    painter.setFont(font);
+    painter.setFont(chromeFont(11, true));
     painter.drawText(QRectF(4, 4, 16, 16), Qt::AlignCenter,
                      QStringLiteral("1"));
   } else if (action == QStringLiteral("tool-rectangle")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,15 +105,19 @@ int main(int argc, char **argv) {
   // loads the qgtk3 plugin, which initialises GTK inside this process
   // (measured 81-112 ms of QApplication construction, plus ~40 MB of RSS)
   // for a hand-painted overlay that opens no dialogs and reads no palette.
-  // The generic theme is all it needs; the chrome font is pinned in
-  // chromeFont() rather than taken from the theme.
-  qputenv("QT_QPA_PLATFORMTHEME", "");
+  // Qt's built-in generic theme is all it needs, so select it by name
+  // (an empty value would let Qt pick a theme from XDG_CURRENT_DESKTOP
+  // instead). The chrome font is pinned in chromeFont() rather than taken
+  // from the theme. `-platformtheme gtk3` on the command line still
+  // overrides this for debugging.
+  qputenv("QT_QPA_PLATFORMTHEME", "generic");
   QGuiApplication::setDesktopFileName(QStringLiteral("omasnap"));
   QApplication application(argc, argv);
   startupTimingMark("QApplication constructed");
-  // With the platform theme disabled the default font would be Qt's generic
-  // "Sans Serif 9"; pin what the theme used to install before any widget
-  // is created, so painter/widget default-font text keeps its size and face.
+  // With the external desktop theme bypassed, Qt's default font would be
+  // generic "Sans Serif 9"; pin what the theme used to install before any
+  // widget is created, so painter/widget default-font text keeps its size and
+  // face.
   QApplication::setFont(chromeDefaultFont());
 
   // A stitched scroll capture (or any tall pinned image) exceeds Qt's default

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "cli-path.hpp"
 #include "editor.hpp"
 #include "instance-lock.hpp"
+#include "overlay-chrome.hpp"
 #include "pin.hpp"
 #include "recent-snaps.hpp"
 #include "startup-timing.hpp"
@@ -100,9 +101,20 @@ int main(int argc, char **argv) {
   QCoreApplication::setApplicationVersion(QString::fromLatin1(OMASNAP_VERSION));
   QCoreApplication::setOrganizationName(QStringLiteral("Omarchy"));
   qputenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell");
+  // Omarchy exports QT_QPA_PLATFORMTHEME=gtk3 session-wide. Honouring it
+  // loads the qgtk3 plugin, which initialises GTK inside this process
+  // (measured 81-112 ms of QApplication construction, plus ~40 MB of RSS)
+  // for a hand-painted overlay that opens no dialogs and reads no palette.
+  // The generic theme is all it needs; the chrome font is pinned in
+  // chromeFont() rather than taken from the theme.
+  qputenv("QT_QPA_PLATFORMTHEME", "");
   QGuiApplication::setDesktopFileName(QStringLiteral("omasnap"));
   QApplication application(argc, argv);
   startupTimingMark("QApplication constructed");
+  // With the platform theme disabled the default font would be Qt's generic
+  // "Sans Serif 9"; pin what the theme used to install before any widget
+  // is created, so painter/widget default-font text keeps its size and face.
+  QApplication::setFont(chromeDefaultFont());
 
   // A stitched scroll capture (or any tall pinned image) exceeds Qt's default
   // 256 MB image-decode allocation limit; lift it so --file/--pin can open it.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,8 +103,8 @@ int main(int argc, char **argv) {
   qputenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell");
   // Omarchy exports QT_QPA_PLATFORMTHEME=gtk3 session-wide. Honouring it
   // loads the qgtk3 plugin, which initialises GTK inside this process
-  // (measured 81-112 ms of QApplication construction, plus ~40 MB of RSS)
-  // for a hand-painted overlay that opens no dialogs and reads no palette.
+  // (measured 81-112 ms of QApplication construction, plus ~20-24 MiB of
+  // RSS) for a hand-painted overlay that opens no dialogs and reads no palette.
   // Qt's built-in generic theme is all it needs, so select it by name
   // (an empty value would let Qt pick a theme from XDG_CURRENT_DESKTOP
   // instead). The chrome font is pinned in chromeFont() rather than taken

--- a/src/overlay-chrome.cpp
+++ b/src/overlay-chrome.cpp
@@ -2,11 +2,45 @@
 #include "overlay-chrome.hpp"
 
 #include <QFont>
-#include <QFontDatabase>
 #include <QFontMetricsF>
+#include <QString>
+#include <QStringList>
 #include <QPainter>
 
 #include <algorithm>
+
+QFont chromeFont(int pixelSize, bool bold) {
+  static const QFont base = [] {
+    QFont font;
+    font.setFamilies({QStringLiteral("Adwaita Sans"),
+                      QStringLiteral("Noto Sans")});
+    return font;
+  }();
+  QFont font = base;
+  font.setPixelSize(pixelSize);
+  font.setBold(bold);
+  return font;
+}
+
+QFont chromeDefaultFont() {
+  QFont font;
+  font.setFamilies({QStringLiteral("Adwaita Sans"),
+                    QStringLiteral("Noto Sans")});
+  font.setPointSize(11);
+  return font;
+}
+
+QFont chromeMonoFont(int pixelSize, bool bold) {
+  static const QFont base = [] {
+    QFont font;
+    font.setFamilies({QStringLiteral("monospace")});
+    return font;
+  }();
+  QFont font = base;
+  font.setPixelSize(pixelSize);
+  font.setBold(bold);
+  return font;
+}
 
 QString captureTabLabel(CaptureKind kind) {
   switch (kind) {
@@ -139,8 +173,7 @@ void drawHotkeyLegend(QPainter &painter, const QRect &bounds,
                       const QVector<QPair<QString, QString>> &entries) {
   if (entries.isEmpty())
     return;
-  QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
-  font.setPixelSize(11);
+  const QFont font = chromeFont(11);
   const QFontMetricsF metrics(font);
   constexpr qreal keyGap = 10;    // between a key and what it does
   constexpr qreal marginLeft = 14;

--- a/src/overlay-chrome.hpp
+++ b/src/overlay-chrome.hpp
@@ -12,7 +12,25 @@
 #include <QString>
 #include <QVector>
 
+class QFont;
 class QPainter;
+
+/// The typeface for overlay chrome text (toolbar labels, hotkey legend,
+/// tooltips): pinned in code, never the platform theme's system font, so
+/// startup does not depend on a theme plugin and the look is the same on
+/// every install. Adwaita Sans is the stock Omarchy UI font; Noto Sans is
+/// the fallback the tab strip already uses.
+[[nodiscard]] QFont chromeFont(int pixelSize, bool bold = false);
+/// The application-wide default font, installed by main() before any widget
+/// exists: the same face and 11 pt size the gtk3 platform theme used to
+/// supply, so text drawn with a painter's or widget's default font (pin
+/// tips, scroll-panel buttons) does not shrink or change family now that
+/// the theme is disabled.
+[[nodiscard]] QFont chromeDefaultFont();
+/// Monospace counterpart for numeric readouts: fontconfig's `monospace`
+/// alias, which is what the fixed-font lookup resolved to under every theme
+/// (on Omarchy, the face `omarchy-font-set` chose).
+[[nodiscard]] QFont chromeMonoFont(int pixelSize, bool bold = false);
 
 /// The kinds of capture the tab strip across the top offers, on every
 /// overlay. Region and Window are modes of the area overlay, Scroll is the

--- a/src/overlay-chrome.hpp
+++ b/src/overlay-chrome.hpp
@@ -25,7 +25,7 @@ class QPainter;
 /// exists: the same face and 11 pt size the gtk3 platform theme used to
 /// supply, so text drawn with a painter's or widget's default font (pin
 /// tips, scroll-panel buttons) does not shrink or change family now that
-/// the theme is disabled.
+/// the external desktop theme is bypassed.
 [[nodiscard]] QFont chromeDefaultFont();
 /// Monospace counterpart for numeric readouts: fontconfig's `monospace`
 /// alias, which is what the fixed-font lookup resolved to under every theme

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7,6 +7,7 @@
 #include "cut-mapping-smoke.hpp"
 #include "cut-smoke.hpp"
 #include "editor.hpp"
+#include "overlay-chrome.hpp"
 #include "recent-snaps.hpp"
 #include "instance-lock-smoke.hpp"
 #include "palette-config-smoke.hpp"
@@ -713,6 +714,37 @@ void paintTextLikeBand(QImage &image, const QRectF &logicalBand, qreal scale,
 }
 
 /** Local edge scan finds text height across themes and native image scales. */
+// The chrome font is pinned in code (the platform theme is disabled at
+// startup); the general face must resolve to a real family and the mono face
+// to a fixed-pitch one.
+bool runChromeFontCheck(QString &error) {
+  const QFont general = chromeFont(11, true);
+  if (general.pixelSize() != 11 || !general.bold() ||
+      QFontInfo(general).family().isEmpty()) {
+    error = QStringLiteral("chromeFont(11, true) did not resolve: %1")
+                .arg(general.toString());
+    return false;
+  }
+  const QFont mono = chromeMonoFont(12);
+  const QFont appFont = QApplication::font();
+  if (appFont.pointSize() != 11 || QFontInfo(appFont).family().isEmpty() ||
+      appFont.families() != chromeDefaultFont().families()) {
+    error = QStringLiteral("application default font is %1, expected "
+                           "chromeDefaultFont()")
+                .arg(appFont.toString());
+    return false;
+  }
+  const QFontInfo monoInfo(mono);
+  if (mono.pixelSize() != 12 || mono.bold() || monoInfo.family().isEmpty() ||
+      !monoInfo.fixedPitch()) {
+    error = QStringLiteral("chromeMonoFont(12) resolved to %1, expected a "
+                           "fixed-pitch family")
+                .arg(monoInfo.family());
+    return false;
+  }
+  return true;
+}
+
 bool runTextBandDetectionCheck(QString &error) {
   for (const qreal scale : {1.0, 2.0}) {
     const QSize logicalSize(360, 180);
@@ -7378,6 +7410,7 @@ int main(int argc, char **argv) {
     return runInstanceLockHolder(heldLockPath);
 
   QApplication application(argc, argv);
+  QApplication::setFont(chromeDefaultFont()); // as main() does
   if (!loadCaptureFonts())
     return 17;
 
@@ -7449,6 +7482,10 @@ int main(int argc, char **argv) {
   if (!runTextBandDetectionCheck(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 128;
+  }
+  if (!runChromeFontCheck(snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 130;
   }
   if (!runTextAwareHighlighterEditorCheck(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
## Summary

Omarchy exports `QT_QPA_PLATFORMTHEME=gtk3` session-wide. Omasnap is almost entirely hand-painted and does not use GTK dialogs, palettes, styles, or icons, so loading `qgtk3` adds startup and memory overhead without providing useful functionality.

This PR:

- selects Qt's built-in `generic` platform theme before constructing `QApplication`
- avoids initializing GTK3, GLib/GIO, and dconf
- pins the application and overlay chrome fonts to preserve Omasnap's stock appearance
- replaces remaining system-font lookups with shared `chromeFont()` and `chromeMonoFont()` helpers
- explicitly styles inline text selection colors instead of relying on the platform palette
- adds smoke coverage for the application, chrome, and monospace fonts
- documents why Omasnap does not depend on an external Qt platform theme

## Performance

Measured from fresh Release builds in an Omarchy Wayland session:

| Measurement | Before | After | Reduction |
|---|---:|---:|---:|
| `QApplication` construction | 88–101 ms | 9–12 ms | ~80–90 ms |
| Minimal startup RSS | 61.2 MiB | 37.8 MiB | 23.4 MiB |
| Open overlay RSS | 132–152 MiB | 110–131 MiB | 21–22 MiB |
| Open overlay PSS | 80.7–90.7 MiB | 72.8–83.3 MiB | 7.4–7.9 MiB |

Overlay RSS moves by approximately 19.8 MiB depending on whether an additional 2880×1800 capture buffer is resident. The reported reduction compares matching buffer states.

RSS includes shared library pages in full. PSS divides those pages between processes and is a better approximation of the physical-memory impact on a desktop where GTK is already loaded elsewhere.

## Behavior

The stock appearance is preserved through the pinned Adwaita Sans/Noto Sans font stack and the system monospace alias.

Desktop GTK font customization no longer affects Omasnap chrome. This is intentional: Omasnap is pre-configured for Omarchy, and its rendering should not require an external desktop theme.

An explicit command-line override such as `-platformtheme gtk3` still takes precedence for debugging.

## Verification

- `make check`
- offscreen smoke suite
- changed-line `clang-tidy`
- live Wayland launches with both `generic` and `gtk3`
- repeated Release-build memory measurements
