### PR TITLE
feat(editor): insert cut bands and reveal saved captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ Runtime commands used by the application:
 - `hyprctl`
 - `wl-copy` and `wl-paste`
 - `tesseract`
-- `omarchy-notification-send` when available; saved captures include a thumbnail and
-  reopen in Omasnap when clicked. Notification failure does not invalidate output.
+- `omarchy-notification-send` when available; saved captures include a thumbnail.
+  Notification failure does not invalidate output.
+- `uwsm-app` and Nautilus for the optional reveal-after-save gesture and saved
+  notification click. A reveal failure does not invalidate output.
 
 ## Install on Omarchy
 
@@ -218,8 +220,7 @@ the overlay that is still on screen.
 
 Editing an existing image is never cancelled this way: `--file`, `--clipboard`, or an
 image path stops the running instance, waits up to two seconds for the lock, and opens the
-editor on that image. That is how a pin's Edit button and a notification click always land
-in the editor.
+editor on that image. That is how a pin's Edit button lands in the editor.
 
 A lock left behind by a crashed instance is removed and reclaimed. A lock file that cannot
 be read or written at all is reported on stderr instead of being mistaken for a running
@@ -253,8 +254,9 @@ omasnap --clipboard
 The clipboard must offer readable image data. Text-only clipboard contents return an
 error instead of opening an empty editor.
 
-File URLs are accepted too. A saved capture notification's "Click to edit" action launches
-`omasnap` on the finished screenshot, so it can be reopened and re-annotated.
+File URLs are accepted too. A saved capture notification's "Click to show in folder"
+action reveals the finished screenshot in Files. To reopen it with editable layers, use
+the Recent captures shelf.
 
 ### Recent captures
 
@@ -389,10 +391,15 @@ without reaching for the pointer.
 | `Ctrl+Shift+Z`, `Ctrl+Y` | Redo |
 | `Ctrl+C` | Copy PNG only |
 | `Ctrl+S` | Save PNG only |
+| `Ctrl+Shift+S` | Save and reveal the selected file in Files |
 | `Enter` | Copy and save (with a text layer selected: edit it) |
+| `Shift+Enter` | Copy, save, and reveal the selected file in Files |
 | `P` | Pin the capture on screen and close the editor |
 | `Esc` | Return to Select; press again to close |
 | Right-click | Return to Select; cancel active drawing |
+
+Holding `Shift` while clicking the toolbar's Save or Copy+Save button also
+reveals the finished file in Files.
 
 ### Pinned captures
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ resizable vector layers and preserves the monitor's native pixels on scaled disp
   mesh-gradient backdrops, and rendered drop shadows on standard backdrop cards.
 - Cut tool: drag across a band of the image to remove it and collapse the gap, with a
   live preview and dashed seam marker while dragging; annotations shift to follow.
+  Hold **Ctrl** (or **Ctrl+X**) to insert a transparent band instead; the toolbar
+  icon swaps to a split-plus while Ctrl is down.
 - Pin a finished capture as a bottom-right always-on-top layer surface, launched
   from the same `omasnap` executable and visible on every workspace.
 - Crash-resistant working documents under `/run/user/<UID>/omasnap/` (falling back to
@@ -365,7 +367,7 @@ without reaching for the pointer.
 | `R` | Rectangle; hover the shape button for rectangle, ellipse, and fill controls; `Alt`+wheel rounds corners |
 | `E` | Ellipse; shares the shape submenu and filled/hollow toggle |
 | `D` | Redact; press again to toggle randomized pixelation or solid redaction |
-| `X` | Cut out a band; drag to preview the crossed-out strip, then release to remove and collapse it |
+| `X` | Cut out a band; drag to preview the crossed-out strip, then release to remove and collapse it. **Ctrl** (with Cut armed, or **Ctrl+X**) inserts a band instead; the cut icon becomes a split-plus |
 | `T` | Text on a cream readability pill, with Neucha as the default. Click for a one-line label, or drag a box to give it room for several lines: Enter moves to the next line while there is room and commits on the last one; `Shift+Enter` always adds a line; `Esc` commits too but keeps the label selected, so `Backspace` removes it; clicking away keeps the text; press T again to toggle the pill |
 | `Shift+T` | Cycle the next or selected text through Neucha, JetBrains Mono, and Inter Display |
 | `O` | Recognize and copy all text in the current image |

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -37,6 +37,7 @@ no user-visible benefit.
 | `wl-copy` / `wl-paste` | Writing PNG/text to the Wayland clipboard, and verifying the write | Yes |
 | `tesseract` | OCR text recognition | Only if OCR is used; missing tesseract fails just that action |
 | `omarchy-notification-send` | Capture-finished notifications | No — falls back silently if absent (checked with `command -v` semantics via failed `QProcess::startDetached`) |
+| `uwsm-app` / `nautilus` | Reveal a saved screenshot selected in Files | No — missing/failed reveal never invalidates a successful save |
 
 Each of these is invoked through the same small `runProcess`/
 `QProcess::startDetached` helpers in `src/capture.cpp`, from a background

--- a/docs/editing-model.md
+++ b/docs/editing-model.md
@@ -44,9 +44,10 @@ Two operations *do* need to touch real pixels before export, and both are
 still fully undoable because of how they're kept in the log:
 
 - **Cut** (`Operation::Type::Cut`) removes a band of the image and shifts
-  everything after it. The working image (`capture_.source`) after a cut is
-  `composeCuts(pristineSource_, cuts_)` — recomputed from the untouched
-  original plus the list of cut ops every time the list changes
+  everything after it, or **inserts** a transparent band (`cut.insert`) and
+  shifts everything after the seam out. The working image (`capture_.source`)
+  after a cut is `composeCuts(pristineSource_, cuts_)` — recomputed from the
+  untouched original plus the list of cut ops every time the list changes
   (`CaptureEditor::refreshComposedCapture()`). Undo a cut and the composed
   image is rebuilt without it; `pristineSource_` was never modified.
 - **Redaction** exists to permanently destroy sensitive content, so it is

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -2027,9 +2027,29 @@ QString recognizeText(const QImage &image, QString &error) {
   return text;
 }
 
-QString shellQuote(QString value) {
-  value.replace('\'', QStringLiteral("'\"'\"'"));
-  return QStringLiteral("'%1'").arg(value);
+namespace {
+struct RevealCommand {
+  QString program;
+  QStringList arguments;
+};
+
+QString absoluteLocalFileUrl(const QString &path) {
+  return QUrl::fromLocalFile(QFileInfo(path).absoluteFilePath())
+      .toString(QUrl::FullyEncoded);
+}
+
+RevealCommand revealFileCommand(const QString &path) {
+  return {QStringLiteral("uwsm-app"),
+          {QStringLiteral("--"), QStringLiteral("nautilus"),
+           QStringLiteral("--select"), absoluteLocalFileUrl(path)}};
+}
+} // namespace
+
+bool revealFileInFolder(const QString &path) {
+  if (path.isEmpty())
+    return false;
+  const RevealCommand command = revealFileCommand(path);
+  return QProcess::startDetached(command.program, command.arguments);
 }
 
 void sendCaptureNotification(const QString &message, const QString &imagePath) {
@@ -2037,18 +2057,16 @@ void sendCaptureNotification(const QString &message, const QString &imagePath) {
                         QStringLiteral("--app-name"), QStringLiteral("omasnap"),
                         message};
   if (!imagePath.isEmpty()) {
-    const QString imageUrl =
-        QUrl::fromLocalFile(imagePath).toString(QUrl::FullyEncoded);
-    QString omasnap = QDir(QCoreApplication::applicationDirPath())
-                          .filePath(QStringLiteral("omasnap"));
-    if (!QFileInfo::exists(omasnap))
-      omasnap = QStringLiteral("omasnap");
-    arguments << QStringLiteral("Click to edit") << QStringLiteral("--image")
-              << imagePath << QStringLiteral("--exec")
-              << QStringLiteral("%1 %2").arg(shellQuote(omasnap),
-                                             shellQuote(imageUrl));
+    const QString absoluteImagePath = QFileInfo(imagePath).absoluteFilePath();
+    const RevealCommand reveal = revealFileCommand(absoluteImagePath);
+    arguments << QStringLiteral("Click to show in folder")
+              << QStringLiteral("--image") << absoluteImagePath
+              << QStringLiteral("-t") << QStringLiteral("4500")
+              << QStringLiteral("--exec") << reveal.program;
+    arguments << reveal.arguments;
+  } else {
+    arguments << QStringLiteral("-t") << QStringLiteral("4500");
   }
-  arguments << QStringLiteral("-t") << QStringLiteral("4500");
   QProcess::startDetached(QStringLiteral("omarchy-notification-send"),
                           arguments);
 }

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1821,6 +1821,8 @@ QJsonObject operationToJson(const Operation &operation) {
     object.insert(QStringLiteral("sourceEnd"), operation.cut.sourceEnd);
     object.insert(QStringLiteral("logicalStart"), operation.cut.logicalStart);
     object.insert(QStringLiteral("logicalEnd"), operation.cut.logicalEnd);
+    if (operation.cut.insert)
+      object.insert(QStringLiteral("insert"), true);
     break;
   }
   return object;
@@ -1894,6 +1896,7 @@ bool operationFromJson(const QJsonObject &object, Operation &operation,
         object.value(QStringLiteral("logicalStart")).toInt();
     operation.cut.logicalEnd =
         object.value(QStringLiteral("logicalEnd")).toInt();
+    operation.cut.insert = object.value(QStringLiteral("insert")).toBool();
     return true;
   }
   error = QStringLiteral("Operation log has an unknown operation type");

--- a/src/capture.hpp
+++ b/src/capture.hpp
@@ -328,7 +328,8 @@ void prunePinnedSnapshots();
 [[nodiscard]] bool saveTemporarySnapshot(const QImage &image, QString path,
                                          QString &error, int quality = -1);
 [[nodiscard]] QString recognizeText(const QImage &image, QString &error);
-/** Quotes a string for a shell argument passed to omarchy-notification-send. */
-[[nodiscard]] QString shellQuote(QString value);
+/** Opens the file manager with `path` selected. Best-effort: save succeeds
+ * even when the desktop launcher is unavailable. */
+[[nodiscard]] bool revealFileInFolder(const QString &path);
 void sendCaptureNotification(const QString &message,
                              const QString &imagePath = {});

--- a/src/cut.cpp
+++ b/src/cut.cpp
@@ -1,6 +1,5 @@
-/** @fileoverview Band cut-out engine: removes a horizontal or vertical band
- *  from an image and collapses the gap (Snagit-style "cut out", ported from
- *  omapic). */
+/** @fileoverview Band cut engine: removes a horizontal or vertical band and
+ *  collapses the gap, or inserts transparent space at the seam. */
 #include "cut.hpp"
 
 #include <QPainter>
@@ -44,27 +43,82 @@ QImage removeBand(const QImage &source, Qt::Orientation orientation,
   return out;
 }
 
+QImage insertBand(const QImage &source, Qt::Orientation orientation,
+                  int start, int end) {
+  if (source.isNull())
+    return source;
+  const int extent =
+      orientation == Qt::Horizontal ? source.height() : source.width();
+  start = std::clamp(start, 0, extent);
+  end = std::clamp(end, start, extent);
+  const int band = end - start;
+  if (band <= 0)
+    return source;
+  QImage image = source;
+  if (image.format() != QImage::Format_ARGB32 &&
+      image.format() != QImage::Format_ARGB32_Premultiplied)
+    image = image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
+  if (orientation == Qt::Horizontal) {
+    const int height = image.height();
+    QImage out(image.width(), height + band, image.format());
+    out.setDevicePixelRatio(image.devicePixelRatio());
+    out.fill(Qt::transparent);
+    for (int y = 0; y < start; ++y)
+      std::memcpy(out.scanLine(y), image.constScanLine(y), image.bytesPerLine());
+    for (int y = start; y < height; ++y)
+      std::memcpy(out.scanLine(y + band), image.constScanLine(y),
+                  image.bytesPerLine());
+    return out;
+  }
+  const int width = image.width();
+  QImage out(width + band, image.height(), image.format());
+  out.setDevicePixelRatio(image.devicePixelRatio());
+  out.fill(Qt::transparent);
+  QPainter painter(&out);
+  painter.setCompositionMode(QPainter::CompositionMode_Source);
+  painter.drawImage(QPoint(0, 0), image, QRect(0, 0, start, image.height()));
+  painter.drawImage(QPoint(start + band, 0), image,
+                    QRect(start, 0, width - start, image.height()));
+  return out;
+}
+
+QImage applyCutOp(const QImage &source, const CutOp &cut) {
+  return cut.insert ? insertBand(source, cut.orientation, cut.sourceStart,
+                                 cut.sourceEnd)
+                    : removeBand(source, cut.orientation, cut.sourceStart,
+                                 cut.sourceEnd);
+}
+
 QImage composeCuts(const QImage &pristine, const QVector<CutOp> &cuts) {
   QImage image = pristine;
   for (const CutOp &cut : cuts)
-    image = removeBand(image, cut.orientation, cut.sourceStart, cut.sourceEnd);
+    image = applyCutOp(image, cut);
   return image;
 }
 
 QSize composedLogicalSize(QSize pristineLogical, const QVector<CutOp> &cuts) {
   for (const CutOp &cut : cuts) {
     const int band = cut.logicalEnd - cut.logicalStart;
+    if (band <= 0)
+      continue;
+    if (cut.insert) {
+      if (cut.orientation == Qt::Horizontal)
+        pristineLogical.setHeight(pristineLogical.height() + band);
+      else
+        pristineLogical.setWidth(pristineLogical.width() + band);
+      continue;
+    }
     if (cut.orientation == Qt::Horizontal) {
       const int extent = pristineLogical.height();
       // Mirror removeBand()'s no-op guard so this can never disagree with
       // what composeCuts() actually produces: an empty or full-extent band
       // leaves the image unchanged.
-      if (band <= 0 || band >= extent)
+      if (band >= extent)
         continue;
       pristineLogical.setHeight(std::max(1, extent - band));
     } else {
       const int extent = pristineLogical.width();
-      if (band <= 0 || band >= extent)
+      if (band >= extent)
         continue;
       pristineLogical.setWidth(std::max(1, extent - band));
     }
@@ -78,4 +132,10 @@ qreal shiftForCut(qreal value, qreal start, qreal end) {
   if (value >= end)
     return value - (end - start);
   return start;
+}
+
+qreal shiftForInsert(qreal value, qreal start, qreal size) {
+  if (size <= 0.0 || value < start)
+    return value;
+  return value + size;
 }

--- a/src/cut.hpp
+++ b/src/cut.hpp
@@ -18,6 +18,7 @@ struct CutOp {
   int sourceEnd = 0;
   int logicalStart = 0;
   int logicalEnd = 0;
+  bool insert = false;
   bool operator==(const CutOp &) const = default;
 };
 
@@ -27,6 +28,14 @@ struct CutOp {
 [[nodiscard]] QImage removeBand(const QImage &source,
                                 Qt::Orientation orientation, int start,
                                 int end);
+
+/** Inserts a transparent band `[start, end)` and shifts the rest out. An
+ *  empty band is a no-op. */
+[[nodiscard]] QImage insertBand(const QImage &source,
+                                Qt::Orientation orientation, int start,
+                                int end);
+
+[[nodiscard]] QImage applyCutOp(const QImage &source, const CutOp &cut);
 
 /** Replays `cuts` in order over the pristine image. */
 [[nodiscard]] QImage composeCuts(const QImage &pristine,
@@ -39,3 +48,7 @@ struct CutOp {
 /** Shifts one coordinate for a removed band [start, end): values past the
  *  band shift back by the band size, values inside clamp to the seam. */
 [[nodiscard]] qreal shiftForCut(qreal value, qreal start, qreal end);
+
+/** Shifts one coordinate for an inserted band of `size` at `start`: values
+ *  on or past the seam move out by `size`. */
+[[nodiscard]] qreal shiftForInsert(qreal value, qreal start, qreal size);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2284,8 +2284,10 @@ CaptureEditor::toolbarButtons(QVector<qreal> *groupDividers,
   add(36, QStringLiteral("pin"), {},
       QStringLiteral("Pin on screen · P · Ctrl+C on the pin copies it"));
   add(36, QStringLiteral("copy"), {}, QStringLiteral("Copy only · Ctrl+C"));
-  add(40, QStringLiteral("both"), {}, QStringLiteral("Copy and save · Enter"));
-  add(36, QStringLiteral("save"), {}, QStringLiteral("Save only · Ctrl+S"));
+  add(40, QStringLiteral("both"), {},
+      QStringLiteral("Copy and save · Enter · Shift reveals"));
+  add(36, QStringLiteral("save"), {},
+      QStringLiteral("Save only · Ctrl+S · Shift reveals"));
   add(36, QStringLiteral("close"), {}, QStringLiteral("Close · Esc twice"));
 
   if (includeSubmenus && shapeMenuOpen_) {
@@ -3424,7 +3426,7 @@ void CaptureEditor::paintOcrOverlay(QPainter &painter, const QRectF &image,
   painter.restore();
 }
 
-void CaptureEditor::finish(OutputMode mode) {
+void CaptureEditor::finish(OutputMode mode, bool reveal) {
   if (busy_ || selection_.isEmpty())
     return;
   busy_ = true;
@@ -3443,47 +3445,50 @@ void CaptureEditor::finish(OutputMode mode) {
   const QImage backdrop = customBackdrop_;
   const QString appSlug =
       appFilenameSlug(dominantAppClass(capture_.windows, selection_));
-  finishWatcher_.setFuture(QtConcurrent::run([captureCopy, selection,
-                                              annotations, background,
-                                              imageShadow, canvasBoundary,
-                                              backdrop, appSlug, mode]() {
-    FinishResult result;
-    result.mode = mode;
-    const QImage image = renderCapture(captureCopy, selection, annotations,
-                                       background, imageShadow,
-                                       canvasBoundary, backdrop);
-    if (!image.isNull())
-      result.thumbnail = image.scaled(kRecentThumbEdge, kRecentThumbEdge,
-                                      Qt::KeepAspectRatio,
-                                      Qt::SmoothTransformation);
-    const QString exportPath = temporaryExportPath();
-    QString error;
-    if (image.isNull() || exportPath.isEmpty() ||
-        !saveTemporarySnapshot(image, exportPath, error, -1)) {
-      result.error = error.isEmpty()
-                         ? QStringLiteral("Could not prepare screenshot snapshot")
-                         : error;
-      return result;
-    }
-    if (mode == OutputMode::Copy || mode == OutputMode::Both) {
-      if (!copyPngFileToClipboard(exportPath, error)) {
-        QFile::remove(exportPath);
-        result.error = error;
+  finishWatcher_.setFuture(QtConcurrent::run(
+      [captureCopy, selection, annotations, background, imageShadow,
+       canvasBoundary, backdrop, appSlug, mode, reveal]() {
+        FinishResult result;
+        result.mode = mode;
+        const QImage image =
+            renderCapture(captureCopy, selection, annotations, background,
+                          imageShadow, canvasBoundary, backdrop);
+        if (!image.isNull())
+          result.thumbnail =
+              image.scaled(kRecentThumbEdge, kRecentThumbEdge,
+                           Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        const QString exportPath = temporaryExportPath();
+        QString error;
+        if (image.isNull() || exportPath.isEmpty() ||
+            !saveTemporarySnapshot(image, exportPath, error, -1)) {
+          result.error =
+              error.isEmpty()
+                  ? QStringLiteral("Could not prepare screenshot snapshot")
+                  : error;
+          return result;
+        }
+        if (mode == OutputMode::Copy || mode == OutputMode::Both) {
+          if (!copyPngFileToClipboard(exportPath, error)) {
+            QFile::remove(exportPath);
+            result.error = error;
+            return result;
+          }
+        }
+        if (mode == OutputMode::Save || mode == OutputMode::Both) {
+          result.saved = moveSnapshotToScreenshots(exportPath, error, appSlug);
+          if (result.saved.isEmpty()) {
+            QFile::remove(exportPath);
+            result.error = error;
+            return result;
+          }
+          if (reveal && !revealFileInFolder(result.saved))
+            qWarning().noquote()
+                << QStringLiteral("Could not reveal saved screenshot");
+        } else {
+          QFile::remove(exportPath);
+        }
         return result;
-      }
-    }
-    if (mode == OutputMode::Save || mode == OutputMode::Both) {
-      result.saved = moveSnapshotToScreenshots(exportPath, error, appSlug);
-      if (result.saved.isEmpty()) {
-        QFile::remove(exportPath);
-        result.error = error;
-        return result;
-      }
-    } else {
-      QFile::remove(exportPath);
-    }
-    return result;
-  }));
+      }));
 }
 
 void CaptureEditor::completeFinish(const FinishResult &result) {
@@ -3527,7 +3532,7 @@ void CaptureEditor::completeFinish(const FinishResult &result) {
   close();
 }
 
-void CaptureEditor::handleToolbar(const QString &action) {
+void CaptureEditor::handleToolbar(const QString &action, bool reveal) {
   const Tool toolBefore = tool_;
   const QString statusBefore = status_;
   if (action == QStringLiteral("tool-select"))
@@ -3631,9 +3636,9 @@ void CaptureEditor::handleToolbar(const QString &action) {
   else if (action == QStringLiteral("copy"))
     finish(OutputMode::Copy);
   else if (action == QStringLiteral("both"))
-    finish(OutputMode::Both);
+    finish(OutputMode::Both, reveal);
   else if (action == QStringLiteral("save"))
-    finish(OutputMode::Save);
+    finish(OutputMode::Save, reveal);
   else if (action == QStringLiteral("close"))
     close();
   if (tool_ != toolBefore && status_ == statusBefore)
@@ -3813,13 +3818,17 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
   } else if (event->matches(QKeySequence::Copy)) {
     finish(OutputMode::Copy);
     return;
-  } else if (event->matches(QKeySequence::Save)) {
-    finish(OutputMode::Save);
+  } else if (event->matches(QKeySequence::Save) ||
+             (event->key() == Qt::Key_S &&
+              event->modifiers() ==
+                  (Qt::ControlModifier | Qt::ShiftModifier))) {
+    finish(OutputMode::Save, event->modifiers().testFlag(Qt::ShiftModifier));
     return;
   } else if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
     // Enter on a selected label reopens it for editing; anywhere else it
     // finishes the capture.
-    if (selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
+    if (!event->modifiers().testFlag(Qt::ShiftModifier) &&
+        selectedAnnotation_ >= 0 && selectedAnnotation_ < annotations_.size() &&
         selectedAnnotations_.size() <= 1 &&
         annotations_.at(selectedAnnotation_).kind == Annotation::Kind::Text &&
         !dragging_ && !textEditing()) {
@@ -3828,16 +3837,16 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
       update();
       return;
     }
-    finish(OutputMode::Both);
+    finish(OutputMode::Both, event->modifiers().testFlag(Qt::ShiftModifier));
     return;
   } else if (event->key() == Qt::Key_D &&
              event->modifiers() == Qt::AltModifier) {
     duplicateSelectedAnnotation();
   } else if (const QPointF nudge = arrowKeyDelta(
-                 event->key(), heldModifiers(event->modifiers())
-                                       .testFlag(Qt::ShiftModifier)
-                                   ? kNudgeStepShift
-                                   : kNudgeStep);
+                 event->key(),
+                 heldModifiers(event->modifiers()).testFlag(Qt::ShiftModifier)
+                     ? kNudgeStepShift
+                     : kNudgeStep);
              !nudge.isNull() &&
              !heldModifiers(event->modifiers())
                   .testAnyFlags(Qt::ControlModifier | Qt::AltModifier |
@@ -3848,9 +3857,8 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     nudgeSelectedAnnotation(nudge);
   } else if (viewZoom_ > 1.0 && selectedAnnotation_ < 0 && !dragging_ &&
              !textEditing() &&
-             !event->modifiers().testAnyFlags(Qt::ControlModifier |
-                                              Qt::AltModifier |
-                                              Qt::MetaModifier) &&
+             !event->modifiers().testAnyFlags(
+                 Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier) &&
              (event->key() == Qt::Key_Left || event->key() == Qt::Key_Right ||
               event->key() == Qt::Key_Up || event->key() == Qt::Key_Down)) {
     // With nothing selected the arrows have nothing else to do, so they walk
@@ -4657,7 +4665,9 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
 
   for (const ToolbarButton &button : toolbarButtons()) {
     if (button.rect.contains(cursor_)) {
-      handleToolbar(button.action);
+      handleToolbar(
+          button.action,
+          heldModifiers(event->modifiers()).testFlag(Qt::ShiftModifier));
       return;
     }
   }
@@ -6176,9 +6186,9 @@ void CaptureEditor::paintEdit(QPainter &painter) {
        {QStringLiteral("B / P"), QStringLiteral("Backdrop / Pin on screen")},
        {QStringLiteral("Ctrl+Z"), QStringLiteral("Undo")},
        {QStringLiteral("Ctrl+Shift+Z"), QStringLiteral("Redo")},
-       {QStringLiteral("Enter"), QStringLiteral("Copy + save")},
+       {QStringLiteral("Enter"), QStringLiteral("Copy + save · Shift reveals")},
        {QStringLiteral("Ctrl+C"), QStringLiteral("Copy only")},
-       {QStringLiteral("Ctrl+S"), QStringLiteral("Save only")},
+       {QStringLiteral("Ctrl+S"), QStringLiteral("Save only · Shift reveals")},
        {QStringLiteral("Esc"), QStringLiteral("Arrow / twice close")}});
   // When zoomed past fit the image is larger than the viewport; clip content
   // to the band between the toolbar and the status so it cannot overdraw them.

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1307,7 +1307,9 @@ QString CaptureEditor::toolStatus() const {
                           "it circular")
         .arg(size);
   case Tool::Cut:
-    return QStringLiteral("Cut · drag a band to remove it");
+    return cutInsertHint()
+               ? QStringLiteral("Insert a band · drag across")
+               : QStringLiteral("Cut · drag a band to remove it");
   case Tool::Highlighter:
     return highlighterStatus();
   case Tool::Arrow:
@@ -2264,7 +2266,9 @@ CaptureEditor::toolbarButtons(QVector<qreal> *groupDividers,
       QStringLiteral("Redact · D · %1 · D again toggles")
           .arg(redactionStyleName(redactionStyle_)));
   add(36, QStringLiteral("tool-cut"), {},
-      QStringLiteral("Cut out a band · X · drag across"));
+      cutInsertHint()
+          ? QStringLiteral("Insert a band · drag across")
+          : QStringLiteral("Cut out a band · X · drag across"));
   add(36, QStringLiteral("tool-text"), {},
       QStringLiteral("%1 text · T · %2 · %3 · T again cycles style · "
                      "Shift+T cycles font · Wheel")
@@ -2508,6 +2512,15 @@ void CaptureEditor::commitCrop(const QRectF &crop) {
   commitOp(std::move(op));
 }
 
+bool CaptureEditor::cutInsertHint() const {
+  if (tool_ != Tool::Cut)
+    return false;
+  if (cutDragActive_)
+    return liveCut_.insert;
+  return QGuiApplication::queryKeyboardModifiers().testFlag(
+      Qt::ControlModifier);
+}
+
 void CaptureEditor::commitCut(CutOp cut) {
   Operation op;
   op.type = Operation::Type::Cut;
@@ -2714,6 +2727,13 @@ void CaptureEditor::replayLog() {
       const qreal band = hi - lo;
       for (Annotation &annotation : annotations) {
         auto shift = [&](QPointF &point) {
+          if (op.cut.insert) {
+            if (horizontal)
+              point.setY(shiftForInsert(point.y(), lo, band));
+            else
+              point.setX(shiftForInsert(point.x(), lo, band));
+            return;
+          }
           if (horizontal)
             point.setY(shiftForCut(point.y(), lo, hi));
           else
@@ -2725,7 +2745,12 @@ void CaptureEditor::replayLog() {
           shift(point);
       }
       if (band > 0.0) {
-        if (horizontal)
+        if (op.cut.insert) {
+          if (horizontal)
+            selection.setHeight(selection.height() + band);
+          else
+            selection.setWidth(selection.width() + band);
+        } else if (horizontal)
           selection.setHeight(std::max<qreal>(1.0, selection.height() - band));
         else
           selection.setWidth(std::max<qreal>(1.0, selection.width() - band));
@@ -3559,7 +3584,9 @@ void CaptureEditor::handleToolbar(const QString &action) {
   } else if (action == QStringLiteral("tool-cut")) {
     tool_ = Tool::Cut;
     selectedAnnotation_ = -1;
-    setStatus(QStringLiteral("Cut: drag across a band to remove it"));
+    setStatus(cutInsertHint()
+                  ? QStringLiteral("Insert a band · drag across")
+                  : QStringLiteral("Cut: drag across a band to remove it"));
   } else if (action == QStringLiteral("tool-text")) {
     if (tool_ == Tool::Text)
       toggleTextBackground();
@@ -3918,7 +3945,9 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     }
   } else if (event->key() == Qt::Key_X) {
     tool_ = Tool::Cut;
-    setStatus(QStringLiteral("Cut: drag across a band to remove it"));
+    setStatus(heldModifiers(event->modifiers()).testFlag(Qt::ControlModifier)
+                  ? QStringLiteral("Insert a band · drag across")
+                  : QStringLiteral("Cut: drag across a band to remove it"));
   } else if (event->key() == Qt::Key_T &&
              event->modifiers() == Qt::ShiftModifier) {
     cycleTextFont();
@@ -3951,6 +3980,8 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
       commitBackground(backgroundStyle_, next);
     } else
       cycleBackground();
+  } else if (tool_ == Tool::Cut && event->key() == Qt::Key_Control) {
+    setStatus(QStringLiteral("Insert a band · drag across"));
   } else if (event->key() >= Qt::Key_1 && event->key() <= Qt::Key_8) {
     colorIndex_ = event->key() - Qt::Key_1;
     usingCustomColor_ = false;
@@ -3975,6 +4006,13 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
 
 void CaptureEditor::keyReleaseEvent(QKeyEvent *event) {
   modifiersSeen_ = true;
+  if (tool_ == Tool::Cut && event->key() == Qt::Key_Control &&
+      !cutDragActive_) {
+    setStatus(QStringLiteral("Cut: drag across a band to remove it"));
+    QWidget::keyReleaseEvent(event);
+    update();
+    return;
+  }
   if (event->key() == Qt::Key_Shift &&
       (creationConstraintActive_ || resizeConstraintActive_)) {
     creationConstraintActive_ = false;
@@ -4373,6 +4411,9 @@ void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
         liveCut_.orientation = std::abs(delta.y()) >= std::abs(delta.x())
                                     ? Qt::Horizontal
                                     : Qt::Vertical;
+        liveCut_.insert =
+            liveCut_.insert || heldModifiers(event->modifiers())
+                                   .testFlag(Qt::ControlModifier);
         // Lock the source/preview mapping together with the drag axis. The
         // capture remains unchanged until this preview is committed.
         cutDragOriginOffset_ = liveCut_.orientation == Qt::Horizontal
@@ -4843,9 +4884,12 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
   } else if (tool_ == Tool::Cut) {
     // Activation waits for a dominant drag axis (see mouseMoveEvent); a
     // plain click never crosses that threshold and mouseReleaseEvent treats
-    // it as a no-op.
+    // it as a no-op. Ctrl at press arms insert; the 3px lock records it.
     cutDragStart_ = point;
     cutDragActive_ = false;
+    liveCut_ = {};
+    liveCut_.insert = heldModifiers(event->modifiers())
+                          .testFlag(Qt::ControlModifier);
     dragging_ = true;
   } else {
     dragStart_ = point;
@@ -4989,23 +5033,24 @@ void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
     const qreal band = hi - lo;
     const qreal extent =
         horizontal ? selection_.height() : selection_.width();
-    if (band <= 0.0 || band >= extent) {
-      // Full-extent (or empty) band: toAnnotationPoint clamps lo/hi to
-      // [0, extent], so an edge-to-edge drag on a full selection lands
-      // exactly here. removeBand() no-ops on this band, so applying it
-      // would still shrink composedLogicalSize/selection_ while the actual
-      // pixels don't shrink -- desyncing preview size from the source
-      // aspect. Bail out instead.
+    if (band <= 0.0 || (!liveCut_.insert && band >= extent)) {
+      // Full-extent (or empty) remove is a no-op in removeBand(), so
+      // applying it would still shrink composedLogicalSize/selection_
+      // while the pixels stay put. Insert may grow past the current
+      // extent. Empty always bails.
       cutDragActive_ = false;
       refreshComposedCapture();
-      setStatus(QStringLiteral("Cut too large — nothing left"));
+      setStatus(liveCut_.insert ? QStringLiteral("Insert too small")
+                                : QStringLiteral("Cut too large — nothing left"));
       updatePointerCursor();
       update();
       return;
     }
     cutDragActive_ = false;
     commitCut(liveCut_);
-    setStatus(QStringLiteral("Cut applied · Ctrl+Z to undo"));
+    setStatus(liveCut_.insert
+                  ? QStringLiteral("Band inserted · Ctrl+Z to undo")
+                  : QStringLiteral("Cut applied · Ctrl+Z to undo"));
     updatePointerCursor();
     update();
     return;
@@ -6122,6 +6167,7 @@ void CaptureEditor::paintEdit(QPainter &painter) {
        {QStringLiteral("C"), QStringLiteral("Marker")},
        {QStringLiteral("R / E"), QStringLiteral("Rectangle / Ellipse")},
        {QStringLiteral("X"), QStringLiteral("Cut out a band")},
+       {QStringLiteral("Ctrl"), QStringLiteral("Insert a band (with Cut)")},
        {QStringLiteral("T"), QStringLiteral("Text")},
        {QStringLiteral("Double click"), QStringLiteral("Edit text layer")},
        {QStringLiteral("1–8"), QStringLiteral("Color")},
@@ -6405,13 +6451,17 @@ void CaptureEditor::paintEdit(QPainter &painter) {
                                      selection_.height());
     painter.save();
     painter.setClipRect(band);
-    painter.fillRect(band, QColor(104, 110, 120, 175));
+    painter.fillRect(band, liveCut_.insert ? QColor(48, 180, 90, 140)
+                                           : QColor(104, 110, 120, 175));
 
-    const qreal spacing = 14.0 / scale;
-    painter.setPen(QPen(QColor(255, 255, 255, 72), 1.0 / scale));
-    for (qreal x = band.left() - band.height(); x < band.right(); x += spacing)
-      painter.drawLine(QPointF(x, band.bottom()),
-                       QPointF(x + band.height(), band.top()));
+    if (!liveCut_.insert) {
+      const qreal spacing = 14.0 / scale;
+      painter.setPen(QPen(QColor(255, 255, 255, 72), 1.0 / scale));
+      for (qreal x = band.left() - band.height(); x < band.right();
+           x += spacing)
+        painter.drawLine(QPointF(x, band.bottom()),
+                         QPointF(x + band.height(), band.top()));
+    }
 
     const QPointF center = band.center();
     const qreal crossRadius =
@@ -6420,10 +6470,17 @@ void CaptureEditor::paintEdit(QPainter &painter) {
     if (crossRadius >= 3.0 / scale) {
       painter.setPen(QPen(QColor(255, 255, 255, 230), 2.0 / scale,
                           Qt::SolidLine, Qt::RoundCap));
-      painter.drawLine(center + QPointF(-crossRadius, -crossRadius),
-                       center + QPointF(crossRadius, crossRadius));
-      painter.drawLine(center + QPointF(-crossRadius, crossRadius),
-                       center + QPointF(crossRadius, -crossRadius));
+      if (liveCut_.insert) {
+        painter.drawLine(center + QPointF(-crossRadius, 0),
+                         center + QPointF(crossRadius, 0));
+        painter.drawLine(center + QPointF(0, -crossRadius),
+                         center + QPointF(0, crossRadius));
+      } else {
+        painter.drawLine(center + QPointF(-crossRadius, -crossRadius),
+                         center + QPointF(crossRadius, crossRadius));
+        painter.drawLine(center + QPointF(-crossRadius, crossRadius),
+                         center + QPointF(crossRadius, -crossRadius));
+      }
     }
     painter.restore();
 
@@ -6646,6 +6703,9 @@ void CaptureEditor::paintEdit(QPainter &painter) {
                                      ? QStringLiteral("tool-ellipse")
                                      : button.action == QStringLiteral("shape-fill")
                                            ? QStringLiteral("tool-rectangle")
+                                     : button.action == QStringLiteral("tool-cut") &&
+                                             cutInsertHint()
+                                           ? QStringLiteral("tool-cut-insert")
                                            : button.action;
       drawToolbarIcon(painter, button.rect, icon, button.label,
                       QColor(245, 245, 247));

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -268,6 +268,9 @@ public:
   /// Apply a cut as if the user had dragged that band. Test hook: operate on
   /// a fixture raster without going through widget coordinates.
   void applyCutForTest(CutOp cut) { commitCut(std::move(cut)); }
+  /// Composed source after cuts. Test accessor: insert-band smoke checks
+  /// the transparent gap on the working image, not the flattened export.
+  [[nodiscard]] QImage composedSourceForTest() const { return capture_.source; }
   /// Number of selected layers. Test accessor.
   [[nodiscard]] int selectedCountForTest() const {
     return static_cast<int>(selectedAnnotations_.size());
@@ -542,6 +545,7 @@ private:
   void commitDelete(const QVector<int> &indices);
   void commitCrop(const QRectF &crop);
   void commitCut(CutOp cut);
+  [[nodiscard]] bool cutInsertHint() const;
   void commitBackground(BackgroundStyle style, bool imageShadow);
   void commitCanvasBoundary(CanvasBoundaryMode mode);
   void cycleCanvasBoundary(bool reverse);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -553,10 +553,10 @@ private:
   void replayLog();
   void redoEdit();
   void selectWindowInDirection(int key);
-  void finish(OutputMode mode);
+  void finish(OutputMode mode, bool reveal = false);
   void completeFinish(const FinishResult &result);
   void handleEscape();
-  void handleToolbar(const QString &action);
+  void handleToolbar(const QString &action, bool reveal);
   void paintEdit(QPainter &painter);
   void paintSelect(QPainter &painter);
   void refreshBackdropCache();

--- a/src/icons.cpp
+++ b/src/icons.cpp
@@ -90,6 +90,12 @@ void drawToolbarIcon(QPainter &painter, const QRectF &bounds,
     painter.drawRect(QRectF(5, 14.5, 14, 5.5));
     painter.setPen(QPen(color, 1.4, Qt::DashLine, Qt::FlatCap));
     painter.drawLine(QPointF(5, 12), QPointF(19, 12));
+  } else if (action == QStringLiteral("tool-cut-insert")) {
+    // Two image halves opening, plus in the gap (insert a band).
+    painter.drawRect(QRectF(5, 3, 14, 5));
+    painter.drawRect(QRectF(5, 16, 14, 5));
+    painter.drawLine(QPointF(12, 9.5), QPointF(12, 14.5));
+    painter.drawLine(QPointF(9.5, 12), QPointF(14.5, 12));
   } else if (action == QStringLiteral("tool-text")) {
     painter.drawLine(QPointF(5, 5), QPointF(19, 5));
     painter.drawLine(QPointF(12, 5), QPointF(12, 19));

--- a/tests/cut-mapping-smoke.cpp
+++ b/tests/cut-mapping-smoke.cpp
@@ -298,5 +298,43 @@ bool runCutMappingSmoke(QApplication &application, const QString &outputRoot,
     editor.close();
   }
 
+  // Ctrl+drag inserts a transparent band and grows the image.
+  {
+    CaptureEditor editor(fixtureCapture(source),
+                         CaptureEditor::CaptureMode::File);
+    editor.resize(800, 600);
+    editor.show();
+    application.processEvents();
+    QTest::keyClick(&editor, Qt::Key_X, Qt::ControlModifier);
+    application.processEvents();
+    if (editor.armedToolForTest() != CaptureEditor::Tool::Cut) {
+      error = QStringLiteral("Ctrl+X did not arm the cut tool");
+      return false;
+    }
+    const QPoint from = screenOf(editor, kWidth / 2.0, 80);
+    const QPoint to = screenOf(editor, kWidth / 2.0, 96);
+    QTest::mousePress(&editor, Qt::LeftButton, Qt::ControlModifier, from);
+    QTest::mouseMove(&editor, to, 10);
+    application.processEvents();
+    QTest::mouseRelease(&editor, Qt::LeftButton, Qt::ControlModifier, to);
+    application.processEvents();
+    bool inserted = false;
+    for (const Operation &op : editor.operationLog()) {
+      if (op.type == Operation::Type::Cut && op.cut.insert)
+        inserted = true;
+    }
+    if (!inserted) {
+      error = QStringLiteral("Ctrl+drag did not log an insert band");
+      return false;
+    }
+    const QImage composed = editor.composedSourceForTest();
+    if (composed.height() != kBand * kBands + 16 ||
+        composed.pixelColor(0, 80).alpha() != 0) {
+      error = QStringLiteral("insert band did not open a transparent gap");
+      return false;
+    }
+    editor.close();
+  }
+
   return true;
 }

--- a/tests/cut-smoke.cpp
+++ b/tests/cut-smoke.cpp
@@ -89,6 +89,55 @@ bool runCutSmoke(QString &error) {
     return false;
   }
 
+  if (shiftForInsert(3.0, 5.0, 4.0) != 3.0 ||
+      shiftForInsert(5.0, 5.0, 4.0) != 9.0 ||
+      shiftForInsert(12.0, 5.0, 4.0) != 16.0) {
+    error = QStringLiteral("shiftForInsert wrong");
+    return false;
+  }
+
+  // Horizontal insert at row 2 of width 2: 10,20, gap, gap, 30,40.
+  const QImage inserted = insertBand(source, Qt::Horizontal, 2, 4);
+  if (inserted.size() != QSize(4, 6) || redAt(inserted, 0, 0) != 10 ||
+      redAt(inserted, 0, 1) != 20 || inserted.pixelColor(0, 2).alpha() != 0 ||
+      inserted.pixelColor(0, 3).alpha() != 0 || redAt(inserted, 0, 4) != 30 ||
+      redAt(inserted, 0, 5) != 40) {
+    error = QStringLiteral("horizontal insertBand produced wrong image");
+    return false;
+  }
+  if (insertBand(source, Qt::Horizontal, 2, 2) != source) {
+    error = QStringLiteral("empty insertBand changed the image");
+    return false;
+  }
+
+  // Derive insertion size after clamping both bounds. Mapping round-off may
+  // put an endpoint just outside the source; it must not create extra space.
+  const QImage clampedRows = insertBand(source, Qt::Horizontal, -5, 1);
+  const QImage columnSource = indexedImage({{1, 2, 3, 4}, {1, 2, 3, 4}});
+  const QImage clampedCols = insertBand(columnSource, Qt::Vertical, 3, 99);
+  if (clampedRows.size() != QSize(4, 5) ||
+      clampedRows.pixelColor(0, 0).alpha() != 0 ||
+      redAt(clampedRows, 0, 1) != 10 || redAt(clampedRows, 0, 4) != 40 ||
+      clampedCols.size() != QSize(5, 2) || redAt(clampedCols, 2, 0) != 3 ||
+      clampedCols.pixelColor(3, 0).alpha() != 0 ||
+      redAt(clampedCols, 4, 0) != 4) {
+    error = QStringLiteral("insertBand bounds handling wrong");
+    return false;
+  }
+
+  CutOp insertOp{Qt::Vertical, 1, 3, 1, 3, true};
+  const QImage viaOp = applyCutOp(
+      indexedImage({{1, 2, 3, 4}, {1, 2, 3, 4}}), insertOp);
+  if (viaOp.size() != QSize(6, 2) || redAt(viaOp, 0, 0) != 1 ||
+      viaOp.pixelColor(1, 0).alpha() != 0 || redAt(viaOp, 3, 0) != 2) {
+    error = QStringLiteral("applyCutOp insert was not a vertical gap");
+    return false;
+  }
+  if (composedLogicalSize(QSize(100, 80), {insertOp}) != QSize(102, 80)) {
+    error = QStringLiteral("composedLogicalSize did not grow on insert");
+    return false;
+  }
+
   // Vertical band removal must preserve alpha: create ARGB32 image with
   // semi-transparent pixel, remove a vertical band, verify alpha is unchanged.
   QImage alphaSource(4, 2, QImage::Format_ARGB32);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -2969,6 +2969,292 @@ bool runAsyncCaptureRegionSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+enum class RevealGesture {
+  SaveShortcut,
+  BothShortcut,
+  SaveClick,
+  BothClick,
+  PlainSave
+};
+
+struct RevealExpectation {
+  RevealGesture gesture;
+  QString label;
+  bool copied;
+  bool revealed;
+};
+
+struct RevealSmokeFiles {
+  QString screenshots;
+  QString revealLog;
+  QString clipboardPng;
+};
+
+bool waitForSmokeFile(QApplication &application, const QString &path) {
+  QElapsedTimer timer;
+  timer.start();
+  while (!QFile::exists(path) && timer.elapsed() < 3000) {
+    application.processEvents();
+    QThread::msleep(1);
+  }
+  return QFile::exists(path);
+}
+
+QStringList readArgumentLog(const QString &path) {
+  QFile file(path);
+  return file.open(QIODevice::ReadOnly)
+             ? QString::fromUtf8(file.readAll()).split('\n', Qt::SkipEmptyParts)
+             : QStringList{};
+}
+
+void restoreEnvironmentVariable(const char *name, const QByteArray &value) {
+  if (value.isEmpty())
+    qunsetenv(name);
+  else
+    qputenv(name, value);
+}
+
+bool runRevealGestureSmoke(QApplication &application,
+                           const CaptureData &capture,
+                           const RevealExpectation &expectation,
+                           const RevealSmokeFiles &files,
+                           const QString &notificationLog, QString &savedPath,
+                           QString &error) {
+  QDir(files.screenshots).removeRecursively();
+  QFile::remove(files.revealLog);
+  QFile::remove(files.clipboardPng);
+  QFile::remove(notificationLog);
+  qputenv("OMASNAP_TEST_NOTIFICATION_LOG", notificationLog.toUtf8());
+
+  CaptureEditor editor(capture, CaptureEditor::CaptureMode::File);
+  editor.setSuppressSnapshots(true);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  if (expectation.gesture == RevealGesture::BothShortcut) {
+    QTest::keyClick(&editor, Qt::Key_T);
+    QTest::mouseClick(&editor, Qt::LeftButton, Qt::NoModifier,
+                      editor.toScreenPointForTest({80, 80}).toPoint());
+    QWidget *inlineEditor = QApplication::focusWidget();
+    if (!inlineEditor) {
+      error = QStringLiteral(
+          "Could not open a label before testing selected Shift+Enter");
+      return false;
+    }
+    QTest::keyClicks(inlineEditor, QStringLiteral("Selected label"));
+    QTest::keyClick(inlineEditor, Qt::Key_Escape);
+    application.processEvents();
+    if (editor.annotationCountForTest() != 1 ||
+        editor.selectedCountForTest() != 1) {
+      error = QStringLiteral(
+          "Could not select a committed label before Shift+Enter");
+      return false;
+    }
+  }
+  switch (expectation.gesture) {
+  case RevealGesture::SaveShortcut:
+    QTest::keyClick(&editor, Qt::Key_S,
+                    Qt::ControlModifier | Qt::ShiftModifier);
+    break;
+  case RevealGesture::BothShortcut:
+    QTest::keyClick(&editor, Qt::Key_Return, Qt::ShiftModifier);
+    break;
+  case RevealGesture::SaveClick:
+  case RevealGesture::BothClick:
+    QTest::keyPress(&editor, Qt::Key_Shift);
+    QTest::mouseClick(&editor, Qt::LeftButton, Qt::ShiftModifier,
+                      editor.toolbarButtonCenterForTest(
+                          expectation.gesture == RevealGesture::SaveClick
+                              ? QStringLiteral("save")
+                              : QStringLiteral("both")));
+    QTest::keyRelease(&editor, Qt::Key_Shift);
+    break;
+  case RevealGesture::PlainSave:
+    QTest::keyClick(&editor, Qt::Key_S, Qt::ControlModifier);
+    break;
+  }
+  editor.waitForExport();
+  static_cast<void>(waitForSmokeFile(application, notificationLog));
+  if (expectation.revealed)
+    static_cast<void>(waitForSmokeFile(application, files.revealLog));
+  else {
+    QThread::msleep(50);
+    application.processEvents();
+  }
+
+  const QStringList saved =
+      QDir(files.screenshots)
+          .entryList({QStringLiteral("*.png")}, QDir::Files);
+  const bool copied = QFile::exists(files.clipboardPng);
+  const bool revealed = QFile::exists(files.revealLog);
+  if (editor.isVisible() || saved.size() != 1 || copied != expectation.copied ||
+      revealed != expectation.revealed) {
+    error = QStringLiteral("%1 failed (saved=%2, copied=%3, revealed=%4)")
+                .arg(expectation.label)
+                .arg(saved.size())
+                .arg(copied)
+                .arg(revealed);
+    return false;
+  }
+
+  savedPath = QDir(files.screenshots).filePath(saved.constFirst());
+  if (!revealed)
+    return true;
+  const QStringList expected{
+      QStringLiteral("--"), QStringLiteral("nautilus"),
+      QStringLiteral("--select"),
+      QUrl::fromLocalFile(QFileInfo(savedPath).absoluteFilePath())
+          .toString(QUrl::FullyEncoded)};
+  const QStringList actual = readArgumentLog(files.revealLog);
+  if (actual == expected)
+    return true;
+  error = QStringLiteral("%1 reveal command was %2, expected %3")
+              .arg(expectation.label, actual.join(QStringLiteral(" | ")),
+                   expected.join(QStringLiteral(" | ")));
+  return false;
+}
+
+bool runRevealSavedScreenshotSmoke(QApplication &application, QString &error) {
+  QTemporaryDir root;
+  if (!root.isValid()) {
+    error =
+        QStringLiteral("Could not create reveal-screenshot smoke directory");
+    return false;
+  }
+
+  const auto writeExecutable = [](const QString &path,
+                                  const QByteArray &contents) {
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly) ||
+        file.write(contents) != contents.size())
+      return false;
+    file.close();
+    return QFile::setPermissions(path, QFileDevice::ReadOwner |
+                                           QFileDevice::WriteOwner |
+                                           QFileDevice::ExeOwner);
+  };
+  const QString commands = QDir(root.path()).filePath(QStringLiteral("bin"));
+  if (!QDir().mkpath(commands)) {
+    error =
+        QStringLiteral("Could not create reveal-screenshot command directory");
+    return false;
+  }
+  const QByteArray revealScript = QByteArrayLiteral(
+      "#!/bin/sh\n"
+      "printf '%s\\n' \"$@\" > \"$OMASNAP_TEST_REVEAL_LOG\"\n");
+  const QByteArray notificationScript = QByteArrayLiteral(
+      "#!/bin/sh\n"
+      "printf '%s\\n' \"$@\" > \"$OMASNAP_TEST_NOTIFICATION_LOG\"\n");
+  const QByteArray copyScript =
+      QByteArrayLiteral("#!/bin/sh\ncat > \"$OMASNAP_TEST_CLIPBOARD_PNG\"\n");
+  const QByteArray pasteScript =
+      QByteArrayLiteral("#!/bin/sh\ncat \"$OMASNAP_TEST_CLIPBOARD_PNG\"\n");
+  if (!writeExecutable(QDir(commands).filePath(QStringLiteral("uwsm-app")),
+                       revealScript) ||
+      !writeExecutable(
+          QDir(commands).filePath(QStringLiteral("omarchy-notification-send")),
+          notificationScript) ||
+      !writeExecutable(QDir(commands).filePath(QStringLiteral("wl-copy")),
+                       copyScript) ||
+      !writeExecutable(QDir(commands).filePath(QStringLiteral("wl-paste")),
+                       pasteScript)) {
+    error = QStringLiteral("Could not create reveal-screenshot commands");
+    return false;
+  }
+
+  const QByteArray previousPath = qgetenv("PATH");
+  const QByteArray previousScreenshotDir = qgetenv("OMASNAP_SCREENSHOT_DIR");
+  const QByteArray previousRevealLog = qgetenv("OMASNAP_TEST_REVEAL_LOG");
+  const QByteArray previousClipboard = qgetenv("OMASNAP_TEST_CLIPBOARD_PNG");
+  const QByteArray previousNotificationLog =
+      qgetenv("OMASNAP_TEST_NOTIFICATION_LOG");
+  const QString previousCurrentPath = QDir::currentPath();
+  const auto restoreEnvironment = qScopeGuard([&] {
+    QDir::setCurrent(previousCurrentPath);
+    qputenv("PATH", previousPath);
+    restoreEnvironmentVariable("OMASNAP_SCREENSHOT_DIR", previousScreenshotDir);
+    restoreEnvironmentVariable("OMASNAP_TEST_REVEAL_LOG", previousRevealLog);
+    restoreEnvironmentVariable("OMASNAP_TEST_CLIPBOARD_PNG", previousClipboard);
+    restoreEnvironmentVariable("OMASNAP_TEST_NOTIFICATION_LOG",
+                               previousNotificationLog);
+  });
+
+  if (!QDir::setCurrent(root.path())) {
+    error = QStringLiteral("Could not enter reveal-screenshot smoke directory");
+    return false;
+  }
+  const RevealSmokeFiles files{
+      QStringLiteral("relative-screenshots"),
+      QDir(root.path()).filePath(QStringLiteral("reveal-arguments")),
+      QDir(root.path()).filePath(QStringLiteral("clipboard.png"))};
+  qputenv("PATH", commands.toUtf8() + ':' + previousPath);
+  qputenv("OMASNAP_SCREENSHOT_DIR", files.screenshots.toUtf8());
+  qputenv("OMASNAP_TEST_REVEAL_LOG", files.revealLog.toUtf8());
+  qputenv("OMASNAP_TEST_CLIPBOARD_PNG", files.clipboardPng.toUtf8());
+
+  CaptureData capture;
+  capture.monitor.name = QStringLiteral("TEST");
+  capture.monitor.geometry = {0, 0, 320, 240};
+  capture.monitor.pixelSize = {320, 240};
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(320, 240, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor(QStringLiteral("#183048")));
+  capture.previewSize = capture.source.size();
+
+  const std::array expectations{
+      RevealExpectation{RevealGesture::SaveShortcut,
+                        QStringLiteral("Ctrl+Shift+S"), false, true},
+      RevealExpectation{RevealGesture::BothShortcut,
+                        QStringLiteral("Shift+Enter with selected text"), true,
+                        true},
+      RevealExpectation{RevealGesture::SaveClick,
+                        QStringLiteral("Shift-click Save"), false, true},
+      RevealExpectation{RevealGesture::BothClick,
+                        QStringLiteral("Shift-click Copy+Save"), true, true},
+      RevealExpectation{RevealGesture::PlainSave, QStringLiteral("Ctrl+S"),
+                        false, false}};
+  QString savedPath;
+  for (std::size_t index = 0; index < expectations.size(); ++index) {
+    const QString notificationLog =
+        QDir(root.path())
+            .filePath(QStringLiteral("notification-%1").arg(index));
+    if (!runRevealGestureSmoke(application, capture, expectations.at(index),
+                               files, notificationLog, savedPath, error))
+      return false;
+  }
+
+  const QString notificationActionLog =
+      QDir(root.path()).filePath(QStringLiteral("notification-action"));
+  qputenv("OMASNAP_TEST_NOTIFICATION_LOG", notificationActionLog.toUtf8());
+  sendCaptureNotification(QStringLiteral("Screenshot saved"), savedPath);
+  if (!waitForSmokeFile(application, notificationActionLog)) {
+    error = QStringLiteral("Saved notification did not launch");
+    return false;
+  }
+  const QStringList notificationActual = readArgumentLog(notificationActionLog);
+  const QString savedUrl =
+      QUrl::fromLocalFile(QFileInfo(savedPath).absoluteFilePath())
+          .toString(QUrl::FullyEncoded);
+  const int execIndex = notificationActual.indexOf(QStringLiteral("--exec"));
+  const QStringList notificationExec =
+      execIndex < 0 ? QStringList{} : notificationActual.sliced(execIndex + 1);
+  const int imageIndex = notificationActual.indexOf(QStringLiteral("--image"));
+  const QString notificationImage =
+      imageIndex < 0 || imageIndex + 1 >= notificationActual.size()
+          ? QString()
+          : notificationActual.at(imageIndex + 1);
+  const QStringList expectedExec{
+      QStringLiteral("uwsm-app"), QStringLiteral("--"),
+      QStringLiteral("nautilus"), QStringLiteral("--select"), savedUrl};
+  if (notificationActual.contains(QStringLiteral("Click to show in folder")) &&
+      notificationImage == QFileInfo(savedPath).absoluteFilePath() &&
+      notificationExec == expectedExec)
+    return true;
+  error = QStringLiteral("Saved notification did not offer reveal: %1")
+              .arg(notificationActual.join(QStringLiteral(" | ")));
+  return false;
+}
+
 /** Checks that the wheel retargets the spotlight under the cursor. */
 bool runSpotlightWheelSmoke(QApplication &application, QString &error) {
   CaptureData capture;
@@ -3459,26 +3745,6 @@ bool runRecentsShelfSmoke(QApplication &application, QString &error) {
       return false;
     }
   }
-  return true;
-}
-
-/** Quotes the same way sendCaptureNotification builds --exec. */
-bool runShellQuoteCheck(QString &error) {
-  if (shellQuote(QStringLiteral("omasnap")) != QStringLiteral("'omasnap'")) {
-    error = QStringLiteral("shellQuote did not wrap a simple token");
-    return false;
-  }
-  if (shellQuote(QStringLiteral("omasnap /tmp/a.png")) !=
-      QStringLiteral("'omasnap /tmp/a.png'")) {
-    error = QStringLiteral("shellQuote did not keep spaces inside quotes");
-    return false;
-  }
-  if (shellQuote(QStringLiteral("it's")) != QStringLiteral("'it'\"'\"'s'")) {
-    error = QStringLiteral("shellQuote did not escape a single quote (%1)")
-                .arg(shellQuote(QStringLiteral("it's")));
-    return false;
-  }
-  sendCaptureNotification(QStringLiteral("smoke"));
   return true;
 }
 
@@ -7696,6 +7962,10 @@ int main(int argc, char **argv) {
     qWarning().noquote() << snapshotError;
     return 82;
   }
+  if (!runRevealSavedScreenshotSmoke(application, snapshotError)) {
+    qWarning().noquote() << snapshotError;
+    return 135;
+  }
   if (!runPinLayoutSmoke(snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 77;
@@ -7916,10 +8186,6 @@ int main(int argc, char **argv) {
   if (!runRecentsShelfSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 120;
-  }
-  if (!runShellQuoteCheck(snapshotError)) {
-    qWarning().noquote() << snapshotError;
-    return 83;
   }
   if (!runOpLogCapKeepsLeadingCrop(application, snapshotError)) {
     qWarning().noquote() << snapshotError;


### PR DESCRIPTION
Integrates #114 and #115 onto current main.

- Ctrl+Cut inserts an undoable transparent band and shifts later content.
- Save gestures can reveal the resulting file in Nautilus.
- Saved notifications reveal the selected file using safe argv-based Omarchy actions.
- Clamps insert endpoints before deriving band size.
- Keeps insert modifier handling consistently Ctrl-only.
- Adds horizontal/vertical out-of-range insertion regression coverage.

Validation: `make check` and `make install`.