### PR TITLE
screenshots via  keyboard only nvim motions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,9 @@ Press Enter to capture the window under the pointer. HJKL highlights that
 window as the pointer moves; Enter over empty desktop leaves selection open.
 Hold Ctrl with H/J/K/L to anchor a corner and draw a region. Release direction
 keys to pause, keeping Ctrl held while you change direction. Esc cancels the
-rectangle.
+rectangle. Release Ctrl to capture the rectangle. With `--copy --save`, this
+copies and saves immediately; otherwise it opens the annotation editor.
+Tapping Ctrl alone or drawing a zero-width/height rectangle does not capture.
 
 Tabs across the top of the overlay switch the capture kind: **Region**,
 **Window**, **Scrolling Region**, **Fullscreen**. All four are modes of the

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Install the corresponding Tesseract language data before adding a language to
 
 ### Capture selection
 
+The pointer starts at the center of the focused monitor.
+
 Tabs across the top of the overlay switch the capture kind: **Region**,
 **Window**, **Scrolling Region**, **Fullscreen**. All four are modes of the
 same overlay. Scrolling Region selects exactly like Region; once the region is

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ Install the corresponding Tesseract language data before adding a language to
 The pointer starts at the center of the focused monitor. Hold H/J/K/L to
 move left/down/up/right; movement accelerates while held. Hold Shift for
 fine positioning. Direction keys can be combined for diagonal motion.
+Press Enter to capture the window under the pointer. HJKL highlights that
+window as the pointer moves; Enter over empty desktop leaves selection open.
 
 Tabs across the top of the overlay switch the capture kind: **Region**,
 **Window**, **Scrolling Region**, **Fullscreen**. All four are modes of the

--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ move left/down/up/right; movement accelerates while held. Hold Shift for
 fine positioning. Direction keys can be combined for diagonal motion.
 Press Enter to capture the window under the pointer. HJKL highlights that
 window as the pointer moves; Enter over empty desktop leaves selection open.
+Hold Ctrl with H/J/K/L to anchor a corner and draw a region. Release direction
+keys to pause, keeping Ctrl held while you change direction. Esc cancels the
+rectangle.
 
 Tabs across the top of the overlay switch the capture kind: **Region**,
 **Window**, **Scrolling Region**, **Fullscreen**. All four are modes of the

--- a/README.md
+++ b/README.md
@@ -325,7 +325,9 @@ Install the corresponding Tesseract language data before adding a language to
 
 ### Capture selection
 
-The pointer starts at the center of the focused monitor.
+The pointer starts at the center of the focused monitor. Hold H/J/K/L to
+move left/down/up/right; movement accelerates while held. Hold Shift for
+fine positioning. Direction keys can be combined for diagonal motion.
 
 Tabs across the top of the overlay switch the capture kind: **Region**,
 **Window**, **Scrolling Region**, **Fullscreen**. All four are modes of the

--- a/src/capture-pointer.hpp
+++ b/src/capture-pointer.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QPointF>
+#include <QString>
+#include <memory>
+
+// Reuse the output-bound Wayland pointer used by scrolling capture.
+class CapturePointer {
+public:
+  explicit CapturePointer(const QString &outputName);
+  ~CapturePointer();
+  CapturePointer(const CapturePointer &) = delete;
+  CapturePointer &operator=(const CapturePointer &) = delete;
+  void moveTo(const QPointF &fraction);
+
+private:
+  struct State;
+  std::shared_ptr<State> state_;
+};

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -3778,9 +3778,11 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
         }
         if (event->modifiers().testFlag(Qt::ControlModifier))
           beginKeyboardSelection();
-        if (!dragging_ && !scrollMode_) {
+        if (!dragging_ && !scrollMode_ && !windowMode_) {
           windowMode_ = true;
           hoveredWindow_ = windowAt(cursor_);
+          updatePointerCursor();
+          update();
         }
         pointerKeys_.insert(event->key());
         keyboardFineMotion_ = event->modifiers().testFlag(Qt::ShiftModifier);
@@ -4105,6 +4107,24 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
 
 void CaptureEditor::keyReleaseEvent(QKeyEvent *event) {
   modifiersSeen_ = true;
+  if (event->key() == Qt::Key_Control && keyboardSelecting_) {
+    if (!event->isAutoRepeat()) {
+      keyboardSelecting_ = false;
+      stopKeyboardPointer();
+      QMouseEvent release(QEvent::MouseButtonRelease, cursor_,
+                          mapToGlobal(cursor_.toPoint()), Qt::LeftButton,
+                          Qt::NoButton, Qt::NoModifier);
+      mouseReleaseEvent(&release);
+      if (phase_ == Phase::Select &&
+          (selection_.width() < 2 || selection_.height() < 2)) {
+        selection_ = {};
+        setStatus(QStringLiteral("Region too small · Ctrl+HJKL draws"));
+        update();
+      }
+    }
+    event->accept();
+    return;
+  }
   if (pointerKeys_.contains(event->key())) {
     if (!event->isAutoRepeat()) {
       pointerKeys_.remove(event->key());
@@ -4657,6 +4677,8 @@ void CaptureEditor::mouseDoubleClickEvent(QMouseEvent *event) {
 }
 
 void CaptureEditor::mousePressEvent(QMouseEvent *event) {
+  if (keyboardSelecting_)
+    return;
   if (phase_ == Phase::Export || busy_ || capturePending_)
     return;
   if (!ocrResultText_.isEmpty())
@@ -6181,7 +6203,10 @@ void CaptureEditor::paintSelect(QPainter &painter) {
   // selection all paint over it wherever they overlap.
   if (!exporting)
     drawHotkeyLegend(painter, rect(),
-                     {{QStringLiteral("Drag"), QStringLiteral("Area")},
+                     {{QStringLiteral("HJKL"), QStringLiteral("Move pointer (Shift: fine)")},
+                      {QStringLiteral("Enter"), QStringLiteral("Window under pointer")},
+                      {QStringLiteral("Ctrl+HJKL"), QStringLiteral("Draw; release Ctrl to capture")},
+                      {QStringLiteral("Drag"), QStringLiteral("Area")},
                       {QStringLiteral("Space"), QStringLiteral("Window")},
                       {QStringLiteral("Ctrl+A"), QStringLiteral("Fullscreen")},
                       {QStringLiteral("R"), QStringLiteral("Last region")},

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -84,6 +84,16 @@ constexpr qreal kToolbarGroupGap = 10;
 constexpr qreal kMinimumRedactionExtent = 5.0;
 constexpr int kBackdropDim = 143;
 
+QPointF captureKeyDirection(int key) {
+  switch (key) {
+  case Qt::Key_H: return {-1, 0};
+  case Qt::Key_J: return {0, 1};
+  case Qt::Key_K: return {0, -1};
+  case Qt::Key_L: return {1, 0};
+  default: return {};
+  }
+}
+
 qreal highlighterPreviewHeight(qreal annotationSize) {
   return std::max<qreal>(6.0, annotationSize * 3.0);
 }
@@ -681,6 +691,11 @@ CaptureEditor::CaptureEditor(CaptureData capture, CaptureMode mode,
     setGeometry(QGuiApplication::primaryScreen()->geometry());
   cursor_ = mapFromGlobal(QCursor::pos());
 
+  keyboardMotionTimer_.setInterval(16);
+  keyboardMotionTimer_.setTimerType(Qt::PreciseTimer);
+  connect(&keyboardMotionTimer_, &QTimer::timeout, this,
+          &CaptureEditor::advanceKeyboardPointer);
+
   // Constructing QPlainTextEdit initializes substantial style/layout state.
   // Keep it off the launch path; beginText() creates it on first use.
   textCaretTimer_.setInterval(530);
@@ -950,8 +965,47 @@ void CaptureEditor::showEvent(QShowEvent *event) {
 }
 
 void CaptureEditor::hideEvent(QHideEvent *event) {
+  stopKeyboardPointer();
   capturePointer_.reset();
   QWidget::hideEvent(event);
+}
+
+void CaptureEditor::stopKeyboardPointer() {
+  pointerKeys_.clear();
+  keyboardMotionTimer_.stop();
+}
+
+void CaptureEditor::focusOutEvent(QFocusEvent *event) {
+  stopKeyboardPointer();
+  QWidget::focusOutEvent(event);
+}
+
+void CaptureEditor::advanceKeyboardPointer() {
+  if (phase_ != Phase::Select || capturePending_ || !isVisible()) {
+    stopKeyboardPointer();
+    return;
+  }
+  QPointF direction;
+  for (const int key : std::as_const(pointerKeys_))
+    direction += captureKeyDirection(key);
+  const qreal length = std::hypot(direction.x(), direction.y());
+  const qreal seconds = std::min<qreal>(keyboardMotionClock_.restart(), 40) / 1000;
+  if (length == 0)
+    return;
+  const qreal speed = keyboardFineMotion_ ? 120.0
+      : 240.0 + 1360.0 * std::min<qreal>(keyboardHoldClock_.elapsed() / 350.0, 1);
+  keyboardPosition_ += direction * (speed * seconds / length);
+  keyboardPosition_.setX(std::clamp(keyboardPosition_.x(), 0.0, width() - 1.0));
+  keyboardPosition_.setY(std::clamp(keyboardPosition_.y(), 0.0, height() - 1.0));
+  QMouseEvent motion(QEvent::MouseMove, keyboardPosition_,
+                     mapToGlobal(keyboardPosition_.toPoint()), Qt::NoButton,
+                     Qt::NoButton, Qt::NoModifier);
+  deliveringKeyboardMotion_ = true;
+  mouseMoveEvent(&motion);
+  deliveringKeyboardMotion_ = false;
+  if (capturePointer_)
+    capturePointer_->moveTo({keyboardPosition_.x() / width(),
+                            keyboardPosition_.y() / height()});
 }
 
 bool CaptureEditor::eventFilter(QObject *watched, QEvent *event) {
@@ -2977,6 +3031,7 @@ void CaptureEditor::enterEdit(QString status) {
 }
 
 void CaptureEditor::enterSelectedCapture(QString editStatus) {
+  stopKeyboardPointer();
   if (quickOutputMode_ != QuickOutputMode::None) {
     if (configuredCustomDefaultPending_) {
       pendingSelectedCapture_ = std::move(editStatus);
@@ -3009,6 +3064,7 @@ void CaptureEditor::enterExport() {
 }
 
 void CaptureEditor::handleEscape() {
+  stopKeyboardPointer();
   if (cutDragActive_) {
     cutDragActive_ = false;
     dragging_ = false;
@@ -3684,6 +3740,21 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     return;
   }
   if (phase_ == Phase::Select) {
+    if (!captureKeyDirection(event->key()).isNull() &&
+        !(event->modifiers() & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier))) {
+      if (!event->isAutoRepeat()) {
+        if (pointerKeys_.isEmpty()) {
+          keyboardPosition_ = cursor_;
+          keyboardMotionClock_.start();
+          keyboardHoldClock_.start();
+        }
+        pointerKeys_.insert(event->key());
+        keyboardFineMotion_ = event->modifiers().testFlag(Qt::ShiftModifier);
+        keyboardMotionTimer_.start();
+      }
+      event->accept();
+      return;
+    }
     if (event->matches(QKeySequence::SelectAll)) {
       selectFullscreen();
       return;
@@ -3993,6 +4064,15 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
 
 void CaptureEditor::keyReleaseEvent(QKeyEvent *event) {
   modifiersSeen_ = true;
+  if (pointerKeys_.contains(event->key())) {
+    if (!event->isAutoRepeat()) {
+      pointerKeys_.remove(event->key());
+      if (pointerKeys_.isEmpty())
+        keyboardMotionTimer_.stop();
+    }
+    event->accept();
+    return;
+  }
   if (event->key() == Qt::Key_Shift &&
       (creationConstraintActive_ || resizeConstraintActive_)) {
     creationConstraintActive_ = false;
@@ -4203,6 +4283,9 @@ void CaptureEditor::queuePointerRepaint(const QRegion &damage) {
 }
 
 void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
+  // Compositor echoes must not feed an older position into keyboard motion.
+  if (!pointerKeys_.isEmpty() && !deliveringKeyboardMotion_)
+    return;
   if (panning_) {
     panView(event->position() - panAnchor_);
     panAnchor_ = event->position();

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -3748,6 +3748,10 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
           keyboardMotionClock_.start();
           keyboardHoldClock_.start();
         }
+        if (!dragging_ && !scrollMode_) {
+          windowMode_ = true;
+          hoveredWindow_ = windowAt(cursor_);
+        }
         pointerKeys_.insert(event->key());
         keyboardFineMotion_ = event->modifiers().testFlag(Qt::ShiftModifier);
         keyboardMotionTimer_.start();
@@ -3769,9 +3773,16 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
       update();
       return;
     }
-    if (windowMode_ &&
+    if (!dragging_ && !scrollMode_ && !event->modifiers() &&
         (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)) {
-      chooseWindow(hoveredWindow_);
+      if (!event->isAutoRepeat()) {
+        const int target = windowMode_ ? hoveredWindow_ : windowAt(cursor_);
+        chooseWindow(target);
+        if (target < 0)
+          setStatus(QStringLiteral("No window under pointer · HJKL moves"));
+        update();
+      }
+      event->accept();
       return;
     }
     if (!windowMode_ && !dragging_ && event->key() == Qt::Key_R &&

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -970,6 +970,21 @@ void CaptureEditor::hideEvent(QHideEvent *event) {
   QWidget::hideEvent(event);
 }
 
+void CaptureEditor::beginKeyboardSelection() {
+  if (keyboardSelecting_ || dragging_)
+    return;
+  keyboardSelecting_ = true;
+  windowMode_ = false;
+  scrollMode_ = false;
+  recentsOpen_ = false;
+  hoveredWindow_ = -1;
+  dragStart_ = cursor_;
+  selection_ = {};
+  dragging_ = true;
+  setStatus(QStringLiteral("Ctrl+HJKL draws · release Ctrl to capture"));
+  update();
+}
+
 void CaptureEditor::stopKeyboardPointer() {
   pointerKeys_.clear();
   keyboardMotionTimer_.stop();
@@ -977,6 +992,12 @@ void CaptureEditor::stopKeyboardPointer() {
 
 void CaptureEditor::focusOutEvent(QFocusEvent *event) {
   stopKeyboardPointer();
+  if (keyboardSelecting_) {
+    keyboardSelecting_ = false;
+    dragging_ = false;
+    selection_ = {};
+    update();
+  }
   QWidget::focusOutEvent(event);
 }
 
@@ -3065,6 +3086,7 @@ void CaptureEditor::enterExport() {
 
 void CaptureEditor::handleEscape() {
   stopKeyboardPointer();
+  keyboardSelecting_ = false;
   if (cutDragActive_) {
     cutDragActive_ = false;
     dragging_ = false;
@@ -3740,14 +3762,22 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     return;
   }
   if (phase_ == Phase::Select) {
+    if (event->key() == Qt::Key_Control && !pointerKeys_.isEmpty() &&
+        !event->isAutoRepeat()) {
+      beginKeyboardSelection();
+      event->accept();
+      return;
+    }
     if (!captureKeyDirection(event->key()).isNull() &&
-        !(event->modifiers() & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier))) {
+        !(event->modifiers() & (Qt::AltModifier | Qt::MetaModifier))) {
       if (!event->isAutoRepeat()) {
         if (pointerKeys_.isEmpty()) {
           keyboardPosition_ = cursor_;
           keyboardMotionClock_.start();
           keyboardHoldClock_.start();
         }
+        if (event->modifiers().testFlag(Qt::ControlModifier))
+          beginKeyboardSelection();
         if (!dragging_ && !scrollMode_) {
           windowMode_ = true;
           hoveredWindow_ = windowAt(cursor_);
@@ -4295,7 +4325,7 @@ void CaptureEditor::queuePointerRepaint(const QRegion &damage) {
 
 void CaptureEditor::mouseMoveEvent(QMouseEvent *event) {
   // Compositor echoes must not feed an older position into keyboard motion.
-  if (!pointerKeys_.isEmpty() && !deliveringKeyboardMotion_)
+  if ((!pointerKeys_.isEmpty() || keyboardSelecting_) && !deliveringKeyboardMotion_)
     return;
   if (panning_) {
     panView(event->position() - panAnchor_);
@@ -4990,6 +5020,8 @@ void CaptureEditor::mousePressEvent(QMouseEvent *event) {
 }
 
 void CaptureEditor::mouseReleaseEvent(QMouseEvent *event) {
+  if (keyboardSelecting_)
+    return;
   if (event->button() == Qt::MiddleButton && panning_) {
     panning_ = false;
     updatePointerCursor();

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -3762,6 +3762,11 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
     return;
   }
   if (phase_ == Phase::Select) {
+    if (event->key() == Qt::Key_Shift) {
+      keyboardFineMotion_ = true;
+      event->accept();
+      return;
+    }
     if (event->key() == Qt::Key_Control && !pointerKeys_.isEmpty() &&
         !event->isAutoRepeat()) {
       beginKeyboardSelection();
@@ -4107,6 +4112,8 @@ void CaptureEditor::keyPressEvent(QKeyEvent *event) {
 
 void CaptureEditor::keyReleaseEvent(QKeyEvent *event) {
   modifiersSeen_ = true;
+  if (event->key() == Qt::Key_Shift && !event->isAutoRepeat())
+    keyboardFineMotion_ = false;
   if (event->key() == Qt::Key_Control && keyboardSelecting_) {
     if (!event->isAutoRepeat()) {
       keyboardSelecting_ = false;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -936,6 +936,24 @@ CaptureEditor::~CaptureEditor() {
   removeWorking(workingLogPath());
 }
 
+void CaptureEditor::showEvent(QShowEvent *event) {
+  QWidget::showEvent(event);
+  if (captureMode_ == CaptureMode::File ||
+      captureMode_ == CaptureMode::Fullscreen)
+    return;
+  cursor_ = QPointF(width() / 2.0, height() / 2.0);
+  hoveredWindow_ = windowAt(cursor_);
+  if (QGuiApplication::platformName() == QStringLiteral("wayland")) {
+    capturePointer_ = std::make_unique<CapturePointer>(capture_.monitor.name);
+    capturePointer_->moveTo(QPointF(0.5, 0.5));
+  }
+}
+
+void CaptureEditor::hideEvent(QHideEvent *event) {
+  capturePointer_.reset();
+  QWidget::hideEvent(event);
+}
+
 bool CaptureEditor::eventFilter(QObject *watched, QEvent *event) {
   if (watched == textEditor_ && event->type() == QEvent::KeyPress) {
     auto *key = static_cast<QKeyEvent *>(event);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -2,6 +2,7 @@
 
 #include "background-config.hpp"
 #include "capture.hpp"
+#include "capture-pointer.hpp"
 #include "cut.hpp"
 #include "overlay-chrome.hpp"
 #include "palette-config.hpp"
@@ -94,6 +95,7 @@ public:
   /** Current monitor data (background capture may be in flight). */
   const CaptureData &captureData() const { return capture_; }
   [[nodiscard]] QRectF currentSelection() const { return selection_; }
+  [[nodiscard]] QPointF capturePointerPosition() const { return cursor_; }
   /** Annotation-space canvas, including any strips grown past the source. */
   [[nodiscard]] QRectF currentCanvasForTest() const { return canvasRect_; }
   [[nodiscard]] CanvasBoundaryMode currentCanvasBoundaryForTest() const {
@@ -124,6 +126,8 @@ public:
   void setSuppressSnapshots(bool suppress) { suppressSnapshots_ = suppress; }
 
 protected:
+  void showEvent(QShowEvent *event) override;
+  void hideEvent(QHideEvent *event) override;
   bool eventFilter(QObject *watched, QEvent *event) override;
   void keyPressEvent(QKeyEvent *event) override;
   void keyReleaseEvent(QKeyEvent *event) override;
@@ -630,6 +634,7 @@ private:
   QRectF cropDragImageRect_;
   QRectF marqueeRect_;
   QPointF cursor_;
+  std::unique_ptr<CapturePointer> capturePointer_;
   bool dragging_ = false;
   bool creationConstraintActive_ = false;
   bool marqueeSelecting_ = false;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -15,6 +15,7 @@
 #include <QRegion>
 #include <QLineF>
 #include <QTimer>
+#include <QSet>
 #include <QWidget>
 
 #include <optional>
@@ -128,6 +129,7 @@ public:
 protected:
   void showEvent(QShowEvent *event) override;
   void hideEvent(QHideEvent *event) override;
+  void focusOutEvent(QFocusEvent *event) override;
   bool eventFilter(QObject *watched, QEvent *event) override;
   void keyPressEvent(QKeyEvent *event) override;
   void keyReleaseEvent(QKeyEvent *event) override;
@@ -635,6 +637,15 @@ private:
   QRectF marqueeRect_;
   QPointF cursor_;
   std::unique_ptr<CapturePointer> capturePointer_;
+  QSet<int> pointerKeys_;
+  QTimer keyboardMotionTimer_;
+  QElapsedTimer keyboardMotionClock_;
+  QElapsedTimer keyboardHoldClock_;
+  QPointF keyboardPosition_;
+  bool deliveringKeyboardMotion_ = false;
+  bool keyboardFineMotion_ = false;
+  void advanceKeyboardPointer();
+  void stopKeyboardPointer();
   bool dragging_ = false;
   bool creationConstraintActive_ = false;
   bool marqueeSelecting_ = false;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -644,6 +644,8 @@ private:
   QPointF keyboardPosition_;
   bool deliveringKeyboardMotion_ = false;
   bool keyboardFineMotion_ = false;
+  bool keyboardSelecting_ = false;
+  void beginKeyboardSelection();
   void advanceKeyboardPointer();
   void stopKeyboardPointer();
   bool dragging_ = false;

--- a/src/scroll-inject.cpp
+++ b/src/scroll-inject.cpp
@@ -1,5 +1,9 @@
 /** @fileoverview Auto-scroll injection worker (see scroll-inject.hpp). */
 #include "scroll-inject.hpp"
+#include "capture-pointer.hpp"
+
+#include <condition_variable>
+#include <mutex>
 
 #include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
 
@@ -423,4 +427,59 @@ bool spawnScrollInjector(std::shared_ptr<std::atomic<bool>> stop,
     qInfo().noquote() << QStringLiteral("scroll-inject: worker exited");
   }).detach();
   return true;
+}
+
+struct CapturePointer::State {
+  std::mutex mutex;
+  std::condition_variable changed;
+  QPointF position;
+  bool pending = false;
+  bool stopped = false;
+};
+
+CapturePointer::CapturePointer(const QString &outputName)
+    : state_(std::make_shared<State>()) {
+  std::thread([state = state_, outputName] {
+    QString error;
+    auto pointer = connectWlrPointer(outputName, error);
+    if (!pointer ||
+        zwlr_virtual_pointer_manager_v1_get_version(pointer->manager) < 2) {
+      qWarning().noquote() << "capture pointer:" << error
+                          << "(output-bound virtual pointer required)";
+      return;
+    }
+    std::unique_lock lock(state->mutex);
+    while (true) {
+      state->changed.wait(lock, [&] { return state->stopped || state->pending; });
+      if (state->stopped)
+        return;
+      const QPointF position = state->position;
+      state->pending = false;
+      // Fractions map to the bound output, including its scale and rotation.
+      constexpr uint32_t extent = 1000000;
+      zwlr_virtual_pointer_v1_motion_absolute(
+          pointer->pointer, pointer->timeMs(),
+          static_cast<uint32_t>(std::clamp(position.x(), 0.0, 1.0) * extent),
+          static_cast<uint32_t>(std::clamp(position.y(), 0.0, 1.0) * extent),
+          extent, extent);
+      zwlr_virtual_pointer_v1_frame(pointer->pointer);
+      if (wl_display_flush(pointer->display) < 0) {
+        qWarning() << "capture pointer: Wayland motion failed";
+        return;
+      }
+    }
+  }).detach();
+}
+
+CapturePointer::~CapturePointer() {
+  std::lock_guard lock(state_->mutex);
+  state_->stopped = true;
+  state_->changed.notify_one();
+}
+
+void CapturePointer::moveTo(const QPointF &fraction) {
+  std::lock_guard lock(state_->mutex);
+  state_->position = fraction;
+  state_->pending = true;
+  state_->changed.notify_one();
 }

--- a/src/scroll-inject.cpp
+++ b/src/scroll-inject.cpp
@@ -455,6 +455,7 @@ CapturePointer::CapturePointer(const QString &outputName)
         return;
       const QPointF position = state->position;
       state->pending = false;
+      lock.unlock();
       // Fractions map to the bound output, including its scale and rotation.
       constexpr uint32_t extent = 1000000;
       zwlr_virtual_pointer_v1_motion_absolute(
@@ -467,6 +468,7 @@ CapturePointer::CapturePointer(const QString &outputName)
         qWarning() << "capture pointer: Wayland motion failed";
         return;
       }
+      lock.lock();
     }
   }).detach();
 }

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7470,6 +7470,26 @@ bool runAreaLastRegionSmoke(QApplication &application, QString &error) {
   return true;
 }
 
+bool runKeyboardCaptureSmoke(QApplication &application, QString &error) {
+  CaptureData capture;
+  capture.monitor.geometry = QRect(100, 200, 800, 600);
+  capture.monitor.pixelSize = QSize(800, 600);
+  capture.monitor.scale = 1.0;
+  capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
+  capture.source.fill(QColor("#6480a0"));
+  capture.previewSize = capture.source.size();
+  CaptureEditor editor(capture);
+  editor.resize(800, 600);
+  editor.show();
+  application.processEvents();
+  if (editor.capturePointerPosition() != QPointF(400, 300)) {
+    error = QStringLiteral("capture pointer did not start at monitor center");
+    return false;
+  }
+  editor.close();
+  return true;
+}
+
 int main(int argc, char **argv) {
   // Re-executed by the instance-lock checks as the process holding the lock.
   const QString heldLockPath =
@@ -7530,6 +7550,10 @@ int main(int argc, char **argv) {
     return 0;
   }
   QString snapshotError;
+  if (!runKeyboardCaptureSmoke(application, snapshotError)) {
+    qCritical().noquote() << snapshotError;
+    return 130;
+  }
   if (!runAreaLastRegionSmoke(application, snapshotError)) {
     qWarning().noquote() << snapshotError;
     return 119;

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7524,6 +7524,28 @@ bool runKeyboardCaptureSmoke(QApplication &application, QString &error) {
     error = QStringLiteral("Enter did not capture the window under the pointer");
     return false;
   }
+  CaptureEditor region(capture);
+  region.resize(800, 600);
+  region.show();
+  application.processEvents();
+  QTest::keyPress(&region, Qt::Key_L, Qt::ControlModifier);
+  QTest::qWait(150);
+  QTest::keyRelease(&region, Qt::Key_L, Qt::ControlModifier);
+  QTest::keyPress(&region, Qt::Key_J, Qt::ControlModifier);
+  QTest::qWait(150);
+  QTest::keyRelease(&region, Qt::Key_J, Qt::ControlModifier);
+  const QRectF drawn = region.currentSelection();
+  if (drawn.topLeft() != QPointF(400, 300) || drawn.width() < 30 ||
+      drawn.height() < 30) {
+    error = QStringLiteral("Ctrl+HJKL did not draw from its fixed anchor");
+    return false;
+  }
+  QTest::keyClick(&region, Qt::Key_Escape);
+  if (!region.currentSelection().isEmpty()) {
+    error = QStringLiteral("Escape did not cancel keyboard selection");
+    return false;
+  }
+  region.close();
   editor.close();
   return true;
 }

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7486,6 +7486,29 @@ bool runKeyboardCaptureSmoke(QApplication &application, QString &error) {
     error = QStringLiteral("capture pointer did not start at monitor center");
     return false;
   }
+  QTest::keyPress(&editor, Qt::Key_L);
+  QTest::qWait(180);
+  QTest::keyRelease(&editor, Qt::Key_L);
+  const QPointF moved = editor.capturePointerPosition();
+  if (moved.x() <= 430 || moved.y() != 300) {
+    error = QStringLiteral("held L did not glide horizontally");
+    return false;
+  }
+  QTest::qWait(60);
+  if (editor.capturePointerPosition() != moved) {
+    error = QStringLiteral("pointer kept moving after key release");
+    return false;
+  }
+  QTest::keyPress(&editor, Qt::Key_H);
+  QTest::keyPress(&editor, Qt::Key_K);
+  QTest::qWait(800);
+  QTest::keyRelease(&editor, Qt::Key_H);
+  QTest::keyRelease(&editor, Qt::Key_K);
+  if (editor.capturePointerPosition().x() < 0 ||
+      editor.capturePointerPosition().y() != 0) {
+    error = QStringLiteral("diagonal keyboard motion escaped monitor bounds");
+    return false;
+  }
   editor.close();
   return true;
 }

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7700,7 +7700,7 @@ int main(int argc, char **argv) {
   }
   QString snapshotError;
   if (!runKeyboardCaptureSmoke(application, snapshotError)) {
-    qCritical().noquote() << snapshotError;
+    qWarning().noquote() << snapshotError;
     return 130;
   }
   if (!runAreaLastRegionSmoke(application, snapshotError)) {

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7471,6 +7471,11 @@ bool runAreaLastRegionSmoke(QApplication &application, QString &error) {
 }
 
 bool runKeyboardCaptureSmoke(QApplication &application, QString &error) {
+  const auto key = [](QWidget &target, QEvent::Type type, int code,
+                       Qt::KeyboardModifiers modifiers = Qt::NoModifier) {
+    QKeyEvent event(type, code, modifiers);
+    QApplication::sendEvent(&target, &event);
+  };
   CaptureData capture;
   capture.monitor.geometry = QRect(100, 200, 800, 600);
   capture.monitor.pixelSize = QSize(800, 600);
@@ -7528,24 +7533,82 @@ bool runKeyboardCaptureSmoke(QApplication &application, QString &error) {
   region.resize(800, 600);
   region.show();
   application.processEvents();
-  QTest::keyPress(&region, Qt::Key_L, Qt::ControlModifier);
+  key(region, QEvent::KeyPress, Qt::Key_L, Qt::ControlModifier);
   QTest::qWait(150);
-  QTest::keyRelease(&region, Qt::Key_L, Qt::ControlModifier);
-  QTest::keyPress(&region, Qt::Key_J, Qt::ControlModifier);
+  key(region, QEvent::KeyRelease, Qt::Key_L, Qt::ControlModifier);
+  key(region, QEvent::KeyPress, Qt::Key_J, Qt::ControlModifier);
   QTest::qWait(150);
-  QTest::keyRelease(&region, Qt::Key_J, Qt::ControlModifier);
+  key(region, QEvent::KeyRelease, Qt::Key_J, Qt::ControlModifier);
   const QRectF drawn = region.currentSelection();
   if (drawn.topLeft() != QPointF(400, 300) || drawn.width() < 30 ||
       drawn.height() < 30) {
     error = QStringLiteral("Ctrl+HJKL did not draw from its fixed anchor");
     return false;
   }
-  QTest::keyClick(&region, Qt::Key_Escape);
-  if (!region.currentSelection().isEmpty()) {
-    error = QStringLiteral("Escape did not cancel keyboard selection");
+  QKeyEvent repeatRelease(QEvent::KeyRelease, Qt::Key_Control,
+                          Qt::NoModifier, {}, true);
+  QApplication::sendEvent(&region, &repeatRelease);
+  if (region.currentSelection() != drawn ||
+      !region.operationLog().isEmpty()) {
+    error = QStringLiteral("auto-repeat committed the keyboard rectangle");
+    return false;
+  }
+  key(region, QEvent::KeyRelease, Qt::Key_Control);
+  if (region.currentSelection() != drawn ||
+      region.renderCurrentOutput().size() != drawn.toAlignedRect().size()) {
+    error = QStringLiteral("Ctrl release did not commit the keyboard rectangle");
     return false;
   }
   region.close();
+
+  // Cancellation must leave no latent rectangle that a later Ctrl release saves.
+  CaptureEditor cancelled(capture);
+  cancelled.resize(800, 600);
+  cancelled.show();
+  application.processEvents();
+  key(cancelled, QEvent::KeyPress, Qt::Key_L, Qt::ControlModifier);
+  QTest::qWait(60);
+  QTest::keyClick(&cancelled, Qt::Key_Escape);
+  key(cancelled, QEvent::KeyRelease, Qt::Key_L, Qt::ControlModifier);
+  key(cancelled, QEvent::KeyRelease, Qt::Key_Control);
+  if (!cancelled.currentSelection().isEmpty()) {
+    error = QStringLiteral("cancelled rectangle survived Ctrl release");
+    return false;
+  }
+  cancelled.close();
+
+  CaptureEditor empty(capture);
+  empty.resize(800, 600);
+  empty.show();
+  application.processEvents();
+  key(empty, QEvent::KeyRelease, Qt::Key_Control);
+  key(empty, QEvent::KeyPress, Qt::Key_L, Qt::ControlModifier);
+  QTest::qWait(80);
+  key(empty, QEvent::KeyRelease, Qt::Key_Control);
+  key(empty, QEvent::KeyRelease, Qt::Key_L);
+  if (!empty.currentSelection().isEmpty() || !empty.isVisible()) {
+    error = QStringLiteral("empty or one-dimensional rectangle was captured");
+    return false;
+  }
+  empty.close();
+
+  CaptureEditor interrupted(capture);
+  interrupted.resize(800, 600);
+  interrupted.show();
+  application.processEvents();
+  key(interrupted, QEvent::KeyPress, Qt::Key_J, Qt::ControlModifier);
+  QTest::qWait(80);
+  QFocusEvent focusLost(QEvent::FocusOut);
+  QApplication::sendEvent(&interrupted, &focusLost);
+  const QPointF stopped = interrupted.capturePointerPosition();
+  key(interrupted, QEvent::KeyRelease, Qt::Key_Control);
+  QTest::qWait(50);
+  if (!interrupted.currentSelection().isEmpty() ||
+      interrupted.capturePointerPosition() != stopped) {
+    error = QStringLiteral("focus loss left keyboard capture running");
+    return false;
+  }
+  interrupted.close();
   editor.close();
   return true;
 }

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7561,6 +7561,32 @@ bool runKeyboardCaptureSmoke(QApplication &application, QString &error) {
   }
   region.close();
 
+  for (const auto modifiers : {Qt::NoModifier, Qt::ControlModifier}) {
+    CaptureEditor fine(capture);
+    fine.resize(800, 600);
+    fine.show();
+    application.processEvents();
+    key(fine, QEvent::KeyPress, Qt::Key_H, modifiers);
+    QTest::qWait(60);
+    key(fine, QEvent::KeyPress, Qt::Key_Shift,
+        modifiers | Qt::ShiftModifier);
+    const qreal beforeFine = fine.capturePointerPosition().x();
+    QTest::qWait(120);
+    const qreal afterFine = fine.capturePointerPosition().x();
+    if (beforeFine - afterFine <= 0 || beforeFine - afterFine > 30) {
+      error = QStringLiteral("Shift press did not slow held keyboard motion");
+      return false;
+    }
+    key(fine, QEvent::KeyRelease, Qt::Key_Shift, modifiers);
+    QTest::qWait(120);
+    if (afterFine - fine.capturePointerPosition().x() < 50) {
+      error = QStringLiteral("Shift release did not restore keyboard speed");
+      return false;
+    }
+    key(fine, QEvent::KeyRelease, Qt::Key_H, modifiers);
+    fine.close();
+  }
+
   // Cancellation must leave no latent rectangle that a later Ctrl release saves.
   CaptureEditor cancelled(capture);
   cancelled.resize(800, 600);

--- a/tests/editor-smoke.cpp
+++ b/tests/editor-smoke.cpp
@@ -7478,6 +7478,9 @@ bool runKeyboardCaptureSmoke(QApplication &application, QString &error) {
   capture.source = QImage(800, 600, QImage::Format_ARGB32_Premultiplied);
   capture.source.fill(QColor("#6480a0"));
   capture.previewSize = capture.source.size();
+  WindowTarget window;
+  window.rect = QRect(200, 150, 400, 300);
+  capture.windows.push_back(window);
   CaptureEditor editor(capture);
   editor.resize(800, 600);
   editor.show();
@@ -7507,6 +7510,18 @@ bool runKeyboardCaptureSmoke(QApplication &application, QString &error) {
   if (editor.capturePointerPosition().x() < 0 ||
       editor.capturePointerPosition().y() != 0) {
     error = QStringLiteral("diagonal keyboard motion escaped monitor bounds");
+    return false;
+  }
+  QTest::keyClick(&editor, Qt::Key_Return);
+  if (!editor.currentSelection().isEmpty()) {
+    error = QStringLiteral("Enter captured a window away from the pointer");
+    return false;
+  }
+  QTest::mouseMove(&editor, QPoint(400, 300));
+  QTest::keyClick(&editor, Qt::Key_Return);
+  if (editor.currentSelection() != QRectF(window.rect) ||
+      editor.renderCurrentOutput().size() != window.rect.size()) {
+    error = QStringLiteral("Enter did not capture the window under the pointer");
     return false;
   }
   editor.close();


### PR DESCRIPTION
hey guys thank you for the tool 

given a feasability check, I'd like to work on this feature; the annoyance is that I have to leave my fingers from the keyboard and take the mouse to do screenshots, and I dont think this is necessary 

this adds keyboard control to the capture overlay, using the existing Wayland virtual pointer and output path.

- sttart the pointer at the focused monitor's center
- hold hjkl to glide, with acceleration and shift for fine movement
- pess enter to capture the window under the pointer
- hold ctrl with hjkl to draw from a fixed corner
- release ctrl to capture; releasing direction keys only pauses movement

Esc cancels the rectangle. Focus loss cancels keyboard movement and selection. Auto-repeat, a lone ctrl release, and zero-width or zero-height regions do not trigger a capture. `--copy --save` exports immediately; normal launches open
the editor after selection.

Validation: `make check`, plus live Hyprland checks on landscape and rotated
portrait monitors for pointer centering, movement, window capture, and region
capture. Saved PNGs were compared byte-for-byte with the clipboard output.
